### PR TITLE
Report `pre_patch_failed` and `post_patch_passed` metrics for Test Gen

### DIFF
--- a/.github/workflows/summarize-results.yml
+++ b/.github/workflows/summarize-results.yml
@@ -87,7 +87,7 @@ jobs:
             --metric-definitions "${{ github.workspace }}/evaluator/metrics.py" \
             --metrics "bc_bench_metrics" \
             --eval-run-name "${{ inputs.agent }} (${{ inputs.model }}) - #${{ github.run_id }}" \
-            --tags "${{ inputs.agent }},${{ inputs.model }},${{ inputs.category }}" --upload-results
+            --tags "${{ inputs.agent }},${{ inputs.model }},${{ inputs.category }}" ${{ !inputs.mock && '--upload-results' || '' }}
 
       - name: Update leaderboard in a new branch
         if: ${{ !inputs.mock }}

--- a/.github/workflows/summarize-results.yml
+++ b/.github/workflows/summarize-results.yml
@@ -83,7 +83,7 @@ jobs:
           bceval metrics calculate \
             --input-file "${{ inputs.results-dir }}/${{ github.run_id }}/${{ env.BCEVAL_RESULT_FILE }}" \
             --evaluator-definitions "${{ github.workspace }}/evaluator/scores.py" \
-            --evaluators "resolution_rate,build_rate" \
+            --evaluators "resolution_rate,build_rate${{ inputs.category == 'test-generation' && ',pre_patch_failed_rate,post_patch_passed_rate' || '' }}" \
             --metric-definitions "${{ github.workspace }}/evaluator/metrics.py" \
             --metrics "bc_bench_metrics" \
             --eval-run-name "${{ inputs.agent }} (${{ inputs.model }}) - #${{ github.run_id }}" \

--- a/.github/workflows/summarize-results.yml
+++ b/.github/workflows/summarize-results.yml
@@ -87,7 +87,7 @@ jobs:
             --metric-definitions "${{ github.workspace }}/evaluator/metrics.py" \
             --metrics "bc_bench_metrics" \
             --eval-run-name "${{ inputs.agent }} (${{ inputs.model }}) - #${{ github.run_id }}" \
-            --tags "${{ inputs.agent }},${{ inputs.model }},${{ inputs.category }}" ${{ !inputs.mock && '--upload-results' || '' }}
+            --tags "${{ inputs.agent }},${{ inputs.model }},${{ inputs.category }}" --upload-results
 
       - name: Update leaderboard in a new branch
         if: ${{ !inputs.mock }}

--- a/evaluator/scores.py
+++ b/evaluator/scores.py
@@ -9,3 +9,13 @@ class ResolutionRate:
 class BuildRate:
     def __call__(self, *, metadata: dict, **kwargs):
         return metadata.get("build", False)
+
+
+class PrePatchFailedRate:
+    def __call__(self, *, metadata: dict, **kwargs):
+        return metadata.get("pre_patch_failed", False)
+
+
+class PostPatchPassedRate:
+    def __call__(self, *, metadata: dict, **kwargs):
+        return metadata.get("post_patch_passed", False)

--- a/src/bcbench/results/result_writer.py
+++ b/src/bcbench/results/result_writer.py
@@ -1,14 +1,14 @@
 import json
 from pathlib import Path
+from typing import Any
 
 from bcbench.dataset import DatasetEntry, load_dataset_entries
 from bcbench.logger import get_logger
 from bcbench.results.base import BaseEvaluationResult
+from bcbench.results.testgeneration import TestGenerationResult
 from bcbench.types import EvaluationCategory
 
 logger = get_logger(__name__)
-
-# TODO: handle test-generation category
 
 
 def write_bceval_results(results: list[BaseEvaluationResult], out_dir: Path, run_id: str, dataset_path: Path, output_filename: str) -> None:
@@ -26,25 +26,31 @@ def write_bceval_results(results: list[BaseEvaluationResult], out_dir: Path, run
 
             input, expected = get_info_from_dataset_entry(matching_entries[0], result.category)
 
+            metadata: dict[str, Any] = {
+                "model": result.model,
+                "prompt_tokens": (result.metrics.prompt_tokens if result.metrics else None) or 0,
+                "completion_tokens": (result.metrics.completion_tokens if result.metrics else None) or 0,
+                "llm_duration": (result.metrics.llm_duration if result.metrics else None) or 0,
+                "latency": (result.metrics.execution_time if result.metrics else None) or 0,
+                "turn_count": (result.metrics.turn_count if result.metrics else None) or 0,
+                "resolved": result.resolved,
+                "build": result.build,
+                "run_id": run_id,
+                "project": result.project,
+                "tool_usage": (result.metrics.tool_usage if result.metrics and result.metrics.tool_usage else None) or 0,
+            }
+
+            if isinstance(result, TestGenerationResult):
+                metadata["pre_patch_failed"] = result.pre_patch_failed
+                metadata["post_patch_passed"] = result.post_patch_passed
+
             bceval_result = {
                 "id": result.instance_id,
                 "input": input,
                 "expected": expected,
                 "output": result.generated_patch,
                 "context": "",
-                "metadata": {
-                    "model": result.model,
-                    "prompt_tokens": (result.metrics.prompt_tokens if result.metrics else None) or 0,
-                    "completion_tokens": (result.metrics.completion_tokens if result.metrics else None) or 0,
-                    "llm_duration": (result.metrics.llm_duration if result.metrics else None) or 0,
-                    "latency": (result.metrics.execution_time if result.metrics else None) or 0,
-                    "turn_count": (result.metrics.turn_count if result.metrics else None) or 0,
-                    "resolved": result.resolved,
-                    "build": result.build,
-                    "run_id": run_id,
-                    "project": result.project,
-                    "tool_usage": (result.metrics.tool_usage if result.metrics and result.metrics.tool_usage else None) or 0,
-                },
+                "metadata": metadata,
                 "tags": [],
             }
             f.write(json.dumps(bceval_result) + "\n")

--- a/src/bcbench/results/testgeneration.py
+++ b/src/bcbench/results/testgeneration.py
@@ -9,8 +9,8 @@ class TestGenerationResult(BaseEvaluationResult):
     Tracks whether generated tests failed before patch and passed after patch.
     """
 
-    pre_patch_failed: bool | None = None
-    post_patch_passed: bool | None = None
+    pre_patch_failed: bool = False
+    post_patch_passed: bool = False
 
     @classmethod
     def create_no_tests_extracted(cls: type[T], context: "EvaluationContext", generated_patch: str, error_message: str) -> T:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,7 +35,7 @@ PROBLEM_STATEMENT_CONTENT = "# Test Problem Statement\n\nThis is a test task."
 def create_test_entry(codeunit_id: int = 100, function_names: set[str] | None = None) -> TestEntry:
     if function_names is None:
         function_names = {"TestFunction"}
-    return TestEntry(codeunitID=codeunit_id, functionName=function_names)
+    return TestEntry(codeunitID=codeunit_id, functionName=frozenset(function_names))
 
 
 def create_dataset_entry(
@@ -132,8 +132,8 @@ def create_testgen_result(
     generated_patch: str = "diff --git a/test.al b/test.al\n+test",
     error_message: str | None = None,
     metrics: AgentMetrics | None = None,
-    pre_patch_failed: bool | None = None,
-    post_patch_passed: bool | None = None,
+    pre_patch_failed: bool = False,
+    post_patch_passed: bool = False,
 ) -> TestGenerationResult:
     return TestGenerationResult(
         instance_id=instance_id,


### PR DESCRIPTION
In addition to `% resolved`, including `pre_patch_failed` and `post_patch_passed` for `Test Generation` category 

Not displaying it on the summary for simplicity, upload detailed metrics to Braintrust