### PR TITLE
Update agent harness to include latest model

### DIFF
--- a/.github/workflows/claude-evaluation.yml
+++ b/.github/workflows/claude-evaluation.yml
@@ -13,7 +13,7 @@ on:
         type: choice
         options:
           - "claude-sonnet-4-6"
-          - "claude-opus-4-6"
+          - "claude-opus-4-7"
           - "claude-haiku-4-5"
       category:
         description: "Evaluation category to run"
@@ -60,7 +60,7 @@ jobs:
       category: ${{ inputs.category }}
 
   evaluate-with-claude-code:
-    runs-on: [GitHub-BCBench]
+    runs-on: [ GitHub-BCBench ]
     needs: get-entries
     outputs:
       results-dir: ${{ env.EVALUATION_RESULTS_DIR }}
@@ -105,7 +105,7 @@ jobs:
           echo "$HOME\.dotnet\tools" >> $env:GITHUB_PATH
 
       - name: Install Claude Code
-        run: npm install -g @anthropic-ai/claude-code@2.1.69
+        run: npm install -g @anthropic-ai/claude-code@2.1.112
 
       - name: Run Claude Code for entry ${{ matrix.entry }}
         timeout-minutes: 120

--- a/.github/workflows/copilot-evaluation.yml
+++ b/.github/workflows/copilot-evaluation.yml
@@ -12,12 +12,10 @@ on:
         default: "claude-haiku-4.5"
         type: choice
         options:
-          - "claude-sonnet-4.5"
           - "claude-sonnet-4.6"
           - "claude-haiku-4.5"
-          - "claude-opus-4.5"
           - "claude-opus-4.6"
-          - "claude-opus-4.6-fast"
+          - "claude-opus-4.7"
           - "gpt-5.4"
           - "gpt-5.3-codex"
           - "gpt-5.2-codex"
@@ -68,7 +66,7 @@ jobs:
       category: ${{ inputs.category }}
 
   evaluate-with-copilot-cli:
-    runs-on: [GitHub-BCBench]
+    runs-on: [ GitHub-BCBench ]
     needs: get-entries
     outputs:
       results-dir: ${{ env.EVALUATION_RESULTS_DIR }}
@@ -113,7 +111,7 @@ jobs:
           echo "$HOME\.dotnet\tools" >> $env:GITHUB_PATH
 
       - name: Install GitHub Copilot CLI
-        run: npm install -g @github/copilot@1.0.2
+        run: npm install -g @github/copilot@1.0.31
 
       - name: Select PAT based on job index
         id: select-pat
@@ -124,7 +122,9 @@ jobs:
       - name: Run GitHub Copilot CLI for entry ${{ matrix.entry }}
         timeout-minutes: 120
         env:
-          COPILOT_GITHUB_TOKEN: ${{ steps.select-pat.outputs.pat_index == '0' && secrets.COPILOT_PAT || (steps.select-pat.outputs.pat_index == '1' && secrets.COPILOT_PAT2 || secrets.COPILOT_PAT3) }}
+          COPILOT_GITHUB_TOKEN: ${{ steps.select-pat.outputs.pat_index == '0' &&
+            secrets.COPILOT_PAT || (steps.select-pat.outputs.pat_index == '1' &&
+            secrets.COPILOT_PAT2 || secrets.COPILOT_PAT3) }}
         run: |
           Write-Output "::add-mask::$env:COPILOT_GITHUB_TOKEN"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bcbench"
-version = "0.5.0"
+version = "0.5.1"
 description = "Benchmarking tool for Business Central (AL) ecosystem, inspired by SWE-Bench"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/bcbench/cli_options.py
+++ b/src/bcbench/cli_options.py
@@ -25,12 +25,10 @@ EvaluationCategoryOption = Annotated[EvaluationCategory, typer.Option(help="Cate
 
 CopilotModel = Annotated[
     Literal[
-        "claude-sonnet-4.5",
         "claude-sonnet-4.6",
         "claude-haiku-4.5",
-        "claude-opus-4.5",
         "claude-opus-4.6",
-        "claude-opus-4.6-fast",
+        "claude-opus-4.7",
         "gpt-5.4",
         "gpt-5.3-codex",
         "gpt-5.2-codex",
@@ -48,7 +46,7 @@ FoundryModel = Annotated[
 ClaudeCodeModel = Annotated[
     Literal[
         "claude-sonnet-4-6",
-        "claude-opus-4-6",
+        "claude-opus-4-7",
         "claude-haiku-4-5",
     ],
     typer.Option(help="Claude Code model to use"),

--- a/uv.lock
+++ b/uv.lock
@@ -142,7 +142,7 @@ wheels = [
 
 [[package]]
 name = "bcbench"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "jsonschema" },


### PR DESCRIPTION
Updating Agent Harnesses' version to include the latest `claude-opus-4.7`, refreshing the model list

Bumping the version to `v0.5.1`

---

Claude Code's metrics parsing is broken due to latest version, will fix in a follow-up PR