### PR TITLE
fix al mcp compile in BC-Bench

### DIFF
--- a/.github/workflows/claude-evaluation.yml
+++ b/.github/workflows/claude-evaluation.yml
@@ -105,7 +105,7 @@ jobs:
         run: npm install -g @anthropic-ai/claude-code@2.1.69
 
       - name: Run Claude Code for entry ${{ matrix.entry }}
-        timeout-minutes: 90
+        timeout-minutes: 120
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |

--- a/.github/workflows/copilot-evaluation.yml
+++ b/.github/workflows/copilot-evaluation.yml
@@ -119,7 +119,7 @@ jobs:
           echo "pat_index=$patIndex" >> $env:GITHUB_OUTPUT
 
       - name: Run GitHub Copilot CLI for entry ${{ matrix.entry }}
-        timeout-minutes: 90
+        timeout-minutes: 120
         env:
           GH_TOKEN: ${{ steps.select-pat.outputs.pat_index == '0' && secrets.COPILOT_PAT || (steps.select-pat.outputs.pat_index == '1' && secrets.COPILOT_PAT2 || secrets.COPILOT_PAT3) }}
         run: |

--- a/src/bcbench/agent/shared/config.yaml
+++ b/src/bcbench/agent/shared/config.yaml
@@ -84,6 +84,7 @@ agents:
 mcp:
   servers:
     # AL MCP server (toggled via --al-mcp CLI flag), https://www.nuget.org/packages/Microsoft.Dynamics.BusinessCentral.Development.Tools
+    # NOTE: --assemblyprobingpaths are injected programmatically by mcp.py (requires runtime detection)
     - name: "altool"
       type: "stdio"
       command: "al"
@@ -92,8 +93,8 @@ mcp:
           "launchmcpserver",
           "--transport",
           "stdio",
-          "--assemblyprobingpaths",
-          "{{assembly_probing_path}}",
+          "--packagecachepath",
+          "{{package_cache_path}}",
         ]
 
     # - name: "mslearn"

--- a/src/bcbench/agent/shared/config.yaml
+++ b/src/bcbench/agent/shared/config.yaml
@@ -92,8 +92,6 @@ mcp:
           "launchmcpserver",
           "--transport",
           "stdio",
-          "--packagecachepath",
-          "{{package_cache_path}}",
           "--assemblyprobingpaths",
           "{{assembly_probing_path}}",
         ]

--- a/src/bcbench/agent/shared/config.yaml
+++ b/src/bcbench/agent/shared/config.yaml
@@ -92,6 +92,8 @@ mcp:
           "launchmcpserver",
           "--transport",
           "stdio",
+          "--packagecachepath",
+          "{{package_cache_path}}",
           "--assemblyprobingpaths",
           "{{assembly_probing_path}}",
         ]

--- a/src/bcbench/agent/shared/mcp.py
+++ b/src/bcbench/agent/shared/mcp.py
@@ -120,6 +120,42 @@ def _set_runtime_version(project_paths: list[str]) -> None:
         logger.info(f"Set runtime={runtime} in {app_json_path} (platform {platform})")
 
 
+def _remove_conflicting_symbols(symbols_folder: Path, project_paths: list[str]) -> None:
+    """Remove symbol packages that conflict with loaded source projects.
+
+    When both an app and its test are loaded as source projects, the symbols folder
+    may contain a newer .app version of the app with different method signatures.
+    The compiler resolves the test's dependency against the .app symbol instead of
+    the source project, causing false errors. Removing conflicting symbols forces
+    resolution from the loaded source.
+    """
+    if not symbols_folder.is_dir():
+        return
+
+    loaded_prefixes: set[str] = set()
+    for project_path in project_paths:
+        app_json_path = Path(project_path) / "app.json"
+        if not app_json_path.is_file():
+            continue
+        try:
+            app_json = json.loads(app_json_path.read_text(encoding="utf-8-sig"))
+            publisher = app_json.get("publisher", "")
+            name = app_json.get("name", "")
+            if publisher and name:
+                loaded_prefixes.add(f"{publisher}_{name}_")
+        except (json.JSONDecodeError, OSError):
+            continue
+
+    removed = 0
+    for app_file in symbols_folder.glob("*.app"):
+        if any(app_file.name.startswith(prefix) for prefix in loaded_prefixes):
+            app_file.unlink()
+            removed += 1
+
+    if removed:
+        logger.info(f"Removed {removed} conflicting symbol(s) from {symbols_folder}")
+
+
 def _build_server_entry(server: dict[str, Any], template_context: dict[str, Any]) -> tuple[str, dict[str, Any]]:
     server_type: str = server["type"]
     server_name: str = server["name"]
@@ -147,41 +183,38 @@ def _build_server_entry(server: dict[str, Any], template_context: dict[str, Any]
 def build_mcp_config(config: dict[str, Any], entry: DatasetEntry, repo_path: Path, al_mcp: bool = False, container_name: str = "bcbench") -> tuple[str | None, list[str] | None]:
     mcp_servers: list[dict[str, Any]] = config.get("mcp", {}).get("servers", [])
 
-    if al_mcp:  # insert project paths right after "launchmcpserver" (positional args must precede options)
-        al_server = next(s for s in mcp_servers if s["name"] == "altool")
-        insert_idx = al_server["args"].index("launchmcpserver") + 1
-        project_paths = [str(repo_path / p) for p in entry.project_paths]
-        al_server["args"][insert_idx:insert_idx] = project_paths
-        logger.info("AL MCP server enabled")
-    else:
+    if not al_mcp:
         mcp_servers = list(filter(lambda s: s.get("name") != "altool", mcp_servers))
 
     if not mcp_servers:
         return None, None
 
-    compiler_folder = Path(r"C:\ProgramData\BcContainerHelper\compiler") / container_name
-    symbols_path = str(compiler_folder / "symbols")
-    assembly_probing_paths = _build_assembly_probing_paths(compiler_folder)
+    template_context: dict[str, str | Path] = {"repo_path": repo_path}
 
     if al_mcp:
+        compiler_folder = Path(r"C:\ProgramData\BcContainerHelper\compiler") / container_name
+        template_context["package_cache_path"] = str(compiler_folder / "symbols")
+
         al_server = next(s for s in mcp_servers if s["name"] == "altool")
         project_paths = [str(repo_path / p) for p in entry.project_paths]
 
-        # Set runtime version before MCP loads the projects
+        # Insert project paths right after "launchmcpserver" (positional args must precede options)
+        insert_idx: int = al_server["args"].index("launchmcpserver") + 1
+        al_server["args"][insert_idx:insert_idx] = project_paths
+
         _set_runtime_version(project_paths)
+        _remove_conflicting_symbols(compiler_folder / "symbols", project_paths)
 
         # Each path must be a separate arg (System.CommandLine expects space-separated values)
+        assembly_probing_paths = _build_assembly_probing_paths(compiler_folder)
         if assembly_probing_paths:
             al_server["args"].extend(["--assemblyprobingpaths", *assembly_probing_paths])
             logger.info(f"Assembly probing paths: {assembly_probing_paths}")
 
-    template_context: dict[str, str | Path] = {"repo_path": repo_path, "package_cache_path": symbols_path}
     mcp_server_names: list[str] = [server["name"] for server in mcp_servers]
     mcp_config = {"mcpServers": dict(map(lambda s: _build_server_entry(s, template_context), mcp_servers))}
 
     logger.info(f"Using MCP servers: {mcp_server_names}")
-    if not (compiler_folder / "dlls").exists():
-        logger.warning(f"Compiler folder not found: {compiler_folder}. Run New-BCCompilerFolderSync to create it.")
     logger.debug(f"MCP configuration: {json.dumps(mcp_config, indent=2)}")
 
     return json.dumps(mcp_config, separators=(",", ":")), mcp_server_names

--- a/src/bcbench/agent/shared/mcp.py
+++ b/src/bcbench/agent/shared/mcp.py
@@ -40,20 +40,20 @@ def _detect_dotnet_runtime_version() -> Version | None:
     return max(versions) if versions else None
 
 
-def _build_assembly_probing_paths(compiler_folder: Path) -> str:
-    """Build semicolon-separated assembly probing paths for the AL compiler.
+def _build_assembly_probing_paths(compiler_folder: Path) -> list[str]:
+    """Build list of assembly probing paths for the AL compiler.
 
     The AL compiler recursively searches subdirectories (AssemblyLocatorBase.cs uses
-    SearchOption.AllDirectories), so ``dlls`` covers Service, OpenXML, Mock Assemblies, etc.
-    System .NET runtime paths must be added separately since they live outside the
-    compiler folder and are needed for DotNet interop (System.Net.Http, System.Text.Json, etc.).
+    SearchOption.AllDirectories), so a single ``dlls`` entry covers Service, OpenXML,
+    Mock Assemblies, etc. System .NET runtime paths must be added separately since
+    they live outside the compiler folder.
 
-    AL MCP's --assemblyprobingpaths expects semicolons as separators
-    (see ALMcpOptions.AddPaths in BC-DeveloperExperience).
+    Each path must be a separate CLI argument (System.CommandLine with
+    AllowMultipleArgumentsPerToken expects space-separated values, NOT semicolons).
     """
     paths: list[str] = []
-
     dlls_path = compiler_folder / "dlls"
+
     if dlls_path.is_dir():
         paths.append(str(dlls_path))
 
@@ -70,41 +70,7 @@ def _build_assembly_probing_paths(compiler_folder: Path) -> str:
         else:
             logger.warning("No compatible .NET runtime found. DotNet interop types may not resolve.")
 
-    return ";".join(paths)
-
-
-def _setup_package_cache(compiler_folder: Path, project_paths: list[str]) -> None:
-    """Copy symbol packages from the compiler folder into each project's .alpackages.
-
-    Mirrors BCContainerHelper's Compile-AppWithBcCompilerFolder.ps1 (lines 175-206),
-    which copies full symbol .app files into .alpackages before compiling. The AL MCP
-    workspace loads packages from .alpackages at startup; --packagecachepath doesn't
-    reliably override this.
-    """
-    symbols_folder = compiler_folder / "symbols"
-    if not symbols_folder.is_dir():
-        logger.warning(f"Symbols folder not found: {symbols_folder}")
-        return
-
-    symbol_apps = list(symbols_folder.glob("*.app"))
-    if not symbol_apps:
-        logger.warning(f"No symbol packages found in {symbols_folder}")
-        return
-
-    for project_path in project_paths:
-        alpackages = Path(project_path) / ".alpackages"
-        try:
-            alpackages.mkdir(parents=True, exist_ok=True)
-        except OSError:
-            logger.warning(f"Cannot create .alpackages at {alpackages}")
-            continue
-
-        for app in symbol_apps:
-            dest = alpackages / app.name
-            if not dest.exists():
-                shutil.copy2(app, dest)
-
-        logger.info(f"Copied {len(symbol_apps)} symbol packages to {alpackages}")
+    return paths
 
 
 def _build_server_entry(server: dict[str, Any], template_context: dict[str, Any]) -> tuple[str, dict[str, Any]]:
@@ -147,23 +113,23 @@ def build_mcp_config(config: dict[str, Any], entry: DatasetEntry, repo_path: Pat
         return None, None
 
     compiler_folder = Path(r"C:\ProgramData\BcContainerHelper\compiler") / container_name
+    symbols_path = str(compiler_folder / "symbols")
     assembly_probing_paths = _build_assembly_probing_paths(compiler_folder)
 
     if al_mcp:
-        project_paths = [str(repo_path / p) for p in entry.project_paths]
-        _setup_package_cache(compiler_folder, project_paths)
+        al_server = next(s for s in mcp_servers if s["name"] == "altool")
 
-    template_context: dict[str, str | Path] = {
-        "repo_path": repo_path,
-        "assembly_probing_path": assembly_probing_paths,
-    }
+        # Each path must be a separate arg (System.CommandLine expects space-separated values)
+        if assembly_probing_paths:
+            al_server["args"].extend(["--assemblyprobingpaths", *assembly_probing_paths])
+            logger.info(f"Assembly probing paths: {assembly_probing_paths}")
+
+    template_context: dict[str, str | Path] = {"repo_path": repo_path, "package_cache_path": symbols_path}
     mcp_server_names: list[str] = [server["name"] for server in mcp_servers]
     mcp_config = {"mcpServers": dict(map(lambda s: _build_server_entry(s, template_context), mcp_servers))}
 
     logger.info(f"Using MCP servers: {mcp_server_names}")
-    if (compiler_folder / "dlls").exists():
-        logger.info(f"Assembly probing paths: {assembly_probing_paths}")
-    else:
+    if not (compiler_folder / "dlls").exists():
         logger.warning(f"Compiler folder not found: {compiler_folder}. Run New-BCCompilerFolderSync to create it.")
     logger.debug(f"MCP configuration: {json.dumps(mcp_config, indent=2)}")
 

--- a/src/bcbench/agent/shared/mcp.py
+++ b/src/bcbench/agent/shared/mcp.py
@@ -48,20 +48,21 @@ def _build_assembly_probing_paths(compiler_folder: Path) -> list[str]:
     Mock Assemblies, etc. System .NET runtime paths must be added separately since
     they live outside the compiler folder.
 
+    Path order matters: .NET runtime paths must come BEFORE dlls to avoid stale
+    type-forwarding stubs (e.g. XrmV91's 5.0.0.0 DLLs) shadowing the real types.
+    This matches BCContainerHelper's ordering (OpenXML → dotnet → Service).
+
     Each path must be a separate CLI argument (System.CommandLine with
     AllowMultipleArgumentsPerToken expects space-separated values, NOT semicolons).
     """
     paths: list[str] = []
     dlls_path = compiler_folder / "dlls"
 
-    if dlls_path.is_dir():
-        paths.append(str(dlls_path))
-
-    # .NET runtime: needed for BaseApp's DotNet interop types.
-    # If New-BcCompilerFolder bundled a shared\ folder (dotnet < minimum), it's already
-    # covered by the recursive dlls\ search above. Otherwise, add system dotnet paths.
+    # .NET runtime paths first — avoids stale type-forwarding stubs in dlls\ subfolders
     shared_folder = dlls_path / "shared"
-    if not shared_folder.is_dir():
+    if shared_folder.is_dir():
+        paths.append(str(shared_folder))
+    else:
         dotnet_version = _detect_dotnet_runtime_version()
         if dotnet_version:
             paths.append(str(_DOTNET_SHARED / "Microsoft.NETCore.App" / str(dotnet_version)))
@@ -69,6 +70,10 @@ def _build_assembly_probing_paths(compiler_folder: Path) -> list[str]:
             logger.info(f"Using system .NET runtime {dotnet_version} for assembly probing")
         else:
             logger.warning("No compatible .NET runtime found. DotNet interop types may not resolve.")
+
+    # dlls\ after dotnet — recursively covers Service, OpenXML, Mock Assemblies, etc.
+    if dlls_path.is_dir():
+        paths.append(str(dlls_path))
 
     return paths
 

--- a/src/bcbench/agent/shared/mcp.py
+++ b/src/bcbench/agent/shared/mcp.py
@@ -17,6 +17,11 @@ logger = get_logger(__name__)
 _EXCLUDED_DOTNET_MAJORS = {9, 10}
 _DOTNET_SHARED = Path(r"C:\Program Files\dotnet\shared")
 
+# Offset from BC platform major version to AL runtime version.
+# E.g. platform 25.0 (BC 2024w2) → runtime 14.0, platform 27.0 → runtime 16.0
+# See: BC-DeveloperExperience RuntimeVersion.cs
+_PLATFORM_TO_RUNTIME_OFFSET = 11
+
 
 def _detect_dotnet_runtime_version() -> Version | None:
     dotnet_shared = _DOTNET_SHARED
@@ -78,6 +83,43 @@ def _build_assembly_probing_paths(compiler_folder: Path) -> list[str]:
     return paths
 
 
+def _set_runtime_version(project_paths: list[str]) -> None:
+    """Set the AL runtime version in each project's app.json based on platform version.
+
+    The AL MCP compiler (altool 17.0+) defaults to the latest runtime when "runtime"
+    is not set in app.json, enabling newer validation rules that reject older code.
+    Setting the runtime to match the platform version makes the compiler behave
+    like the version that originally compiled the code.
+    """
+    for project_path in project_paths:
+        app_json_path = Path(project_path) / "app.json"
+        if not app_json_path.is_file():
+            continue
+
+        try:
+            app_json = json.loads(app_json_path.read_text(encoding="utf-8-sig"))
+        except (json.JSONDecodeError, OSError):
+            continue
+
+        if app_json.get("runtime"):
+            continue
+
+        platform = app_json.get("platform", "")
+        try:
+            platform_major = int(platform.split(".")[0])
+        except (ValueError, IndexError):
+            continue
+
+        runtime_major = platform_major - _PLATFORM_TO_RUNTIME_OFFSET
+        if runtime_major < 1:
+            continue
+
+        runtime = f"{runtime_major}.0"
+        app_json["runtime"] = runtime
+        app_json_path.write_text(json.dumps(app_json, indent=2, ensure_ascii=False), encoding="utf-8")
+        logger.info(f"Set runtime={runtime} in {app_json_path} (platform {platform})")
+
+
 def _build_server_entry(server: dict[str, Any], template_context: dict[str, Any]) -> tuple[str, dict[str, Any]]:
     server_type: str = server["type"]
     server_name: str = server["name"]
@@ -123,6 +165,10 @@ def build_mcp_config(config: dict[str, Any], entry: DatasetEntry, repo_path: Pat
 
     if al_mcp:
         al_server = next(s for s in mcp_servers if s["name"] == "altool")
+        project_paths = [str(repo_path / p) for p in entry.project_paths]
+
+        # Set runtime version before MCP loads the projects
+        _set_runtime_version(project_paths)
 
         # Each path must be a separate arg (System.CommandLine expects space-separated values)
         if assembly_probing_paths:

--- a/src/bcbench/agent/shared/mcp.py
+++ b/src/bcbench/agent/shared/mcp.py
@@ -73,6 +73,40 @@ def _build_assembly_probing_paths(compiler_folder: Path) -> str:
     return ";".join(paths)
 
 
+def _setup_package_cache(compiler_folder: Path, project_paths: list[str]) -> None:
+    """Copy symbol packages from the compiler folder into each project's .alpackages.
+
+    Mirrors BCContainerHelper's Compile-AppWithBcCompilerFolder.ps1 (lines 175-206),
+    which copies full symbol .app files into .alpackages before compiling. The AL MCP
+    workspace loads packages from .alpackages at startup; --packagecachepath doesn't
+    reliably override this.
+    """
+    symbols_folder = compiler_folder / "symbols"
+    if not symbols_folder.is_dir():
+        logger.warning(f"Symbols folder not found: {symbols_folder}")
+        return
+
+    symbol_apps = list(symbols_folder.glob("*.app"))
+    if not symbol_apps:
+        logger.warning(f"No symbol packages found in {symbols_folder}")
+        return
+
+    for project_path in project_paths:
+        alpackages = Path(project_path) / ".alpackages"
+        try:
+            alpackages.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            logger.warning(f"Cannot create .alpackages at {alpackages}")
+            continue
+
+        for app in symbol_apps:
+            dest = alpackages / app.name
+            if not dest.exists():
+                shutil.copy2(app, dest)
+
+        logger.info(f"Copied {len(symbol_apps)} symbol packages to {alpackages}")
+
+
 def _build_server_entry(server: dict[str, Any], template_context: dict[str, Any]) -> tuple[str, dict[str, Any]]:
     server_type: str = server["type"]
     server_name: str = server["name"]
@@ -114,11 +148,14 @@ def build_mcp_config(config: dict[str, Any], entry: DatasetEntry, repo_path: Pat
 
     compiler_folder = Path(r"C:\ProgramData\BcContainerHelper\compiler") / container_name
     assembly_probing_paths = _build_assembly_probing_paths(compiler_folder)
-    package_cache_path = str(compiler_folder / "symbols")
+
+    if al_mcp:
+        project_paths = [str(repo_path / p) for p in entry.project_paths]
+        _setup_package_cache(compiler_folder, project_paths)
+
     template_context: dict[str, str | Path] = {
         "repo_path": repo_path,
         "assembly_probing_path": assembly_probing_paths,
-        "package_cache_path": package_cache_path,
     }
     mcp_server_names: list[str] = [server["name"] for server in mcp_servers]
     mcp_config = {"mcpServers": dict(map(lambda s: _build_server_entry(s, template_context), mcp_servers))}

--- a/src/bcbench/agent/shared/mcp.py
+++ b/src/bcbench/agent/shared/mcp.py
@@ -120,42 +120,6 @@ def _set_runtime_version(project_paths: list[str]) -> None:
         logger.info(f"Set runtime={runtime} in {app_json_path} (platform {platform})")
 
 
-def _remove_conflicting_symbols(symbols_folder: Path, project_paths: list[str]) -> None:
-    """Remove symbol packages that conflict with loaded source projects.
-
-    When both an app and its test are loaded as source projects, the symbols folder
-    may contain a newer .app version of the app with different method signatures.
-    The compiler resolves the test's dependency against the .app symbol instead of
-    the source project, causing false errors. Removing conflicting symbols forces
-    resolution from the loaded source.
-    """
-    if not symbols_folder.is_dir():
-        return
-
-    loaded_prefixes: set[str] = set()
-    for project_path in project_paths:
-        app_json_path = Path(project_path) / "app.json"
-        if not app_json_path.is_file():
-            continue
-        try:
-            app_json = json.loads(app_json_path.read_text(encoding="utf-8-sig"))
-            publisher = app_json.get("publisher", "")
-            name = app_json.get("name", "")
-            if publisher and name:
-                loaded_prefixes.add(f"{publisher}_{name}_")
-        except (json.JSONDecodeError, OSError):
-            continue
-
-    removed = 0
-    for app_file in symbols_folder.glob("*.app"):
-        if any(app_file.name.startswith(prefix) for prefix in loaded_prefixes):
-            app_file.unlink()
-            removed += 1
-
-    if removed:
-        logger.info(f"Removed {removed} conflicting symbol(s) from {symbols_folder}")
-
-
 def _build_server_entry(server: dict[str, Any], template_context: dict[str, Any]) -> tuple[str, dict[str, Any]]:
     server_type: str = server["type"]
     server_name: str = server["name"]
@@ -203,7 +167,6 @@ def build_mcp_config(config: dict[str, Any], entry: DatasetEntry, repo_path: Pat
         al_server["args"][insert_idx:insert_idx] = project_paths
 
         _set_runtime_version(project_paths)
-        _remove_conflicting_symbols(compiler_folder / "symbols", project_paths)
 
         # Each path must be a separate arg (System.CommandLine expects space-separated values)
         assembly_probing_paths = _build_assembly_probing_paths(compiler_folder)

--- a/src/bcbench/agent/shared/mcp.py
+++ b/src/bcbench/agent/shared/mcp.py
@@ -4,12 +4,73 @@ from pathlib import Path
 from typing import Any
 
 from jinja2 import Template
+from packaging.version import Version
 
 from bcbench.dataset import DatasetEntry
 from bcbench.exceptions import AgentError
 from bcbench.logger import get_logger
 
 logger = get_logger(__name__)
+
+# .NET major versions excluded from runtime detection (unstable/preview)
+# See: navcontainerhelper/InitializeModule.ps1 line 62
+_EXCLUDED_DOTNET_MAJORS = {9, 10}
+_DOTNET_SHARED = Path(r"C:\Program Files\dotnet\shared")
+
+
+def _detect_dotnet_runtime_version() -> Version | None:
+    dotnet_shared = _DOTNET_SHARED
+    netcore_folder = dotnet_shared / "Microsoft.NETCore.App"
+    aspnetcore_folder = dotnet_shared / "Microsoft.AspNetCore.App"
+
+    if not netcore_folder.is_dir():
+        return None
+
+    versions: list[Version] = []
+    for entry in netcore_folder.iterdir():
+        if not entry.is_dir() or not (aspnetcore_folder / entry.name).is_dir():
+            continue
+        try:
+            v = Version(entry.name)
+            if v.major not in _EXCLUDED_DOTNET_MAJORS:
+                versions.append(v)
+        except Exception:
+            continue
+
+    return max(versions) if versions else None
+
+
+def _build_assembly_probing_paths(compiler_folder: Path) -> str:
+    """Build semicolon-separated assembly probing paths for the AL compiler.
+
+    The AL compiler recursively searches subdirectories (AssemblyLocatorBase.cs uses
+    SearchOption.AllDirectories), so ``dlls`` covers Service, OpenXML, Mock Assemblies, etc.
+    System .NET runtime paths must be added separately since they live outside the
+    compiler folder and are needed for DotNet interop (System.Net.Http, System.Text.Json, etc.).
+
+    AL MCP's --assemblyprobingpaths expects semicolons as separators
+    (see ALMcpOptions.AddPaths in BC-DeveloperExperience).
+    """
+    paths: list[str] = []
+
+    dlls_path = compiler_folder / "dlls"
+    if dlls_path.is_dir():
+        paths.append(str(dlls_path))
+
+    # .NET runtime: needed for BaseApp's DotNet interop types.
+    # If New-BcCompilerFolder bundled a shared\ folder (dotnet < minimum), it's already
+    # covered by the recursive dlls\ search above. Otherwise, add system dotnet paths.
+    shared_folder = dlls_path / "shared"
+    if not shared_folder.is_dir():
+        dotnet_version = _detect_dotnet_runtime_version()
+        if dotnet_version:
+            paths.append(str(_DOTNET_SHARED / "Microsoft.NETCore.App" / str(dotnet_version)))
+            paths.append(str(_DOTNET_SHARED / "Microsoft.AspNetCore.App" / str(dotnet_version)))
+            logger.info(f"Using system .NET runtime {dotnet_version} for assembly probing")
+        else:
+            logger.warning("No compatible .NET runtime found. DotNet interop types may not resolve.")
+
+    return ";".join(paths)
 
 
 def _build_server_entry(server: dict[str, Any], template_context: dict[str, Any]) -> tuple[str, dict[str, Any]]:
@@ -51,16 +112,22 @@ def build_mcp_config(config: dict[str, Any], entry: DatasetEntry, repo_path: Pat
     if not mcp_servers:
         return None, None
 
-    assembly_path = Path(r"C:\ProgramData\BcContainerHelper\compiler") / container_name / "dlls"
-    template_context: dict[str, str | Path] = {"repo_path": repo_path, "assembly_probing_path": str(assembly_path)}
+    compiler_folder = Path(r"C:\ProgramData\BcContainerHelper\compiler") / container_name
+    assembly_probing_paths = _build_assembly_probing_paths(compiler_folder)
+    package_cache_path = str(compiler_folder / "symbols")
+    template_context: dict[str, str | Path] = {
+        "repo_path": repo_path,
+        "assembly_probing_path": assembly_probing_paths,
+        "package_cache_path": package_cache_path,
+    }
     mcp_server_names: list[str] = [server["name"] for server in mcp_servers]
     mcp_config = {"mcpServers": dict(map(lambda s: _build_server_entry(s, template_context), mcp_servers))}
 
     logger.info(f"Using MCP servers: {mcp_server_names}")
-    if assembly_path.exists():
-        logger.info(f"Assembly probing path: {assembly_path}")
+    if (compiler_folder / "dlls").exists():
+        logger.info(f"Assembly probing paths: {assembly_probing_paths}")
     else:
-        logger.warning(f"Assembly probing path not found: {assembly_path}. Run New-BCCompilerFolderSync to create it.")
+        logger.warning(f"Compiler folder not found: {compiler_folder}. Run New-BCCompilerFolderSync to create it.")
     logger.debug(f"MCP configuration: {json.dumps(mcp_config, indent=2)}")
 
     return json.dumps(mcp_config, separators=(",", ":")), mcp_server_names

--- a/src/bcbench/config.py
+++ b/src/bcbench/config.py
@@ -78,7 +78,7 @@ class TimeoutConfig:
             build_baseapp=30 * 60,  # 30 minutes for BaseApp compilation
             build_app=5 * 60,  # 5 minutes for application compilation
             test_execution=3 * 60,  # 3 minutes for test execution
-            agent_execution=30 * 60,  # 30 minutes for coding agent (claude and copilot) execution
+            agent_execution=60 * 60,  # 60 minutes for coding agent (claude and copilot) execution
         )
 
 

--- a/src/bcbench/operations/setup_operations.py
+++ b/src/bcbench/operations/setup_operations.py
@@ -7,7 +7,7 @@ import yaml
 from bcbench.config import get_config
 from bcbench.dataset import DatasetEntry
 from bcbench.logger import get_logger
-from bcbench.operations.git_operations import apply_patch, checkout_commit, clean_repo, commit_changes
+from bcbench.operations.git_operations import apply_patch, checkout_commit, clean_repo
 from bcbench.operations.instruction_operations import copy_problem_statement_folder
 from bcbench.types import EvaluationCategory
 
@@ -37,39 +37,6 @@ def _get_test_generation_input_mode() -> str:
     return input_mode
 
 
-def _is_under_symlink(path: Path, root: Path) -> bool:
-    current = path
-    while current != root and current != current.parent:
-        if current.is_symlink():
-            return True
-        current = current.parent
-    return False
-
-
-def _remove_table_scope_onprem(repo_path: Path) -> None:
-    """Remove 'Scope = OnPrem;' from the top 50 lines of all *.Table.al files under the repo."""
-    table_files = [f for f in repo_path.rglob("*.Table.al") if not _is_under_symlink(f, repo_path)]
-    if not table_files:
-        return
-
-    logger.info(f"Removing 'Scope = OnPrem;' from {len(table_files)} Table.al files")
-    modified_count = 0
-    for table_file in table_files:
-        try:
-            lines = table_file.read_text(encoding="utf-8-sig").splitlines(keepends=True)
-        except (UnicodeDecodeError, OSError):
-            continue
-        head = lines[:50]
-        target_index = next((i for i, line in enumerate(head) if line.strip() == "Scope = OnPrem;"), None)
-        if target_index is not None:
-            del lines[target_index]
-            table_file.write_text("".join(lines), encoding="utf-8")
-            modified_count += 1
-
-    if modified_count:
-        logger.info(f"Removed 'Scope = OnPrem;' from {modified_count} Table.al files")
-
-
 def setup_repo_prebuild(entry: DatasetEntry, repo_path: Path) -> None:
     """Setup repository before building - clean and checkout base commit.
 
@@ -82,8 +49,6 @@ def setup_repo_prebuild(entry: DatasetEntry, repo_path: Path) -> None:
     """
     clean_repo(repo_path)
     checkout_commit(repo_path, entry.base_commit)
-    _remove_table_scope_onprem(repo_path)
-    commit_changes(repo_path, "Remove Scope = OnPrem from Table.al files")
 
 
 def setup_repo_postbuild(entry: DatasetEntry, repo_path: Path, category: EvaluationCategory) -> None:

--- a/tests/test_mcp_config.py
+++ b/tests/test_mcp_config.py
@@ -98,6 +98,14 @@ class TestBuildAssemblyProbingPaths:
 
         assert str(tmp_path / "dlls") in result
 
+    def test_dlls_after_dotnet(self, tmp_path):
+        (tmp_path / "dlls").mkdir()
+
+        result = _build_assembly_probing_paths(tmp_path)
+
+        dlls_idx = next(i for i, p in enumerate(result) if "dlls" in p)
+        assert dlls_idx == len(result) - 1
+
     def test_shared_folder_suppresses_system_dotnet(self, tmp_path):
         dlls = tmp_path / "dlls"
         dlls.mkdir()

--- a/tests/test_mcp_config.py
+++ b/tests/test_mcp_config.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from bcbench.agent.shared.mcp import build_mcp_config
+from bcbench.agent.shared.mcp import _build_assembly_probing_paths, build_mcp_config
 from tests.conftest import create_dataset_entry
 
 
@@ -84,3 +84,33 @@ class TestAlMcpProjectPaths:
         assert names is not None
 
         assert set(names) == {"altool", "mslearn"}
+
+
+class TestBuildAssemblyProbingPaths:
+    def test_nonexistent_compiler_folder_has_no_dlls_paths(self, tmp_path):
+        result = _build_assembly_probing_paths(tmp_path / "nonexistent")
+        assert "dlls" not in result
+
+    def test_includes_dlls_folder(self, tmp_path):
+        (tmp_path / "dlls").mkdir()
+
+        result = _build_assembly_probing_paths(tmp_path)
+        paths = result.split(";")
+
+        assert str(tmp_path / "dlls") in paths
+
+    def test_shared_folder_suppresses_system_dotnet(self, tmp_path):
+        dlls = tmp_path / "dlls"
+        dlls.mkdir()
+        (dlls / "shared").mkdir()
+
+        result = _build_assembly_probing_paths(tmp_path)
+
+        assert "Program Files" not in result
+
+    def test_semicolon_separator(self, tmp_path):
+        (tmp_path / "dlls").mkdir()
+
+        result = _build_assembly_probing_paths(tmp_path)
+
+        assert "," not in result

--- a/tests/test_mcp_config.py
+++ b/tests/test_mcp_config.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from bcbench.agent.shared.mcp import _build_assembly_probing_paths, build_mcp_config
+from bcbench.agent.shared.mcp import _build_assembly_probing_paths, _set_runtime_version, build_mcp_config
 from tests.conftest import create_dataset_entry
 
 
@@ -121,3 +121,35 @@ class TestBuildAssemblyProbingPaths:
         result = _build_assembly_probing_paths(tmp_path)
 
         assert isinstance(result, list)
+
+
+class TestSetRuntimeVersion:
+    def test_sets_runtime_from_platform(self, tmp_path):
+        app_json = {"platform": "25.0.0.0", "version": "25.0.0.0"}
+        (tmp_path / "app.json").write_text(json.dumps(app_json))
+
+        _set_runtime_version([str(tmp_path)])
+
+        result = json.loads((tmp_path / "app.json").read_text())
+        assert result["runtime"] == "14.0"
+
+    def test_skips_when_runtime_already_set(self, tmp_path):
+        app_json = {"platform": "25.0.0.0", "runtime": "12.0"}
+        (tmp_path / "app.json").write_text(json.dumps(app_json))
+
+        _set_runtime_version([str(tmp_path)])
+
+        result = json.loads((tmp_path / "app.json").read_text())
+        assert result["runtime"] == "12.0"
+
+    def test_platform_27_maps_to_runtime_16(self, tmp_path):
+        app_json = {"platform": "27.0.0.0"}
+        (tmp_path / "app.json").write_text(json.dumps(app_json))
+
+        _set_runtime_version([str(tmp_path)])
+
+        result = json.loads((tmp_path / "app.json").read_text())
+        assert result["runtime"] == "16.0"
+
+    def test_skips_missing_app_json(self, tmp_path):
+        _set_runtime_version([str(tmp_path)])  # should not raise

--- a/tests/test_mcp_config.py
+++ b/tests/test_mcp_config.py
@@ -87,17 +87,16 @@ class TestAlMcpProjectPaths:
 
 
 class TestBuildAssemblyProbingPaths:
-    def test_nonexistent_compiler_folder_has_no_dlls_paths(self, tmp_path):
+    def test_nonexistent_compiler_folder_has_no_dlls(self, tmp_path):
         result = _build_assembly_probing_paths(tmp_path / "nonexistent")
-        assert "dlls" not in result
+        assert not any("dlls" in p for p in result)
 
     def test_includes_dlls_folder(self, tmp_path):
         (tmp_path / "dlls").mkdir()
 
         result = _build_assembly_probing_paths(tmp_path)
-        paths = result.split(";")
 
-        assert str(tmp_path / "dlls") in paths
+        assert str(tmp_path / "dlls") in result
 
     def test_shared_folder_suppresses_system_dotnet(self, tmp_path):
         dlls = tmp_path / "dlls"
@@ -106,11 +105,11 @@ class TestBuildAssemblyProbingPaths:
 
         result = _build_assembly_probing_paths(tmp_path)
 
-        assert "Program Files" not in result
+        assert not any("Program Files" in p for p in result)
 
-    def test_semicolon_separator(self, tmp_path):
+    def test_returns_list(self, tmp_path):
         (tmp_path / "dlls").mkdir()
 
         result = _build_assembly_probing_paths(tmp_path)
 
-        assert "," not in result
+        assert isinstance(result, list)


### PR DESCRIPTION
Our previous integration of al mcp is not complete, it fails to compile BaseApp due to missing symbols.

Need to pass in `assemblyprobingpaths` similar to BCContainerHelper.

Also need to provide `packagecachepath`.

Finally, we also need to extend the timeout because compiling BaseApp is slow