### PR TITLE
Include `llm_duration` and `tool_calls` metrics in the result

### DIFF
--- a/.github/workflows/summarize-results.yml
+++ b/.github/workflows/summarize-results.yml
@@ -77,7 +77,7 @@ jobs:
             --metric-definitions "${{ github.workspace }}/evaluator/metrics.py" \
             --metrics "bc_bench_metrics" \
             --eval-run-name "${{ inputs.agent }} (${{ inputs.model }}) - #${{ github.run_id }}" \
-            --tags "${{ inputs.agent }},${{ inputs.model }},${{ inputs.category }}" "${{ !inputs.mock && '--upload-results' || '' }}"
+            --tags "${{ inputs.agent }},${{ inputs.model }},${{ inputs.category }}" ${{ !inputs.mock && '--upload-results' || '' }}
 
       - name: Update leaderboard in a new branch
         if: ${{ !inputs.mock }}

--- a/.github/workflows/summarize-results.yml
+++ b/.github/workflows/summarize-results.yml
@@ -77,8 +77,7 @@ jobs:
             --metric-definitions "${{ github.workspace }}/evaluator/metrics.py" \
             --metrics "bc_bench_metrics" \
             --eval-run-name "${{ inputs.agent }} (${{ inputs.model }}) - #${{ github.run_id }}" \
-            --tags "${{ inputs.agent }},${{ inputs.model }},${{ inputs.category }}" \
-            "${{ !inputs.mock && '--upload-results' || '' }}"
+            --tags "${{ inputs.agent }},${{ inputs.model }},${{ inputs.category }}" "${{ !inputs.mock && '--upload-results' || '' }}"
 
       - name: Update leaderboard in a new branch
         if: ${{ !inputs.mock }}

--- a/.github/workflows/summarize-results.yml
+++ b/.github/workflows/summarize-results.yml
@@ -77,7 +77,7 @@ jobs:
             --metric-definitions "${{ github.workspace }}/evaluator/metrics.py" \
             --metrics "llm_duration,tool_calls" \
             --eval-run-name "${{ inputs.agent }} (${{ inputs.model }}) - #${{ github.run_id }}" \
-            --tags "${{ inputs.agent }},${{ inputs.model }},${{ inputs.category }}" --upload-results
+            --tags "${{ inputs.agent }},${{ inputs.model }},${{ inputs.category }}" ${{ !inputs.mock && '--upload-results' || '' }}
 
       - name: Update leaderboard in a new branch
         if: ${{ !inputs.mock }}

--- a/.github/workflows/summarize-results.yml
+++ b/.github/workflows/summarize-results.yml
@@ -75,7 +75,7 @@ jobs:
             --evaluator-definitions "${{ github.workspace }}/evaluator/scores.py" \
             --evaluators "resolution_rate,build_rate" \
             --metric-definitions "${{ github.workspace }}/evaluator/metrics.py" \
-            --metrics "llm_duration,tool_calls" \
+            --metrics "llm_duration" \
             --eval-run-name "${{ inputs.agent }} (${{ inputs.model }}) - #${{ github.run_id }}" \
             --tags "${{ inputs.agent }},${{ inputs.model }},${{ inputs.category }}" --upload-results
 

--- a/.github/workflows/summarize-results.yml
+++ b/.github/workflows/summarize-results.yml
@@ -74,8 +74,10 @@ jobs:
           evalRunName="${{ inputs.agent }} (${{ inputs.model }}) - #${{ github.run_id }}"
           tags="${{ inputs.agent }},${{ inputs.model }},${{ inputs.category }}"
           uploadFlag="${{ !inputs.mock && '--upload-results' || '' }}"
+          scoreDef="${{ github.workspace }}/evaluator/scores.py"
+          metricsDef="${{ github.workspace }}/evaluator/metrics.py"
 
-          bceval metrics calculate --input-file "$bcevalResultsFile" --evaluators "resolution_rate,build_rate" --evaluator-definitions "${{ github.workspace }}/evaluator/scores.py" --eval-run-name "$evalRunName" --tags "$tags" $uploadFlag
+          bceval metrics calculate --input-file "$bcevalResultsFile" --evaluators "resolution_rate,build_rate" --evaluator-definitions "$scoreDef" --metric-definitions "$metricsDef" --metrics "bc_bench_metrics" --eval-run-name "$evalRunName" --tags "$tags" $uploadFlag
 
       - name: Update leaderboard in a new branch
         if: ${{ !inputs.mock }}

--- a/.github/workflows/summarize-results.yml
+++ b/.github/workflows/summarize-results.yml
@@ -77,7 +77,7 @@ jobs:
             --metric-definitions "${{ github.workspace }}/evaluator/metrics.py" \
             --metrics "bc_bench_metrics" \
             --eval-run-name "${{ inputs.agent }} (${{ inputs.model }}) - #${{ github.run_id }}" \
-            --tags "${{ inputs.agent }},${{ inputs.model }},${{ inputs.category }}" ${{ !inputs.mock && '--upload-results' || '' }}
+            --tags "${{ inputs.agent }},${{ inputs.model }},${{ inputs.category }}" --upload-results
 
       - name: Update leaderboard in a new branch
         if: ${{ !inputs.mock }}

--- a/.github/workflows/summarize-results.yml
+++ b/.github/workflows/summarize-results.yml
@@ -75,7 +75,7 @@ jobs:
             --evaluator-definitions "${{ github.workspace }}/evaluator/scores.py" \
             --evaluators "resolution_rate,build_rate" \
             --metric-definitions "${{ github.workspace }}/evaluator/metrics.py" \
-            --metrics "bc_bench_metrics" \
+            --metrics "llm_duration,tool_calls" \
             --eval-run-name "${{ inputs.agent }} (${{ inputs.model }}) - #${{ github.run_id }}" \
             --tags "${{ inputs.agent }},${{ inputs.model }},${{ inputs.category }}" --upload-results
 

--- a/.github/workflows/summarize-results.yml
+++ b/.github/workflows/summarize-results.yml
@@ -70,14 +70,15 @@ jobs:
           uv tool install bc-eval==0.1.3 --python 3.11 --index "https://${{ env.USERNAME }}:${{ env.ADO_TOKEN }}@dynamicssmb2.pkgs.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_packaging/PythonPackages%40Local/pypi/simple/"
 
           # Upload summary to Braintrust using bc-eval
-          bcevalResultsFile="${{ inputs.results-dir }}/${{ github.run_id }}/${{ env.BCEVAL_RESULT_FILE }}"
-          evalRunName="${{ inputs.agent }} (${{ inputs.model }}) - #${{ github.run_id }}"
-          tags="${{ inputs.agent }},${{ inputs.model }},${{ inputs.category }}"
-          uploadFlag="${{ !inputs.mock && '--upload-results' || '' }}"
-          scoreDef="${{ github.workspace }}/evaluator/scores.py"
-          metricsDef="${{ github.workspace }}/evaluator/metrics.py"
-
-          bceval metrics calculate --input-file "$bcevalResultsFile" --evaluators "resolution_rate,build_rate" --evaluator-definitions "$scoreDef" --metric-definitions "$metricsDef" --metrics "bc_bench_metrics" --eval-run-name "$evalRunName" --tags "$tags" $uploadFlag
+          bceval metrics calculate \
+            --input-file "${{ inputs.results-dir }}/${{ github.run_id }}/${{ env.BCEVAL_RESULT_FILE }}" \
+            --evaluator-definitions "${{ github.workspace }}/evaluator/scores.py" \
+            --evaluators "resolution_rate,build_rate" \
+            --metric-definitions "${{ github.workspace }}/evaluator/metrics.py" \
+            --metrics "bc_bench_metrics" \
+            --eval-run-name "${{ inputs.agent }} (${{ inputs.model }}) - #${{ github.run_id }}" \
+            --tags "${{ inputs.agent }},${{ inputs.model }},${{ inputs.category }}" \
+            "${{ !inputs.mock && '--upload-results' || '' }}"
 
       - name: Update leaderboard in a new branch
         if: ${{ !inputs.mock }}

--- a/.github/workflows/summarize-results.yml
+++ b/.github/workflows/summarize-results.yml
@@ -75,7 +75,7 @@ jobs:
             --evaluator-definitions "${{ github.workspace }}/evaluator/scores.py" \
             --evaluators "resolution_rate,build_rate" \
             --metric-definitions "${{ github.workspace }}/evaluator/metrics.py" \
-            --metrics "llm_duration" \
+            --metrics "llm_duration,tool_calls" \
             --eval-run-name "${{ inputs.agent }} (${{ inputs.model }}) - #${{ github.run_id }}" \
             --tags "${{ inputs.agent }},${{ inputs.model }},${{ inputs.category }}" --upload-results
 

--- a/evaluator/metrics.py
+++ b/evaluator/metrics.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 
-class BcBenchMetrics:
+class LlmDuration:
+    def __call__(self, *, metadata: dict, **kwargs):
+        return metadata.get("llm_duration", 0)
+
+
+class ToolCalls:
     def __call__(self, *, metadata: dict, **kwargs):
         tool_usage: dict[str, int] = metadata.get("tool_usage", {})
-        return {
-            "llm_duration": metadata.get("llm_duration", 0),
-            "tool_calls": sum(tool_usage.values()) if tool_usage else 0,
-        }
+        return sum(tool_usage.values()) if tool_usage else 0

--- a/evaluator/metrics.py
+++ b/evaluator/metrics.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 
 class BcBenchMetrics:
     def __call__(self, *, metadata: dict, **kwargs):
+        tool_usage: dict[str, int] = metadata.get("tool_usage", {})
         return {
             "llm_duration": metadata.get("llm_duration", 0),
-            "tool_calls": metadata.get("tool_calls", {}),
+            "tool_calls": sum(tool_usage.values()) if tool_usage else 0,
         }

--- a/evaluator/metrics.py
+++ b/evaluator/metrics.py
@@ -5,4 +5,5 @@ class BcBenchMetrics:
     def __call__(self, *, metadata: dict, **kwargs):
         return {
             "llm_duration": metadata.get("llm_duration", 0),
+            "tool_calls": metadata.get("tool_calls", {}),
         }

--- a/evaluator/metrics.py
+++ b/evaluator/metrics.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+
+class BcBenchMetrics:
+    def __call__(self, *, metadata: dict, **kwargs):
+        return {
+            "llm_duration": metadata.get("llm_duration", 0),
+        }

--- a/evaluator/metrics.py
+++ b/evaluator/metrics.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 
 class LlmDuration:
     def __call__(self, *, metadata: dict, **kwargs):
-        return metadata.pop("llm_duration", 0)
+        return {"llm_duration": metadata.pop("llm_duration", 0)}
 
 
 class ToolCalls:
     def __call__(self, *, metadata: dict, **kwargs):
         tool_usage: dict[str, int] = metadata.get("tool_usage", {})
-        return sum(tool_usage.values()) if tool_usage else 0
+        return {"tool_calls": sum(tool_usage.values()) if tool_usage else 0}

--- a/evaluator/metrics.py
+++ b/evaluator/metrics.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 class LlmDuration:
     def __call__(self, *, metadata: dict, **kwargs):
-        return metadata.get("llm_duration", 0)
+        return metadata.pop("llm_duration", 0)
 
 
 class ToolCalls:

--- a/src/bcbench/agent/copilot/metrics.py
+++ b/src/bcbench/agent/copilot/metrics.py
@@ -27,10 +27,19 @@ def parse_metrics(output_lines: Sequence[str]) -> AgentMetrics | None:
     logger.debug(f"Parsing metrics from output:\n{output_text}")
 
     execution_time: float | None = None
+    llm_duration: float | None = None
     prompt_tokens: int | None = None
     completion_tokens: int | None = None
 
     try:
+        # Parse LLM duration (API time)
+        llm_duration_match = re.search(r"Total duration \(API\):\s*(?:(\d+)m\s*)?(\d+(?:\.\d+)?)s", output_text)
+        if llm_duration_match:
+            minutes = int(llm_duration_match.group(1)) if llm_duration_match.group(1) else 0
+            seconds = float(llm_duration_match.group(2))
+            llm_duration = minutes * 60 + seconds
+
+        # Parse wall clock duration
         duration_match = re.search(r"Total duration \(wall\):\s*(?:(\d+)m\s*)?(\d+(?:\.\d+)?)s", output_text)
         if duration_match:
             minutes = int(duration_match.group(1)) if duration_match.group(1) else 0
@@ -52,8 +61,13 @@ def parse_metrics(output_lines: Sequence[str]) -> AgentMetrics | None:
             prompt_tokens = parse_token_count(input_str)
             completion_tokens = parse_token_count(output_str)
 
-        if execution_time is not None or prompt_tokens is not None or completion_tokens is not None:
-            return AgentMetrics(execution_time=execution_time, prompt_tokens=prompt_tokens, completion_tokens=completion_tokens)
+        if execution_time is not None or llm_duration is not None or prompt_tokens is not None or completion_tokens is not None:
+            return AgentMetrics(
+                execution_time=execution_time,
+                llm_duration=llm_duration,
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+            )
 
         logger.warning("No metrics found in output")
         return None

--- a/src/bcbench/agent/copilot/tool_usage_parser.py
+++ b/src/bcbench/agent/copilot/tool_usage_parser.py
@@ -19,9 +19,7 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-from bcbench.types import ToolUsage
-
-__all__ = ["ToolUsage", "parse_tool_usage_from_log"]
+__all__ = ["parse_tool_usage_from_log"]
 
 # Regex to find tool call function names in the log content
 # Matches tool calls (with "arguments") but NOT tool definitions (with "description")
@@ -32,7 +30,7 @@ TOOL_CALL_PATTERN = re.compile(
 )
 
 
-def parse_tool_usage_from_log(log_path: Path) -> ToolUsage:
+def parse_tool_usage_from_log(log_path: Path) -> dict[str, float]:
     """Parse tool usage from a single Copilot CLI log file.
 
     The log file format is timestamped text with embedded JSON responses.
@@ -42,7 +40,7 @@ def parse_tool_usage_from_log(log_path: Path) -> ToolUsage:
         log_path: Path to the Copilot CLI log file
 
     Returns:
-        ToolUsage with counted tool calls from the log
+        Dict mapping tool names to call counts from the log
     """
     tool_counts: dict[str, float] = {}
 
@@ -54,4 +52,4 @@ def parse_tool_usage_from_log(log_path: Path) -> ToolUsage:
     for tool_name in matches:
         tool_counts[tool_name] = tool_counts.get(tool_name, 0) + 1
 
-    return ToolUsage(tool_counts=tool_counts)
+    return tool_counts

--- a/src/bcbench/agent/copilot/tool_usage_parser.py
+++ b/src/bcbench/agent/copilot/tool_usage_parser.py
@@ -30,7 +30,7 @@ TOOL_CALL_PATTERN = re.compile(
 )
 
 
-def parse_tool_usage_from_log(log_path: Path) -> dict[str, float]:
+def parse_tool_usage_from_log(log_path: Path) -> dict[str, int]:
     """Parse tool usage from a single Copilot CLI log file.
 
     The log file format is timestamped text with embedded JSON responses.
@@ -42,7 +42,7 @@ def parse_tool_usage_from_log(log_path: Path) -> dict[str, float]:
     Returns:
         Dict mapping tool names to call counts from the log
     """
-    tool_counts: dict[str, float] = {}
+    tool_counts: dict[str, int] = {}
 
     content = log_path.read_text(encoding="utf-8")
 

--- a/src/bcbench/commands/evaluate.py
+++ b/src/bcbench/commands/evaluate.py
@@ -212,9 +212,9 @@ class MockEvaluationPipeline(EvaluationPipeline):
 
         # Randomize agent metrics to test different scenarios
         metrics_scenarios: list[AgentMetrics | None] = [
-            AgentMetrics(execution_time=0.1, prompt_tokens=100, completion_tokens=50, tool_usage={"bash": 5, "view": 3, "edit": 2}),
-            AgentMetrics(execution_time=0.2, prompt_tokens=250, tool_usage={"bash": 10, "search": 4}),
-            AgentMetrics(execution_time=0.15, tool_usage={"view": 8}),
+            AgentMetrics(execution_time=0.1, llm_duration=0.05, prompt_tokens=100, completion_tokens=50, tool_usage={"bash": 5, "view": 3, "edit": 2}),
+            AgentMetrics(execution_time=0.2, llm_duration=0.1, prompt_tokens=250, tool_usage={"bash": 10, "search": 4}),
+            AgentMetrics(execution_time=0.15, llm_duration=0.07, tool_usage={"view": 8}),
             AgentMetrics(),
             None,
             AgentMetrics(prompt_tokens=500, completion_tokens=100, tool_usage={"bash": 3, "view": 2, "edit": 1, "search": 5}),

--- a/src/bcbench/commands/evaluate.py
+++ b/src/bcbench/commands/evaluate.py
@@ -24,7 +24,7 @@ from bcbench.dataset import DatasetEntry, load_dataset_entries
 from bcbench.evaluate import EvaluationPipeline, create_pipeline
 from bcbench.logger import get_logger
 from bcbench.results import BaseEvaluationResult
-from bcbench.types import AgentMetrics, EvaluationContext, ExperimentConfiguration, ToolUsage
+from bcbench.types import AgentMetrics, EvaluationContext, ExperimentConfiguration
 
 logger = get_logger(__name__)
 _config = get_config()
@@ -212,12 +212,12 @@ class MockEvaluationPipeline(EvaluationPipeline):
 
         # Randomize agent metrics to test different scenarios
         metrics_scenarios: list[AgentMetrics | None] = [
-            AgentMetrics(execution_time=0.1, prompt_tokens=100, completion_tokens=50, tool_usage=ToolUsage(tool_counts={"bash": 5, "view": 3, "edit": 2})),
-            AgentMetrics(execution_time=0.2, prompt_tokens=250, tool_usage=ToolUsage(tool_counts={"bash": 10, "search": 4})),
-            AgentMetrics(execution_time=0.15, tool_usage=ToolUsage(tool_counts={"view": 8})),
+            AgentMetrics(execution_time=0.1, prompt_tokens=100, completion_tokens=50, tool_usage={"bash": 5, "view": 3, "edit": 2}),
+            AgentMetrics(execution_time=0.2, prompt_tokens=250, tool_usage={"bash": 10, "search": 4}),
+            AgentMetrics(execution_time=0.15, tool_usage={"view": 8}),
             AgentMetrics(),
             None,
-            AgentMetrics(prompt_tokens=500, completion_tokens=100, tool_usage=ToolUsage(tool_counts={"bash": 3, "view": 2, "edit": 1, "search": 5})),
+            AgentMetrics(prompt_tokens=500, completion_tokens=100, tool_usage={"bash": 3, "view": 2, "edit": 1, "search": 5}),
         ]
         context.metrics = random.choice(metrics_scenarios)
 

--- a/src/bcbench/commands/run.py
+++ b/src/bcbench/commands/run.py
@@ -138,8 +138,8 @@ def run_copilot_tool_analyzer(path: Annotated[Path, typer.Argument(help="Directo
     print("Tool Usage Summary:")
     print("-" * 40)
 
-    for tool_name, count in sorted(usage.tool_counts.items(), key=lambda x: (-x[1], x[0])):
+    for tool_name, count in sorted(usage.items(), key=lambda x: (-x[1], x[0])):
         print(f"  {tool_name}: {count}")
 
     print("-" * 40)
-    print(f"Total tool calls: {sum(usage.tool_counts.values())}")
+    print(f"Total tool calls: {sum(usage.values())}")

--- a/src/bcbench/results/base.py
+++ b/src/bcbench/results/base.py
@@ -57,22 +57,11 @@ class BaseEvaluationResult(BaseModel):
         Returns:
             Result instance (base or category-specific subclass)
         """
-        # Warn about missing critical data
+        # Warn about missing metrics if they are not present
         if not context.metrics:
             logger.warning(f"Creating result for {context.entry.instance_id} with no agent metrics - performance data will be unavailable")
-        else:
-            missing_metrics = []
-            if context.metrics.execution_time is None:
-                missing_metrics.append("execution_time")
-            if context.metrics.prompt_tokens is None:
-                missing_metrics.append("prompt_tokens")
-            if context.metrics.completion_tokens is None:
-                missing_metrics.append("completion_tokens")
-            if context.metrics.tool_usage is None:
-                missing_metrics.append("tool_usage")
-
-            if missing_metrics:
-                logger.warning(f"Result for {context.entry.instance_id} missing metrics: {', '.join(missing_metrics)}")
+        elif missing_metrics := [name for name in AgentMetrics.model_fields if getattr(context.metrics, name) is None]:
+            logger.warning(f"Result for {context.entry.instance_id} missing metrics: {', '.join(missing_metrics)}")
 
         project = context.entry.extract_project_name()
         return cls(

--- a/src/bcbench/results/display.py
+++ b/src/bcbench/results/display.py
@@ -25,9 +25,9 @@ def create_console_summary(results: list[BaseEvaluationResult]) -> None:
     tool_usages = [r.metrics.tool_usage for r in results if r.metrics and r.metrics.tool_usage is not None]
     if tool_usages:
         avg_usage = _calculate_average_tool_usage(tool_usages)
-        if avg_usage.tool_counts:
+        if avg_usage:
             console.print("\n[bold cyan]Average Tool Usage[/bold cyan]")
-            sorted_tools = sorted(avg_usage.tool_counts.items(), key=lambda x: x[1], reverse=True)
+            sorted_tools = sorted(avg_usage.items(), key=lambda x: x[1], reverse=True)
             for tool_name, count in sorted_tools:
                 console.print(f"  {tool_name}: [bold]{count}[/bold]")
 
@@ -66,8 +66,8 @@ def create_github_job_summary(results: list[BaseEvaluationResult]) -> None:
     tool_usages = [r.metrics.tool_usage for r in results if r.metrics and r.metrics.tool_usage is not None]
     if tool_usages:
         avg_usage = _calculate_average_tool_usage(tool_usages)
-        if avg_usage.tool_counts:
-            sorted_tools = sorted(avg_usage.tool_counts.items(), key=lambda x: x[1], reverse=True)
+        if avg_usage:
+            sorted_tools = sorted(avg_usage.items(), key=lambda x: x[1], reverse=True)
             tool_lines = [f"  - `{tool}`: {count}" for tool, count in sorted_tools]
             tool_usage_section = "\n\n## Average Tool Usage\n" + "\n".join(tool_lines)
 

--- a/src/bcbench/results/evaluation_result.py
+++ b/src/bcbench/results/evaluation_result.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel
 
 from bcbench.logger import get_logger
 from bcbench.results.base import BaseEvaluationResult
-from bcbench.types import EvaluationCategory, ExperimentConfiguration, ToolUsage
+from bcbench.types import EvaluationCategory, ExperimentConfiguration
 
 logger = get_logger(__name__)
 
@@ -28,7 +28,7 @@ class EvaluationResultSummary(BaseModel):
     average_prompt_tokens: float
     average_completion_tokens: float
     average_llm_duration: float
-    average_tool_usage: ToolUsage | None = None
+    average_tool_usage: dict[str, float] | None = None
 
     github_run_id: str | None = None
     experiment: ExperimentConfiguration | None = None
@@ -85,21 +85,19 @@ class EvaluationResultSummary(BaseModel):
         logger.info(f"Saved evaluation summary to {output_file}")
 
 
-def _calculate_average_tool_usage(tool_usages: list[ToolUsage]) -> ToolUsage:
+def _calculate_average_tool_usage(tool_usages: list[dict[str, float]]) -> dict[str, float]:
     """Calculate average tool usage across multiple results.
 
     Sums up all tool counts and divides by the number of results to get average.
     """
     if not tool_usages:
-        return ToolUsage()
+        return {}
 
     aggregated: dict[str, float] = {}
     for usage in tool_usages:
-        for tool_name, count in usage.tool_counts.items():
+        for tool_name, count in usage.items():
             aggregated[tool_name] = aggregated.get(tool_name, 0) + count
 
     # Calculate average (rounded to nearest integer)
     num_results = len(tool_usages)
-    average_counts = {tool: round(count / num_results, 2) for tool, count in aggregated.items()}
-
-    return ToolUsage(tool_counts=average_counts)
+    return {tool: round(count / num_results, 2) for tool, count in aggregated.items()}

--- a/src/bcbench/results/evaluation_result.py
+++ b/src/bcbench/results/evaluation_result.py
@@ -85,7 +85,7 @@ class EvaluationResultSummary(BaseModel):
         logger.info(f"Saved evaluation summary to {output_file}")
 
 
-def _calculate_average_tool_usage(tool_usages: list[dict[str, float]]) -> dict[str, float]:
+def _calculate_average_tool_usage(tool_usages: list[dict[str, int]]) -> dict[str, float]:
     """Calculate average tool usage across multiple results.
 
     Sums up all tool counts and divides by the number of results to get average.

--- a/src/bcbench/results/evaluation_result.py
+++ b/src/bcbench/results/evaluation_result.py
@@ -27,6 +27,7 @@ class EvaluationResultSummary(BaseModel):
     average_duration: float
     average_prompt_tokens: float
     average_completion_tokens: float
+    average_llm_duration: float
     average_tool_usage: ToolUsage | None = None
 
     github_run_id: str | None = None
@@ -40,6 +41,7 @@ class EvaluationResultSummary(BaseModel):
         durations = [r.metrics.execution_time for r in results if r.metrics and r.metrics.execution_time is not None]
         prompt_tokens = [r.metrics.prompt_tokens for r in results if r.metrics and r.metrics.prompt_tokens is not None]
         completion_tokens = [r.metrics.completion_tokens for r in results if r.metrics and r.metrics.completion_tokens is not None]
+        llm_durations = [r.metrics.llm_duration for r in results if r.metrics and r.metrics.llm_duration is not None]
 
         # Calculate average tool usage across all results
         tool_usages = [r.metrics.tool_usage for r in results if r.metrics and r.metrics.tool_usage is not None]
@@ -61,6 +63,7 @@ class EvaluationResultSummary(BaseModel):
             average_duration=sum(durations) / len(durations) if durations else 0.0,
             average_prompt_tokens=sum(prompt_tokens) / len(prompt_tokens) if prompt_tokens else 0.0,
             average_completion_tokens=sum(completion_tokens) / len(completion_tokens) if completion_tokens else 0.0,
+            average_llm_duration=sum(llm_durations) / len(llm_durations) if llm_durations else 0.0,
             average_tool_usage=average_tool_usage,
             github_run_id=run_id,
             experiment=experiment,

--- a/src/bcbench/results/result_writer.py
+++ b/src/bcbench/results/result_writer.py
@@ -42,7 +42,7 @@ def write_bceval_results(results: list[BaseEvaluationResult], out_dir: Path, run
                     "build": result.build,
                     "run_id": run_id,
                     "project": result.project,
-                    "tool_calls": (result.metrics.tool_usage if result.metrics and result.metrics.tool_usage else None) or 0,
+                    "tool_usage": (result.metrics.tool_usage if result.metrics and result.metrics.tool_usage else None) or 0,
                 },
                 "tags": [],
             }

--- a/src/bcbench/results/result_writer.py
+++ b/src/bcbench/results/result_writer.py
@@ -36,6 +36,7 @@ def write_bceval_results(results: list[BaseEvaluationResult], out_dir: Path, run
                     "model": result.model,
                     "prompt_tokens": (result.metrics.prompt_tokens if result.metrics else None) or 0,
                     "completion_tokens": (result.metrics.completion_tokens if result.metrics else None) or 0,
+                    "llm_duration": (result.metrics.llm_duration if result.metrics else None) or 0,
                     "latency": (result.metrics.execution_time if result.metrics else None) or 0,
                     "resolved": result.resolved,
                     "build": result.build,

--- a/src/bcbench/results/result_writer.py
+++ b/src/bcbench/results/result_writer.py
@@ -42,6 +42,7 @@ def write_bceval_results(results: list[BaseEvaluationResult], out_dir: Path, run
                     "build": result.build,
                     "run_id": run_id,
                     "project": result.project,
+                    "tool_calls": (result.metrics.tool_usage if result.metrics and result.metrics.tool_usage else None) or 0,
                 },
                 "tags": [],
             }

--- a/src/bcbench/types.py
+++ b/src/bcbench/types.py
@@ -34,7 +34,7 @@ class AgentMetrics(BaseModel):
     completion_tokens: int | None = None
 
     # Tool usage statistics from agent logs
-    tool_usage: dict[str, float] | None = None
+    tool_usage: dict[str, int] | None = None
 
 
 class ExperimentConfiguration(BaseModel):

--- a/src/bcbench/types.py
+++ b/src/bcbench/types.py
@@ -33,6 +33,7 @@ class AgentMetrics(BaseModel):
 
     # Total execution time in seconds
     execution_time: float | None = None
+    llm_duration: float | None = None
 
     # Token usage from LLM calls
     prompt_tokens: int | None = None

--- a/src/bcbench/types.py
+++ b/src/bcbench/types.py
@@ -14,15 +14,9 @@ from bcbench.logger import get_logger
 if TYPE_CHECKING:
     from bcbench.dataset import DatasetEntry
 
-__all__ = ["AgentMetrics", "EvaluationContext", "ExperimentConfiguration", "ToolUsage"]
+__all__ = ["AgentMetrics", "EvaluationContext", "ExperimentConfiguration"]
 
 logger = get_logger(__name__)
-
-
-class ToolUsage(BaseModel):
-    """Tool usage statistics from agent logs."""
-
-    tool_counts: dict[str, float] = {}
 
 
 class AgentMetrics(BaseModel):
@@ -40,7 +34,7 @@ class AgentMetrics(BaseModel):
     completion_tokens: int | None = None
 
     # Tool usage statistics from agent logs
-    tool_usage: ToolUsage | None = None
+    tool_usage: dict[str, float] | None = None
 
 
 class ExperimentConfiguration(BaseModel):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -220,7 +220,7 @@ def sample_testgen_result() -> TestGenerationResult:
 @pytest.fixture
 def sample_bugfix_result_with_metrics() -> BugFixResult:
     return create_bugfix_result(
-        metrics=AgentMetrics(execution_time=120.5, prompt_tokens=5000, completion_tokens=1200),
+        metrics=AgentMetrics(execution_time=120.5, prompt_tokens=5000, completion_tokens=1200, llm_duration=100.0, tool_usage={"view_code": 2, "run_tests": 1}),
     )
 
 

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -335,6 +335,7 @@ def sample_leaderboard_and_summary(tmp_path):
             "average_duration": 120.5,
             "average_prompt_tokens": 5000.0,
             "average_completion_tokens": 1500.0,
+            "average_llm_duration": 80.0,
             "github_run_id": "run_001",
             "experiment": {
                 "mcp_servers": ["server1", "server2"],
@@ -354,6 +355,7 @@ def sample_leaderboard_and_summary(tmp_path):
             "average_duration": 95.0,
             "average_prompt_tokens": 3500.0,
             "average_completion_tokens": 1000.0,
+            "average_llm_duration": 65.0,
             "github_run_id": "run_003",
             "experiment": {
                 "mcp_servers": None,
@@ -377,6 +379,7 @@ def sample_leaderboard_and_summary(tmp_path):
             "average_duration": 110.0,
             "average_prompt_tokens": 4500.0,
             "average_completion_tokens": 1200.0,
+            "average_llm_duration": 75.0,
             "github_run_id": "run_002",
             "experiment": {
                 "mcp_servers": None,
@@ -405,6 +408,7 @@ def sample_leaderboard_and_summary(tmp_path):
         "average_duration": 130.0,
         "average_prompt_tokens": 5200.0,
         "average_completion_tokens": 1600.0,
+        "average_llm_duration": 90.0,
         "github_run_id": "run_004",
         "experiment": {
             "mcp_servers": ["server1", "server2"],
@@ -476,6 +480,7 @@ def test_result_update_adds_new_entry(sample_leaderboard_and_summary):
         "average_duration": 100.0,
         "average_prompt_tokens": 4800.0,
         "average_completion_tokens": 1400.0,
+        "average_llm_duration": 70.0,
         "github_run_id": "run_005",
         "experiment": {
             "mcp_servers": None,
@@ -535,6 +540,7 @@ def test_result_update_distinguishes_by_mcp_servers(sample_leaderboard_and_summa
         "average_duration": 115.0,
         "average_prompt_tokens": 4900.0,
         "average_completion_tokens": 1350.0,
+        "average_llm_duration": 78.0,
         "github_run_id": "run_006",
         "experiment": {
             "mcp_servers": None,  # Different from existing ["server1", "server2"]

--- a/tests/test_copilot_metrics_parsing.py
+++ b/tests/test_copilot_metrics_parsing.py
@@ -16,6 +16,7 @@ def test_parse_metrics_full_output_gpt5():
 
     assert result is not None
     assert result.execution_time == 235.1
+    assert result.llm_duration == 34.5
     assert result.prompt_tokens == 125500
     assert result.completion_tokens == 3600
 
@@ -35,8 +36,27 @@ def test_parse_metrics_full_output_haiku45():
 
     assert result is not None
     assert result.execution_time == 1765.4
+    assert result.llm_duration == 97.1
     assert result.prompt_tokens == 1100000
     assert result.completion_tokens == 6600
+
+
+def test_parse_metrics_llm_duration_seconds_only():
+    output_lines = ["Total duration (API):  45.7s\n"]
+
+    result = parse_metrics(output_lines)
+
+    assert result is not None
+    assert result.llm_duration == 45.7
+
+
+def test_parse_metrics_llm_duration_minutes_and_seconds():
+    output_lines = ["Total duration (API):  5m 12.3s\n"]
+
+    result = parse_metrics(output_lines)
+
+    assert result is not None
+    assert result.llm_duration == 312.3
 
 
 def test_parse_metrics_wall_time_seconds_only():
@@ -98,6 +118,7 @@ def test_parse_metrics_partial_data():
 
     assert result is not None
     assert result.execution_time == 90.0
+    assert result.llm_duration is None
     assert result.prompt_tokens is None
     assert result.completion_tokens is None
 
@@ -141,6 +162,7 @@ def test_parse_metrics_with_command_output():
 
     assert result is not None
     assert result.execution_time == 235.1
+    assert result.llm_duration == 34.5
     assert result.prompt_tokens == 125500
     assert result.completion_tokens == 3600
 

--- a/tests/test_evaluation_summary.py
+++ b/tests/test_evaluation_summary.py
@@ -22,6 +22,7 @@ class TestEvaluationResultSummary:
             average_duration=120.5,
             average_prompt_tokens=5000.0,
             average_completion_tokens=1200.0,
+            average_llm_duration=80.0,
         )
 
         summary_file = "test.json"
@@ -57,6 +58,7 @@ class TestEvaluationResultSummary:
             average_duration=90.0,
             average_prompt_tokens=3000.0,
             average_completion_tokens=800.0,
+            average_llm_duration=60.0,
         )
 
         summary.save(tmp_path, summary_file="custom_summary.json")
@@ -244,6 +246,7 @@ class TestExperimentConfiguration:
             average_duration=100.0,
             average_prompt_tokens=4000.0,
             average_completion_tokens=1000.0,
+            average_llm_duration=70.0,
             experiment=experiment,
         )
 
@@ -265,6 +268,7 @@ class TestExperimentConfiguration:
             average_duration=100.0,
             average_prompt_tokens=4000.0,
             average_completion_tokens=1000.0,
+            average_llm_duration=70.0,
         )
 
         assert summary.experiment is None
@@ -286,6 +290,7 @@ class TestExperimentConfiguration:
             average_duration=120.5,
             average_prompt_tokens=5000.0,
             average_completion_tokens=1200.0,
+            average_llm_duration=80.0,
             experiment=experiment,
         )
 
@@ -312,6 +317,7 @@ class TestExperimentConfiguration:
             average_duration=100.0,
             average_prompt_tokens=4000.0,
             average_completion_tokens=1000.0,
+            average_llm_duration=70.0,
             experiment=None,
         )
 

--- a/tests/test_evaluation_summary.py
+++ b/tests/test_evaluation_summary.py
@@ -159,8 +159,6 @@ class TestFromResults:
         assert summary.average_completion_tokens == 0.0
 
     def test_from_results_calculates_average_tool_usage(self):
-        from bcbench.types import ToolUsage
-
         results = [
             create_bugfix_result(
                 instance_id="test__1",
@@ -168,7 +166,7 @@ class TestFromResults:
                 resolved=True,
                 metrics=AgentMetrics(
                     execution_time=100.0,
-                    tool_usage=ToolUsage(tool_counts={"bash": 10, "view": 5}),
+                    tool_usage={"bash": 10, "view": 5},
                 ),
             ),
             create_bugfix_result(
@@ -177,7 +175,7 @@ class TestFromResults:
                 resolved=True,
                 metrics=AgentMetrics(
                     execution_time=100.0,
-                    tool_usage=ToolUsage(tool_counts={"bash": 6, "view": 3, "edit": 2}),
+                    tool_usage={"bash": 6, "view": 3, "edit": 2},
                 ),
             ),
         ]
@@ -186,11 +184,11 @@ class TestFromResults:
 
         assert summary.average_tool_usage is not None
         # bash: (10 + 6) / 2 = 8
-        assert summary.average_tool_usage.tool_counts["bash"] == 8
+        assert summary.average_tool_usage["bash"] == 8
         # view: (5 + 3) / 2 = 4
-        assert summary.average_tool_usage.tool_counts["view"] == 4
+        assert summary.average_tool_usage["view"] == 4
         # edit: (0 + 2) / 2 = 1
-        assert summary.average_tool_usage.tool_counts["edit"] == 1
+        assert summary.average_tool_usage["edit"] == 1
 
     def test_from_results_handles_no_tool_usage(self):
         results = [

--- a/tests/test_result_serialization.py
+++ b/tests/test_result_serialization.py
@@ -2,7 +2,6 @@ import json
 
 import pytest
 
-from bcbench.agent.copilot.tool_usage_parser import ToolUsage
 from bcbench.commands.result import _experiments_equal
 from bcbench.results.base import create_result_from_json
 from bcbench.results.evaluation_result import EvaluationResultSummary
@@ -184,7 +183,7 @@ class TestCategorySerialization:
         assert data["experiment"]["mcp_servers"] is None
 
     def test_tool_usage_saves_as_dict(self, tmp_path):
-        tool_usage = ToolUsage(tool_counts={"bash": 5, "view": 3, "search": 2})
+        tool_usage = {"bash": 5, "view": 3, "search": 2}
         result = create_bugfix_result(
             instance_id="test__tool-usage",
             project="app",
@@ -199,7 +198,7 @@ class TestCategorySerialization:
 
         assert data["metrics"]["tool_usage"] is not None
         assert isinstance(data["metrics"]["tool_usage"], dict)
-        assert data["metrics"]["tool_usage"]["tool_counts"] == {"bash": 5, "view": 3, "search": 2}
+        assert data["metrics"]["tool_usage"] == {"bash": 5, "view": 3, "search": 2}
 
     def test_tool_usage_loads_from_json(self):
         payload = {
@@ -215,7 +214,7 @@ class TestCategorySerialization:
                 "execution_time": 100.0,
                 "prompt_tokens": 5000,
                 "completion_tokens": 1000,
-                "tool_usage": {"tool_counts": {"bash": 5, "view": 3}},
+                "tool_usage": {"bash": 5, "view": 3},
             },
         }
 
@@ -223,11 +222,11 @@ class TestCategorySerialization:
 
         assert result.metrics is not None
         assert result.metrics.tool_usage is not None
-        assert result.metrics.tool_usage.tool_counts["bash"] == 5
-        assert result.metrics.tool_usage.tool_counts["view"] == 3
+        assert result.metrics.tool_usage["bash"] == 5
+        assert result.metrics.tool_usage["view"] == 3
 
     def test_tool_usage_round_trip(self, tmp_path):
-        tool_usage = ToolUsage(tool_counts={"bash": 10, "view": 5})
+        tool_usage = {"bash": 10, "view": 5}
         original = create_bugfix_result(
             instance_id="round-trip-tool-usage",
             project="test-project",
@@ -249,7 +248,7 @@ class TestCategorySerialization:
         assert loaded.metrics.tool_usage is not None
         assert original.metrics is not None
         assert original.metrics.tool_usage is not None
-        assert loaded.metrics.tool_usage.tool_counts == original.metrics.tool_usage.tool_counts
+        assert loaded.metrics.tool_usage == original.metrics.tool_usage
 
 
 class TestExperimentsEqual:

--- a/tests/test_result_serialization.py
+++ b/tests/test_result_serialization.py
@@ -133,6 +133,7 @@ class TestCategorySerialization:
             "average_duration": 120.5,
             "average_prompt_tokens": 1500.0,
             "average_completion_tokens": 600.0,
+            "average_llm_duration": 80.0,
         }
 
         summary = EvaluationResultSummary.model_validate(payload)
@@ -246,6 +247,8 @@ class TestCategorySerialization:
 
         assert loaded.metrics is not None
         assert loaded.metrics.tool_usage is not None
+        assert original.metrics is not None
+        assert original.metrics.tool_usage is not None
         assert loaded.metrics.tool_usage.tool_counts == original.metrics.tool_usage.tool_counts
 
 

--- a/tests/test_result_writer.py
+++ b/tests/test_result_writer.py
@@ -36,6 +36,8 @@ class TestWriteBcevalResults:
         assert data["metadata"]["resolved"] is True
         assert data["metadata"]["run_id"] == "test_run_123"
         assert data["metadata"]["project"] == "Shopify"
+        assert data["metadata"]["llm_duration"] == 100.0
+        assert data["metadata"]["tool_usage"] == {"view_code": 2, "run_tests": 1}
 
     def test_handles_none_prompt_tokens(self, tmp_path, sample_dataset_file, sample_testgen_result, problem_statement_dir):
         output_dir = tmp_path / "output"

--- a/tests/test_tool_usage_parser.py
+++ b/tests/test_tool_usage_parser.py
@@ -1,21 +1,6 @@
 from pathlib import Path
 
-from bcbench.agent.copilot.tool_usage_parser import ToolUsage, parse_tool_usage_from_log
-
-
-class TestToolUsage:
-    def test_serialization_to_dict(self):
-        usage = ToolUsage(tool_counts={"bash": 5, "view": 3})
-        data = usage.model_dump()
-
-        assert data["tool_counts"] == {"bash": 5, "view": 3}
-
-    def test_deserialization_from_dict(self):
-        data = {"tool_counts": {"bash": 5, "view": 3}}
-        usage = ToolUsage.model_validate(data)
-
-        assert usage.tool_counts["bash"] == 5
-        assert usage.tool_counts["view"] == 3
+from bcbench.agent.copilot.tool_usage_parser import parse_tool_usage_from_log
 
 
 class TestParseToolUsageFromLog:
@@ -41,8 +26,8 @@ class TestParseToolUsageFromLog:
 
         usage = parse_tool_usage_from_log(log_file)
 
-        assert usage.tool_counts["bash"] == 2
-        assert usage.tool_counts["view"] == 1
+        assert usage["bash"] == 2
+        assert usage["view"] == 1
 
     def test_ignores_tool_definitions(self, tmp_path: Path):
         log_file = tmp_path / "test.log"
@@ -57,7 +42,7 @@ class TestParseToolUsageFromLog:
 
         usage = parse_tool_usage_from_log(log_file)
 
-        assert usage.tool_counts.get("view", 0) == 0
+        assert usage.get("view", 0) == 0
 
     def test_parses_mixed_tool_calls_and_definitions(self, tmp_path: Path):
         log_file = tmp_path / "test.log"
@@ -78,7 +63,7 @@ class TestParseToolUsageFromLog:
         usage = parse_tool_usage_from_log(log_file)
 
         # Should only count the actual tool call, not the definition
-        assert usage.tool_counts["view"] == 1
+        assert usage["view"] == 1
 
     def test_skips_non_json_lines(self, tmp_path: Path):
         log_file = tmp_path / "test.log"
@@ -91,7 +76,7 @@ Another non-JSON line
 
         usage = parse_tool_usage_from_log(log_file)
 
-        assert usage.tool_counts["bash"] == 1
+        assert usage["bash"] == 1
 
     def test_returns_empty_for_nonexistent_file(self, tmp_path: Path):
         log_file = tmp_path / "empty.log"
@@ -99,7 +84,7 @@ Another non-JSON line
 
         usage = parse_tool_usage_from_log(log_file)
 
-        assert usage.tool_counts == {}
+        assert usage == {}
 
     def test_parses_mcp_tool_names(self, tmp_path: Path):
         log_file = tmp_path / "test.log"
@@ -111,5 +96,5 @@ Another non-JSON line
 
         usage = parse_tool_usage_from_log(log_file)
 
-        assert usage.tool_counts["bc-code-intelligence-find_bc_knowledge"] == 1
-        assert usage.tool_counts["bc-code-intelligence-ask_bc_expert"] == 1
+        assert usage["bc-code-intelligence-find_bc_knowledge"] == 1
+        assert usage["bc-code-intelligence-ask_bc_expert"] == 1


### PR DESCRIPTION
We'd like a historic view of additional information (i.e. `llm_duration` and `tool_calls`)

Also replaced `ToolUsage` class with `dict[str, int]` for simplicity

closes #164 