### PR TITLE
Switch back to hyperv isolation for stability

### DIFF
--- a/scripts/BCContainerManagement.psm1
+++ b/scripts/BCContainerManagement.psm1
@@ -301,7 +301,7 @@ function New-BCContainerSync {
         multitenant              = $false
         shortcuts                = 'None'
         memoryLimit              = "16G"
-        isolation                = "process"
+        isolation                = "hyperv"
     }
 
     if ($AcceptEula) {


### PR DESCRIPTION
Thought process isolation will speed things up, but then we suffer a bit more build timeout.