### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dataset-validation.yml
+++ b/.github/workflows/dataset-validation.yml
@@ -1,4 +1,6 @@
 name: Dataset Validation
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/BC-Bench/security/code-scanning/2](https://github.com/microsoft/BC-Bench/security/code-scanning/2)

**How to fix the problem:**  
Explicitly add a `permissions` block to the workflow to limit the GITHUB_TOKEN permissions to the minimum required. Since the jobs only need to read the repository contents (to checkout code and read secrets), the block should set `contents: read`. This block can be added at the workflow level (to apply to all jobs), or per-job if differing permissions are needed. In this case, workflow-level (top-level) makes sense.

**Detailed steps:**  
- Edit `.github/workflows/dataset-validation.yml`.
- Add a `permissions:` block after the `name:` line and before the `on:` block.
- Set `contents: read` (which is a minimal, safe default).
- No further changes or imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
