### PR TITLE
Prevent environment deployments and update docs

### DIFF
--- a/.github/workflows/claude-evaluation.yml
+++ b/.github/workflows/claude-evaluation.yml
@@ -64,7 +64,9 @@ jobs:
     outputs:
       results-dir: ${{ env.EVALUATION_RESULTS_DIR }}
     if: needs.get-entries.outputs.entries != '[]'
-    environment: ado-read
+    environment:
+      name: ado-read
+      deployment: false
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/copilot-evaluation.yml
+++ b/.github/workflows/copilot-evaluation.yml
@@ -72,7 +72,9 @@ jobs:
     outputs:
       results-dir: ${{ env.EVALUATION_RESULTS_DIR }}
     if: needs.get-entries.outputs.entries != '[]'
-    environment: ado-read
+    environment:
+      name: ado-read
+      deployment: false
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/dataset-validation.yml
+++ b/.github/workflows/dataset-validation.yml
@@ -24,7 +24,9 @@ jobs:
     runs-on: [self-hosted, 1ES.Pool=GitHub-BCBench]
     needs: get-entries
     if: needs.get-entries.outputs.entries != '[]'
-    environment: ado-read
+    environment:
+      name: ado-read
+      deployment: false
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/mini-evaluation.yml
+++ b/.github/workflows/mini-evaluation.yml
@@ -45,7 +45,9 @@ jobs:
     outputs:
       results-dir: ${{ env.EVALUATION_RESULTS_DIR }}
     if: needs.get-entries.outputs.entries != '[]'
-    environment: ado-read
+    environment:
+      name: ado-read
+      deployment: false
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/summarize-results.yml
+++ b/.github/workflows/summarize-results.yml
@@ -32,7 +32,9 @@ env:
 jobs:
   summarize-results:
     name: Results
-    environment: ado-read
+    environment:
+      name: ado-read
+      deployment: false
     permissions:
       contents: write
       id-token: write

--- a/EXPERIMENTS.md
+++ b/EXPERIMENTS.md
@@ -84,7 +84,7 @@ instructions:
 
 Replace the files below with your instructions:
 ```
-src/bcbench/agent/shared/instructions/microsoftInternal-NAV/
+src/bcbench/agent/shared/instructions/microsoft-BCApps/
   AGENTS.md
   instructions/
     tables.instructions.md
@@ -92,8 +92,8 @@ src/bcbench/agent/shared/instructions/microsoftInternal-NAV/
     codeunits.instructions.md
 ```
 
-How it works (take `NAV` repo as example):
-1. Repo name (`microsoftInternal/NAV`) is sanitized to `microsoftInternal-NAV`
+How it works (take `microsoft/BCApps` repo as example):
+1. Repo name (`microsoft/BCApps`) is sanitized to `microsoft-BCApps`
 2. **All files** are copied into the agent's target directory (`.github/` for Copilot, `.claude/` for Claude)
 3. `AGENTS.md` is renamed to the agent-specific filename (`copilot-instructions.md` for Copilot, `CLAUDE.md` for Claude)
 4. If `enabled: false`, Copilot gets `--no-custom-instructions` flag; Claude skips the file
@@ -111,16 +111,16 @@ skills:
 
 Replace the folder and files below with your skills:
 ```
-src/bcbench/agent/shared/instructions/microsoftInternal-NAV/
+src/bcbench/agent/shared/instructions/microsoft-BCApps/
   skills/
     al-test-generation/
       SKILL.md
 ```
 
-How it works (take `NAV` repo as example):
-1. Repo name (`microsoftInternal/NAV`) is sanitized to `microsoftInternal-NAV`
-2. **Copilot**: The `skills/` folder is copied to `NAV/.github/skills/` (replaces existing skills directory)
-3. **Claude**: The `skills/` folder is copied to `NAV/.claude/skills/`
+How it works (take `microsoft/BCApps` repo as example):
+1. Repo name (`microsoft/BCApps`) is sanitized to `microsoft-BCApps`
+2. **Copilot**: The `skills/` folder is copied to `BCApps/.github/skills/` (replaces existing skills directory)
+3. **Claude**: The `skills/` folder is copied to `BCApps/.claude/skills/`
 4. If `enabled: false`, skills are simply not copied
 
 ### Custom Agents
@@ -134,7 +134,7 @@ agents:
 ```
 
 This controls:
-1. Whether to copy custom agents from `src/bcbench/agent/shared/instructions/<sanitized-repo>/agents/` (Copilot: `.github/agents/`, Claude: `.claude/agents/`)
+1. Whether to copy custom agent files from `src/bcbench/agent/shared/instructions/<sanitized-repo>/agents/` (Copilot: `.github/agents/`, Claude: `.claude/agents/`)
 2. Whether to pass `--agent=<agent-name>` to the coding agent
 
 ## Results & Metrics


### PR DESCRIPTION
Uptake https://github.com/orgs/community/discussions/36919#discussioncomment-16214515, so we don't create deployments for every workflow run.

Update docs to use BCApps as example instead