### PR TITLE
Add retry logic to Get-WorkflowSummary and document altest scripts

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -9,3 +9,87 @@ Scripts for analyzing AL test results from BC-Bench GitHub Actions runs:
 - **`Get-WorkflowSummary.ps1`** — Fetches workflow run summaries from GitHub Actions, downloads run artifacts, and extracts JSONL result files (even from nested zips).
 - **`bcbench_analyze_artifacts.py`** — Extracts, collects, and summarizes test results from downloaded artifact zips or pre-extracted folders. Outputs failure rankings, error variations, and extracted test code.
 - **`group_errors_from_summary.py`** — Groups error messages from `errors_summary.csv` into high-level categories for easier triage.
+
+### Usage
+
+Run the scripts from the `tools/altest/` directory. All paths below use placeholders — replace them with your own local paths.
+
+#### 1. Download workflow artifacts
+
+```powershell
+cd tools/altest
+
+.\Get-WorkflowSummary.ps1 `
+    -Last <N> `
+    -Status completed `
+    -Category <category> `
+    -JsonlOutputRoot <output-dir>
+```
+
+| Parameter | Description |
+|---|---|
+| `-Last` | Number of recent runs to fetch (default: 1) |
+| `-Status` | Filter by run status (`completed`, `in_progress`, `queued`, etc.) |
+| `-Category` | Filter by evaluation category (e.g. `test-generation`, `bug-fix`) |
+| `-JsonlOutputRoot` | Directory to copy discovered JSONL files into (organized by run ID) |
+| `-RunId` | Fetch a specific run instead of recent ones |
+| `-Branch` | Filter runs by branch name |
+| `-KeepArtifacts` | Keep temp artifact download folders (useful for debugging) |
+
+Example:
+
+```powershell
+.\Get-WorkflowSummary.ps1 `
+    -Last 5 `
+    -Status completed `
+    -Category test-generation `
+    -JsonlOutputRoot C:\Repos\BC-Bench\out2
+```
+
+#### 2. Analyze downloaded artifacts
+
+```powershell
+python .\bcbench_analyze_artifacts.py `
+    --zips-dir <output-dir> `
+    --out <analysis-output-dir> `
+    --category <category> `
+    --top <N>
+```
+
+| Parameter | Description |
+|---|---|
+| `--zips-dir` | Directory from step 1 (the `JsonlOutputRoot`), or any folder with artifact zips |
+| `--out` | Directory for analysis output (CSVs, extracted test code, etc.) |
+| `--category` | Filter records by category (default: `test-generation`) |
+| `--top` | Number of top failing tests to extract (default: 10) |
+| `--zip` | Path to a single artifact `.zip` (repeatable) |
+| `--extracted-dir` | Directory with already-extracted artifact content |
+
+Example:
+
+```powershell
+python .\bcbench_analyze_artifacts.py `
+    --zips-dir C:\Repos\BC-Bench\out2 `
+    --out C:\Repos\BC-Bench\out `
+    --category test-generation `
+    --top 10
+```
+
+#### 3. Group errors for triage
+
+```powershell
+python .\group_errors_from_summary.py <errors-summary-csv> <output-dir>
+```
+
+| Argument | Description |
+|---|---|
+| `<errors-summary-csv>` | Path to `errors_summary.csv` produced by step 2 |
+| `<output-dir>` | Directory to write grouped error output |
+
+Example:
+
+```powershell
+python .\group_errors_from_summary.py `
+    C:\Repos\BC-Bench\out\errors_summary.csv `
+    C:\Repos\BC-Bench\out
+```

--- a/tools/altest/Get-WorkflowSummary.ps1
+++ b/tools/altest/Get-WorkflowSummary.ps1
@@ -1,4 +1,4 @@
-using module ..\..\scripts\BCBenchUtils.psm1
+using module .\BCBenchUtils.psm1
 
 <#
     .SYNOPSIS
@@ -74,6 +74,26 @@ param(
     [string]$Category
 )
 
+function Invoke-WithRetry {
+    param(
+        [scriptblock]$ScriptBlock,
+        [int]$MaxRetries = 3,
+        [int]$BaseDelaySec = 2
+    )
+
+    for ($attempt = 1; $attempt -le $MaxRetries; $attempt++) {
+        try {
+            return & $ScriptBlock
+        }
+        catch {
+            if ($attempt -eq $MaxRetries) { throw }
+            $delay = $BaseDelaySec * [math]::Pow(2, $attempt - 1)
+            Write-Log "  Attempt $attempt failed, retrying in ${delay}s..." -Level Warning
+            Start-Sleep -Seconds $delay
+        }
+    }
+}
+
 function Get-WorkflowRuns {
     param(
         [string]$Repo,
@@ -108,12 +128,13 @@ function Get-RunDetails {
         [string]$RunId
     )
 
-    $json = gh run view $RunId --repo $Repo --json "databaseId,displayTitle,conclusion,status,createdAt,headBranch,url" 2>&1
-    if ($LASTEXITCODE -ne 0) {
-        throw "Failed to fetch run details for run $RunId`: $json"
+    return Invoke-WithRetry {
+        $json = gh run view $RunId --repo $Repo --json "databaseId,displayTitle,conclusion,status,createdAt,headBranch,url" 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            throw "Failed to fetch run details for run $RunId`: $json"
+        }
+        $json | ConvertFrom-Json
     }
-
-    return $json | ConvertFrom-Json
 }
 
 function Get-JobSummary {
@@ -122,12 +143,13 @@ function Get-JobSummary {
         [string]$RunId
     )
 
-    $jobs = gh run view $RunId --repo $Repo --json jobs 2>&1
-    if ($LASTEXITCODE -ne 0) {
-        throw "Failed to fetch jobs for run $RunId`: $jobs"
+    return Invoke-WithRetry {
+        $jobs = gh run view $RunId --repo $Repo --json jobs 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            throw "Failed to fetch jobs for run $RunId`: $jobs"
+        }
+        ($jobs | ConvertFrom-Json).jobs
     }
-
-    return ($jobs | ConvertFrom-Json).jobs
 }
 
 function Get-SummarizeJobOutput {
@@ -527,14 +549,19 @@ try {
             Write-Log "  Could not retrieve summary for run $currentRunId" -Level Warning
 
             # At minimum, show job-level failures
-            $jobs = Get-JobSummary -Repo $Repository -RunId $currentRunId
-            $failedJobs = $jobs | Where-Object { $_.conclusion -eq "failure" }
+            try {
+                $jobs = Get-JobSummary -Repo $Repository -RunId $currentRunId
+                $failedJobs = $jobs | Where-Object { $_.conclusion -eq "failure" }
 
-            if ($failedJobs) {
-                Write-Log "  Failed jobs: $($failedJobs.Count)" -Level Error
-                foreach ($job in $failedJobs) {
-                    Write-Log "    - $($job.name): $($job.conclusion)" -Level Warning
+                if ($failedJobs) {
+                    Write-Log "  Failed jobs: $($failedJobs.Count)" -Level Error
+                    foreach ($job in $failedJobs) {
+                        Write-Log "    - $($job.name): $($job.conclusion)" -Level Warning
+                    }
                 }
+            }
+            catch {
+                Write-Log "  Could not fetch job details for run $currentRunId (GitHub API error). Skipping." -Level Warning
             }
         }
 


### PR DESCRIPTION

**Get-WorkflowSummary.ps1**

- Add Invoke-WithRetry helper with exponential backoff (3 retries)
- Wrap Get-RunDetails and Get-JobSummary in retry logic to handle transient GitHub API failures
- Fix module import path (..\..\scripts\BCBenchUtils.psm1 → .\BCBenchUtils.psm1)
- Wrap job-level failure fallback in try/catch so API errors don't crash the script

**README.md**

- Add step-by-step usage instructions for the three altest scripts:
 - download workflow artifacts
 - analyze downloaded artifacts
 - group errors for triage
 
 AB#626728