### PR TITLE
Only include Test Lib for container spinning up

### DIFF
--- a/scripts/powershell/BCContainerManagement.psm1
+++ b/scripts/powershell/BCContainerManagement.psm1
@@ -308,6 +308,7 @@ function New-BCContainerAsync {
             auth = $authType
             credential = $credential
             includeTestToolkit = $true
+            includeTestLibrariesOnly = $true
             multitenant = $false
             shortcuts = 'None'
         }

--- a/scripts/powershell/Setup-ContainerAndRepository.ps1
+++ b/scripts/powershell/Setup-ContainerAndRepository.ps1
@@ -95,7 +95,7 @@ if (Test-Path $NAVRepoPath) {
 }
 
 if ($containerJob) {
-    $success = Wait-JobWithProgress -Job $containerJob -StatusMessage "Container creation" -TimeoutMinutes 45
+    $success = Wait-JobWithProgress -Job $containerJob -StatusMessage "Container creation"
     if ($success) {
         Initialize-ContainerForDevelopment -ContainerName $ContainerName -RepoVersion ([System.Version]$Version)
     } else {


### PR DESCRIPTION
We don't need the standard tests, test lib only should be enough, this will speed things up for env setup