### PR TITLE
Switch to 1ES runners to avoid BaseApp timeout

### DIFF
--- a/.github/workflows/copilot-evaluation.yml
+++ b/.github/workflows/copilot-evaluation.yml
@@ -34,7 +34,7 @@ jobs:
       test-run: ${{ inputs.test-run }}
 
   evaluate-with-copilot-cli:
-    runs-on: windows-latest
+    runs-on: [self-hosted, 1ES.Pool=GitHub-BCBench]
     needs: get-entries
     outputs:
       results-dir: ${{ env.EVALUATION_RESULTS_DIR }}


### PR DESCRIPTION
Publishing BaseApp requires more hardware than the standard GitHub Runners, which usually leads to timeout and instability for the jobs