### PR TITLE
Revert back to latest BCCH

### DIFF
--- a/.github/actions/setup-bc-container/action.yml
+++ b/.github/actions/setup-bc-container/action.yml
@@ -44,7 +44,8 @@ runs:
 
     - name: Install BcContainerHelper module
       if: inputs.skip-container != 'true'
-      run: Install-Module -Name BcContainerHelper -RequiredVersion 6.1.12 -Force -AllowClobber
+      run: |
+        Install-Module -Name BcContainerHelper -Force -AllowClobber -AllowPrerelease
       shell: pwsh
 
     - name: Azure Login with OIDC for cloning internal repository

--- a/scripts/Setup-ContainerAndRepository.ps1
+++ b/scripts/Setup-ContainerAndRepository.ps1
@@ -60,7 +60,7 @@ Invoke-GitCloneWithRetry -RepoUrl $cloneInfo.Url -Token $cloneInfo.Token -CloneP
 if (-not $SkipContainer) {
     [PSCredential]$credential = Get-BCCredential -Username $Username -Password $Password
 
-    Import-Module BcContainerHelper -RequiredVersion 6.1.12 -Force -DisableNameChecking
+    Import-Module BcContainerHelper -Force -DisableNameChecking
 
     Write-Log "Container name: $ContainerName" -Level Info
 

--- a/scripts/Verify-BuildAndTests.ps1
+++ b/scripts/Verify-BuildAndTests.ps1
@@ -46,7 +46,7 @@ if (-not (Test-Path $RepoPath)) {
     exit 1
 }
 
-Import-Module BcContainerHelper -RequiredVersion 6.1.12 -Force -DisableNameChecking
+Import-Module BcContainerHelper -Force -DisableNameChecking
 
 [ValidationResult[]]$validationResults = @()
 

--- a/src/bcbench/operations/bc_operations.py
+++ b/src/bcbench/operations/bc_operations.py
@@ -29,7 +29,7 @@ def _escape_ps_string(value: str) -> str:
 # PowerShell script templates using Python's built-in string.Template
 _BUILD_AND_PUBLISH_TEMPLATE = Template(
     """
-Import-Module BcContainerHelper -RequiredVersion 6.1.12 -Force -DisableNameChecking
+Import-Module BcContainerHelper -Force -DisableNameChecking
 Import-Module '$app_utils_path' -Force
 $$ErrorActionPreference = 'Stop'
 
@@ -44,7 +44,7 @@ Invoke-AppBuildAndPublish -containerName '$container_name' -appProjectFolder $$p
 
 _TEST_EXECUTION_TEMPLATE = Template(
     """
-Import-Module BcContainerHelper -RequiredVersion 6.1.12 -Force -DisableNameChecking
+Import-Module BcContainerHelper -Force -DisableNameChecking
 Import-Module '$app_utils_path' -Force
 $$ErrorActionPreference = 'Stop'
 
@@ -58,7 +58,7 @@ Invoke-BCTest -containerName '$container_name' -credential $$credential -codeuni
 
 _DATASET_TESTS_TEMPLATE = Template(
     """
-Import-Module BcContainerHelper -RequiredVersion 6.1.12 -Force -DisableNameChecking
+Import-Module BcContainerHelper -Force -DisableNameChecking
 Import-Module '$app_utils_path' -Force
 $$ErrorActionPreference = 'Stop'
 

--- a/tests/test_ps_templates.py
+++ b/tests/test_ps_templates.py
@@ -37,7 +37,7 @@ class TestPowerShellScriptGeneration:
             version="1.0.0.0",
         )
 
-        assert "Import-Module BcContainerHelper -RequiredVersion 6.1.12 -Force -DisableNameChecking" in script
+        assert "Import-Module BcContainerHelper -Force -DisableNameChecking" in script
         assert "$ErrorActionPreference = 'Stop'" in script
         assert "ConvertTo-SecureString 'Test123' -AsPlainText -Force" in script
         assert "New-Object System.Management.Automation.PSCredential('admin', $password)" in script


### PR DESCRIPTION
We have found a solution for using the latest BCCH.

Turns out it's still the easiest way to unpin