### PR TITLE
Allow toggling bctool for mini agent

### DIFF
--- a/.github/workflows/dataset-validation.yml
+++ b/.github/workflows/dataset-validation.yml
@@ -53,7 +53,7 @@ jobs:
     runs-on: windows-latest
     needs: validate-schema-and-list-entries
     if: needs.validate-schema-and-list-entries.outputs.entries != '[]'
-    name: Verify ${{ matrix.entry }}
+    name: ${{ matrix.entry }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/mini-evaluation.yml
+++ b/.github/workflows/mini-evaluation.yml
@@ -5,6 +5,12 @@ permissions:
 
 on:
   workflow_dispatch:
+    inputs:
+      bc_tools_enabled:
+        description: 'Allow mini-bc-agent to use BC build and test commands'
+        required: false
+        default: 'true'
+        type: boolean
 
 env:
   EVALUATION_RESULTS_DIR: evaluation_results
@@ -77,13 +83,18 @@ jobs:
           AZURE_API_BASE: ${{ secrets.AZURE_API_BASE }}
           AZURE_API_VERSION: ${{ secrets.AZURE_API_VERSION }}
         run: |
-          python -m bcbench evaluate mini "${{ matrix.entry }}" `
-            --container-name "${{ steps.setup-env.outputs.container_name }}" `
-            --repo-path "${{ steps.setup-env.outputs.nav_clone_path }}" `
-            --output-dir "${{ env.EVALUATION_RESULTS_DIR }}" `
-            --run-id ${{ github.run_id }} `
-            --step-limit 50 `
-            --enable-bc-tools
+          $args = @(
+            'evaluate', 'mini', "${{ matrix.entry }}",
+            '--container-name', "${{ steps.setup-env.outputs.container_name }}",
+            '--repo-path', "${{ steps.setup-env.outputs.nav_clone_path }}",
+            '--output-dir', "${{ env.EVALUATION_RESULTS_DIR }}",
+            '--run-id', '${{ github.run_id }}',
+            '--step-limit', '50'
+          )
+          if ('${{ github.event.inputs.bc_tools_enabled }}' -eq 'true') {
+            $args += '--enable-bc-tools'
+          }
+          python -m bcbench @args
         shell: pwsh
 
       - name: Upload evaluation results

--- a/.github/workflows/mini-evaluation.yml
+++ b/.github/workflows/mini-evaluation.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: windows-latest
     needs: get-entries
     if: needs.get-entries.outputs.entries != '[]'
-    name: Run mini on ${{ matrix.entry }}
+    name: ${{ matrix.entry }}
     strategy:
       fail-fast: false
       max-parallel: 5

--- a/src/bcbench/agent/mini/bc_agent_config.yaml
+++ b/src/bcbench/agent/mini/bc_agent_config.yaml
@@ -2,7 +2,7 @@
 
 agent:
   system_template: |
-    You are an experience software engineer in Business Central (BC) and AL programming language.
+    You are an experienced software engineer in Business Central (BC) and AL programming language.
 
     Your response must contain exactly ONE PowerShell command (or commands connected with && or ||).
     Include a THOUGHT section before your command where you explain your reasoning process.
@@ -32,15 +32,17 @@ agent:
     ## Objective
     Make changes to non-test files in the project paths to fix the issue. Your solution should be general and consistent with the existing codebase.
 
+    ## CRITICAL: DO NOT MODIFY
+    - Test files (any file containing tests)
+    - Existing test codeunits
+    - Configuration files (app.json, etc.)
+
     ## Response Format
     Each response must contain:
     1. A THOUGHT section explaining your reasoning
     2. Exactly ONE PowerShell command in triple backticks
 
     This is an interactive process: issue one command, observe the result, then proceed with the next command.
-
-    ## Important Boundaries
-    - DO NOT MODIFY: Existing Tests, configuration files (app.json, etc.)
 
     ## Recommended Workflow
 
@@ -55,9 +57,7 @@ agent:
     1. **Diagnose**: Identify the root cause of the issue
     1. **Implement**: Edit the source code to resolve the issue
     {% if bc_tools_enabled %}
-    1. **Verify**: Build the project to confirm the code compiles and runs
-    1. **Test**: If you feel it would help, create a NEW test codeunit to reproduce the issue, or verify the fix
-       - Remember, DO NOT MODIFY existing tests
+    1. **Verify**: Build the project to confirm the code compiles and publishes
     {% else %}
     1. **Verify**: Carefully review your code changes to ensure correctness
     {% endif %}

--- a/src/bcbench/agent/mini/bc_agent_config.yaml
+++ b/src/bcbench/agent/mini/bc_agent_config.yaml
@@ -68,7 +68,7 @@ agent:
     ## Important Rules
     1. Every response must contain exactly ONE action enclosed in triple backticks
     2. Directory/environment changes are not persistent across commands (each runs in a new subshell)
-       - Use prefixes like `MY_VAR=value cd /path && ...` to set context per command
+       - Use prefixes like `$env:MY_VAR='value'; cd \path; ...` to set context per command
        - Or persist state by writing/reading from files
 
     ## Formatting your response
@@ -155,8 +155,8 @@ agent:
     <warning>
     The output of your last command was too long.
     Please try a different command that produces less output.
-    If you're looking at a file you can try use head, tail or sed to view a smaller number of lines selectively.
-    If you're using grep or find and it produced too much output, you can use a more selective search pattern.
+    If you're looking at a file you can try use Get-Content with -Head or -Tail, or Select-Object to view a smaller number of lines selectively.
+    If you're using Select-String or Get-ChildItem and it produced too much output, you can use a more selective search pattern.
     If you really need to see something from the full command's output, you can redirect output to a file and then search in that file.
     </warning>
     {%- set elided_chars = output.output | length - 10000 -%}

--- a/src/bcbench/agent/mini/bc_environment.py
+++ b/src/bcbench/agent/mini/bc_environment.py
@@ -122,11 +122,8 @@ class BCEnvironment(LocalEnvironment):
         working_dir: str = cwd or self.config.cwd or str(Path.cwd())
 
         if log_command:
-            # Sensitive data redaction is now handled automatically by the logging filter
             command_preview: str = command if len(command) <= 100 else command[:97] + "..."
             logger.info(f"Executing:\n{command_preview}")
-            if len(command) > 100:
-                logger.debug(f"Full command: {command}")
 
         try:
             result = subprocess.run(
@@ -144,29 +141,20 @@ class BCEnvironment(LocalEnvironment):
 
             output_stripped: str = output.strip()
             output_lines: list[str] = output_stripped.split("\n")
-            line_count: int = len(output_lines)
 
             if result.returncode == 0:
                 logger.info("Command succeeded")
             else:
                 logger.error(f"Command failed with exit code {result.returncode}")
-                if line_count > 0:
-                    preview_lines = min(3, line_count)
-                    logger.error(f"Error output (first {preview_lines} lines):\n{'\n'.join(output_lines[:preview_lines])}")
-
-            # At DEBUG level: show full output (truncated if too long)
-            if line_count <= 10:
-                logger.debug(f"Full output:\n{output_stripped}")
-            else:
-                logger.debug(f"Full output ({line_count} lines, showing first/last 5):\n{'\n'.join(output_lines[:5])}\n... ({line_count - 10} lines omitted) ...\n{'\n'.join(output_lines[-5:])}")
+                if output_lines and log_command:
+                    logger.error(f"Error output (first line):\n{output_lines[0]}")
 
             return {"returncode": result.returncode, "output": output_stripped}
 
         except subprocess.TimeoutExpired as e:
             error_msg = f"Command timed out after {timeout} seconds"
             logger.error(error_msg)
-            if e.stdout:
-                logger.debug(f"Partial output before timeout:\n{e.stdout}")
+
             return {
                 "returncode": -1,
                 "output": f"{error_msg}\n{e.stdout or ''}",

--- a/src/bcbench/commands/run.py
+++ b/src/bcbench/commands/run.py
@@ -56,3 +56,28 @@ def run_mini(
         cost_limit=cost_limit,
         output_dir=output_dir,
     )
+
+
+@run_app.command("mini-inspector")
+def run_mini_inspector(
+    path: Annotated[Path, typer.Argument(help="Directory to search for trajectory files or specific trajectory file")],
+):
+    """
+    Inspect trajectory files (*.traj.json) in the given directory or a specific trajectory file.
+
+    Example:
+        bcbench run mini-inspector ./outputs/mini_agent_runs/
+    """
+    from minisweagent.run.inspector import TrajectoryInspector
+
+    if path.is_file():
+        trajectory_files = [path]
+    elif path.is_dir():
+        trajectory_files = sorted(path.rglob("*.traj.json"))
+        if not trajectory_files:
+            raise typer.BadParameter(f"No trajectory files found in '{path}'")
+    else:
+        raise typer.BadParameter(f"Error: Path '{path}' does not exist")
+
+    inspector = TrajectoryInspector(trajectory_files)
+    inspector.run()


### PR DESCRIPTION
Add the toggle to the GitHub workflow directly, so it can be easily tested.

Simplify logging and include trajectory inspector from mini-swe-agent.

Edit workflow files for better naming visibility in UI.

Another round of moving bash commands to powershell