### PR TITLE
Consolidate evaluation command

### DIFF
--- a/src/bcbench/agent/__init__.py
+++ b/src/bcbench/agent/__init__.py
@@ -1,5 +1,6 @@
 """Agent module for BC-Bench."""
 
+from bcbench.agent.copilot import run_copilot_agent
 from bcbench.agent.mini import run_mini_agent
 
-__all__ = ["run_mini_agent"]
+__all__ = ["run_copilot_agent", "run_mini_agent"]

--- a/src/bcbench/agent/mini/agent.py
+++ b/src/bcbench/agent/mini/agent.py
@@ -6,13 +6,9 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import yaml
-from dotenv import load_dotenv
 
-from bcbench.dataset.dataset_entry import DatasetEntry
-from bcbench.dataset.dataset_loader import load_dataset_entries
+from bcbench.dataset import DatasetEntry
 from bcbench.logger import get_logger
-
-load_dotenv()
 
 # Lazy imports to avoid mini-swe-agent startup message for non-agent commands
 if TYPE_CHECKING:
@@ -52,8 +48,7 @@ def _create_bc_agent_class():
 
 
 def run_mini_agent(
-    dataset_path: Path,
-    entry_id: str,
+    entry: DatasetEntry,
     repo_path: Path,
     enable_bc_tools: bool = False,
     container_name: str | None = None,
@@ -64,15 +59,19 @@ def run_mini_agent(
     output_dir: Path | None = None,
 ) -> None:
     """Run mini-bc-agent on a single dataset entry."""
-    if enable_bc_tools and not container_name:
-        raise ValueError("container_name is required when use_container is True")
+    if enable_bc_tools:
+        from dotenv import load_dotenv
 
-    if enable_bc_tools and not password:
-        password = os.environ.get("BC_CONTAINER_PASSWORD")
+        load_dotenv()
+
+        if not container_name:
+            raise ValueError("container_name is required when enable_bc_tools is True")
+
         if not password:
-            raise ValueError("Password required when use_container is True. Set password or BC_CONTAINER_PASSWORD env var")
+            password = os.environ.get("BC_CONTAINER_PASSWORD")
+            if not password:
+                raise ValueError("Password required when enable_bc_tools is True. Set password or BC_CONTAINER_PASSWORD env var")
 
-    entry: DatasetEntry = load_dataset_entries(dataset_path, entry_id=entry_id)[0]
     logger.info(f"Running mini-bc-agent on: {entry.instance_id}")
 
     task: str = entry.get_task()

--- a/src/bcbench/commands/evaluate.py
+++ b/src/bcbench/commands/evaluate.py
@@ -9,10 +9,8 @@ from typing_extensions import Annotated
 
 from bcbench.agent import run_copilot_agent, run_mini_agent
 from bcbench.dataset import DatasetEntry, load_dataset_entries
-from bcbench.evaluate.evaluation_result import EvaluationResult, summarize_results
-from bcbench.logger import get_logger, github_log_group
-from bcbench.operations.bc_operations import build_and_publish_projects, run_tests
-from bcbench.operations.git_operations import apply_patch, checkout_commit, clean_repo
+from bcbench.evaluate import EvaluationContext, run_evaluation_pipeline, summarize_results
+from bcbench.logger import get_logger
 from bcbench.utils import DATASET_PATH, NAV_REPO_PATH
 
 logger = get_logger(__name__)
@@ -63,59 +61,36 @@ def evaluate_mini(
     run_dir.mkdir(parents=True)
 
     logger.info(f"Running evaluation on entry {entry_id} with mini-bc-agent")
-    result = EvaluationResult(instance_id=entry_id, version=entry.environment_setup_version)
 
-    try:
-        clean_repo(repo_path)
-        checkout_commit(repo_path, entry.base_commit)
-        build_and_publish_projects(
-            repo_path,
-            entry.project_paths,
-            container_name,
-            username,
-            password,
-            entry.environment_setup_version,
-        )
+    context = EvaluationContext(
+        entry=entry,
+        repo_path=repo_path,
+        result_dir=run_dir,
+        container_name=container_name,
+        username=username,
+        password=password,
+        agent_name="mini-bc-agent",
+        agent_options={
+            "enable_bc_tools": enable_bc_tools,
+            "step_limit": step_limit,
+            "cost_limit": cost_limit,
+        },
+    )
 
-        with github_log_group(f"mini-bc-agent -- Entry: {entry.instance_id}"):
-            run_mini_agent(
-                entry=entry,
-                repo_path=repo_path,
-                enable_bc_tools=enable_bc_tools,
-                container_name=container_name,
-                username=username,
-                password=password,
-                step_limit=step_limit,
-                cost_limit=cost_limit,
-                output_dir=run_dir,
-            )
-
-        # TODO: Extract run detailed from agent (metrics to be discussed)
-
-        apply_patch(repo_path, entry.test_patch, f"{entry.instance_id} test patch")
-        build_and_publish_projects(
-            repo_path,
-            entry.project_paths,
-            container_name,
-            username,
-            password,
-            entry.environment_setup_version,
-        )
-        run_tests(entry, container_name, username, password)
-
-        # TODO: Parse test_results to extract pass/fail counts and resolved status
-        # For now, assume resolved if no exception (error will be thrown when tests fail)
-        result.resolved = True
-
-        logger.info(f"Successfully completed {entry.instance_id}")
-
-    except Exception as e:
-        result.resolved = False
-        result.error_message = str(e)
-        logger.error(f"Failed to process {entry.instance_id}: {e}")
-
-    finally:
-        result.save(run_dir, f"instance_results_{entry_id}.jsonl")
+    run_evaluation_pipeline(
+        context,
+        lambda ctx: run_mini_agent(
+            entry=ctx.entry,
+            repo_path=ctx.repo_path,
+            enable_bc_tools=ctx.get_agent_option("enable_bc_tools", False),
+            container_name=ctx.container_name,
+            username=ctx.username,
+            password=ctx.password,
+            step_limit=ctx.get_agent_option("step_limit", 20),
+            cost_limit=ctx.get_agent_option("cost_limit", 1.0),
+            output_dir=ctx.result_dir,
+        ),
+    )
 
     logger.info("Evaluation complete!")
     logger.info(f"Results saved to: {run_dir}")
@@ -158,53 +133,25 @@ def evaluate_copilot(
     run_dir.mkdir(parents=True)
 
     logger.info(f"Running evaluation on entry {entry_id} with GitHub Copilot CLI")
-    result = EvaluationResult(instance_id=entry_id, version=entry.environment_setup_version)
 
-    try:
-        clean_repo(repo_path)
-        checkout_commit(repo_path, entry.base_commit)
-        build_and_publish_projects(
-            repo_path,
-            entry.project_paths,
-            container_name,
-            username,
-            password,
-            entry.environment_setup_version,
-        )
+    context = EvaluationContext(
+        entry=entry,
+        repo_path=repo_path,
+        result_dir=run_dir,
+        container_name=container_name,
+        username=username,
+        password=password,
+        agent_name="GitHub Copilot CLI",
+    )
 
-        with github_log_group(f"GitHub Copilot CLI -- Entry: {entry.instance_id}"):
-            run_copilot_agent(
-                entry=entry,
-                repo_path=repo_path,
-                output_dir=run_dir,
-            )
-
-        # TODO: Extract run details from agent session logs
-
-        apply_patch(repo_path, entry.test_patch, f"{entry.instance_id} test patch")
-        build_and_publish_projects(
-            repo_path,
-            entry.project_paths,
-            container_name,
-            username,
-            password,
-            entry.environment_setup_version,
-        )
-        run_tests(entry, container_name, username, password)
-
-        # TODO: Parse test_results to extract pass/fail counts and resolved status
-        # For now, assume resolved if no exception (error will be thrown when tests fail)
-        result.resolved = True
-
-        logger.info(f"Successfully completed {entry.instance_id}")
-
-    except Exception as e:
-        result.resolved = False
-        result.error_message = str(e)
-        logger.error(f"Failed to process {entry.instance_id}: {e}")
-
-    finally:
-        result.save(run_dir, f"instance_results_{entry_id}.jsonl")
+    run_evaluation_pipeline(
+        context,
+        lambda ctx: run_copilot_agent(
+            entry=ctx.entry,
+            repo_path=ctx.repo_path,
+            output_dir=ctx.result_dir,
+        ),
+    )
 
     logger.info("Evaluation complete!")
     logger.info(f"Results saved to: {run_dir}")

--- a/src/bcbench/commands/evaluate.py
+++ b/src/bcbench/commands/evaluate.py
@@ -80,8 +80,7 @@ def evaluate_mini(
 
         with github_log_group(f"mini-bc-agent -- Entry: {entry.instance_id}"):
             run_mini_agent(
-                dataset_path=DATASET_PATH,
-                entry_id=entry.instance_id,
+                entry=entry,
                 repo_path=repo_path,
                 enable_bc_tools=enable_bc_tools,
                 container_name=container_name,

--- a/src/bcbench/commands/evaluate.py
+++ b/src/bcbench/commands/evaluate.py
@@ -7,8 +7,7 @@ from pathlib import Path
 import typer
 from typing_extensions import Annotated
 
-from bcbench.agent.copilot import run_copilot_agent
-from bcbench.agent.mini import run_mini_agent
+from bcbench.agent import run_copilot_agent, run_mini_agent
 from bcbench.dataset import DatasetEntry, load_dataset_entries
 from bcbench.evaluate.evaluation_result import EvaluationResult, summarize_results
 from bcbench.logger import get_logger, github_log_group

--- a/src/bcbench/commands/run.py
+++ b/src/bcbench/commands/run.py
@@ -44,11 +44,13 @@ def run_mini(
     Example:
         bcbench run mini microsoftInternal__NAV-210528 --step-limit 5
     """
+    entry: DatasetEntry = load_dataset_entries(dataset_path, entry_id=entry_id)[0]
+
     clean_repo(repo_path)
+    checkout_commit(repo_path, entry.base_commit)
 
     run_mini_agent(
-        dataset_path=dataset_path,
-        entry_id=entry_id,
+        entry=entry,
         repo_path=repo_path,
         enable_bc_tools=enable_bc_tools,
         container_name=container_name,

--- a/src/bcbench/evaluate/__init__.py
+++ b/src/bcbench/evaluate/__init__.py
@@ -1,5 +1,7 @@
 """Evaluation commands for running benchmarks."""
 
-from bcbench.evaluate.evaluation_result import EvaluationResult
+from bcbench.evaluate.evaluation_context import EvaluationContext
+from bcbench.evaluate.evaluation_pipeline import run_evaluation_pipeline
+from bcbench.evaluate.evaluation_result import EvaluationResult, summarize_results
 
-__all__ = ["EvaluationResult"]
+__all__ = ["EvaluationContext", "EvaluationResult", "run_evaluation_pipeline", "summarize_results"]

--- a/src/bcbench/evaluate/evaluation_context.py
+++ b/src/bcbench/evaluate/evaluation_context.py
@@ -1,0 +1,50 @@
+"""Evaluation context for managing agent evaluation configuration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from bcbench.dataset import DatasetEntry
+
+__all__ = ["EvaluationContext"]
+
+
+@dataclass
+class EvaluationContext:
+    """Context object containing all configuration for evaluation pipeline.
+
+    This bundles related configuration together to avoid long parameter lists
+    and makes it easier to add new configuration options in the future.
+    """
+
+    # Core configuration
+    entry: DatasetEntry
+    repo_path: Path
+    result_dir: Path
+
+    # BC Container configuration
+    container_name: str
+    password: str
+    username: str = "admin"
+
+    # Agent metadata
+    agent_name: str = "Agent"
+
+    # Agent-specific options (stored as dict for flexibility)
+    agent_options: dict[str, Any] | None = None
+
+    def get_agent_option(self, key: str, default: Any = None) -> Any:
+        """Get an agent-specific option.
+
+        Args:
+            key: Option key to retrieve
+            default: Default value if key is not found
+
+        Returns:
+            The option value or default if not found
+        """
+        if self.agent_options is None:
+            return default
+        return self.agent_options.get(key, default)

--- a/src/bcbench/evaluate/evaluation_pipeline.py
+++ b/src/bcbench/evaluate/evaluation_pipeline.py
@@ -16,7 +16,7 @@ __all__ = ["run_evaluation_pipeline"]
 def run_evaluation_pipeline(
     context: EvaluationContext,
     agent_runner: Callable[[EvaluationContext], None],
-) -> EvaluationResult:
+) -> None:
     """Common evaluation pipeline for all agents.
 
     This function handles the complete evaluation workflow:
@@ -28,9 +28,6 @@ def run_evaluation_pipeline(
     Args:
         context: Evaluation context containing all configuration
         agent_runner: Function that runs the specific agent with the context
-
-    Returns:
-        EvaluationResult with resolved status and metrics
     """
     result = EvaluationResult(
         instance_id=context.entry.instance_id,
@@ -81,5 +78,3 @@ def run_evaluation_pipeline(
 
     finally:
         result.save(context.result_dir, f"instance_results_{context.entry.instance_id}.jsonl")
-
-    return result

--- a/src/bcbench/evaluate/evaluation_pipeline.py
+++ b/src/bcbench/evaluate/evaluation_pipeline.py
@@ -1,0 +1,85 @@
+"""Core evaluation pipeline for running agents against benchmark entries."""
+
+from collections.abc import Callable
+
+from bcbench.evaluate.evaluation_context import EvaluationContext
+from bcbench.evaluate.evaluation_result import EvaluationResult
+from bcbench.logger import get_logger, github_log_group
+from bcbench.operations.bc_operations import build_and_publish_projects, run_tests
+from bcbench.operations.git_operations import apply_patch, checkout_commit, clean_repo
+
+logger = get_logger(__name__)
+
+__all__ = ["run_evaluation_pipeline"]
+
+
+def run_evaluation_pipeline(
+    context: EvaluationContext,
+    agent_runner: Callable[[EvaluationContext], None],
+) -> EvaluationResult:
+    """Common evaluation pipeline for all agents.
+
+    This function handles the complete evaluation workflow:
+    1. Setup environment (clean repo, checkout, build)
+    2. Run agent (agent-specific implementation)
+    3. Apply test patch and validate
+    4. Save results
+
+    Args:
+        context: Evaluation context containing all configuration
+        agent_runner: Function that runs the specific agent with the context
+
+    Returns:
+        EvaluationResult with resolved status and metrics
+    """
+    result = EvaluationResult(
+        instance_id=context.entry.instance_id,
+        version=context.entry.environment_setup_version,
+    )
+
+    try:
+        # Setup environment
+        clean_repo(context.repo_path)
+        checkout_commit(context.repo_path, context.entry.base_commit)
+
+        # Initial build, ensure symbols, etc. align with base commit
+        build_and_publish_projects(
+            context.repo_path,
+            context.entry.project_paths,
+            context.container_name,
+            context.username,
+            context.password,
+            context.entry.environment_setup_version,
+        )
+
+        # Run agent (agent-specific)
+        with github_log_group(f"{context.agent_name} -- Entry: {context.entry.instance_id}"):
+            agent_runner(context)
+
+        # Apply test patch and validate
+        apply_patch(context.repo_path, context.entry.test_patch, f"{context.entry.instance_id} test patch")
+        build_and_publish_projects(
+            context.repo_path,
+            context.entry.project_paths,
+            context.container_name,
+            context.username,
+            context.password,
+            context.entry.environment_setup_version,
+        )
+        run_tests(context.entry, context.container_name, context.username, context.password)
+
+        # TODO: Parse test_results to extract pass/fail counts and resolved status
+        # For now, assume resolved if no exception (error will be thrown when tests fail)
+        result.resolved = True
+
+        logger.info(f"Successfully completed {context.entry.instance_id}")
+
+    except Exception as e:
+        result.resolved = False
+        result.error_message = str(e)
+        logger.error(f"Failed to process {context.entry.instance_id}: {e}")
+
+    finally:
+        result.save(context.result_dir, f"instance_results_{context.entry.instance_id}.jsonl")
+
+    return result


### PR DESCRIPTION
Now we introduced GitHub Copilot CLI in addition to `mini-bc-agent`, lots of duplicated code can be abstracted away.

Introducing EvaluationContext and evaluate pipeline to reduce the duplicate code