### PR TITLE
Fix v24 tasks build failed due to .NET 10

### DIFF
--- a/.github/workflows/dataset-validation.yml
+++ b/.github/workflows/dataset-validation.yml
@@ -14,10 +14,17 @@ on:
     - cron: "0 0 * * 0"
 
 jobs:
-  # TEMP: focused on v24 entries to validate manifest.json injection workaround
-  # (see scripts/BCContainerManagement.psm1). Restore get-entries job before merging.
+  get-entries:
+    uses: ./.github/workflows/get-entries.yml
+    with:
+      modified-only: false
+      test-run: ${{ inputs.test-run || false }}
+      category: "bug-fix"
+
   verify-build-and-tests:
     runs-on: [GitHub-BCBench]
+    needs: get-entries
+    if: needs.get-entries.outputs.entries != '[]'
     environment:
       name: ado-read
       deployment: false
@@ -28,11 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        entry:
-          - microsoftInternal__NAV-178045
-          - microsoftInternal__NAV-176426
-          - microsoftInternal__NAV-180484
-          - microsoftInternal__NAV-185792
+        entry: ${{ fromJson(needs.get-entries.outputs.entries) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5

--- a/.github/workflows/dataset-validation.yml
+++ b/.github/workflows/dataset-validation.yml
@@ -14,17 +14,10 @@ on:
     - cron: "0 0 * * 0"
 
 jobs:
-  get-entries:
-    uses: ./.github/workflows/get-entries.yml
-    with:
-      modified-only: false
-      test-run: ${{ inputs.test-run || false }}
-      category: "bug-fix"
-
+  # TEMP: focused on v24 entries to validate manifest.json injection workaround
+  # (see scripts/BCContainerManagement.psm1). Restore get-entries job before merging.
   verify-build-and-tests:
     runs-on: [GitHub-BCBench]
-    needs: get-entries
-    if: needs.get-entries.outputs.entries != '[]'
     environment:
       name: ado-read
       deployment: false
@@ -35,7 +28,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        entry: ${{ fromJson(needs.get-entries.outputs.entries) }}
+        entry:
+          - microsoftInternal__NAV-178045
+          - microsoftInternal__NAV-176426
+          - microsoftInternal__NAV-180484
+          - microsoftInternal__NAV-185792
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5

--- a/scripts/BCContainerManagement.psm1
+++ b/scripts/BCContainerManagement.psm1
@@ -319,6 +319,18 @@ function New-BCContainerSync {
 
     New-BCContainer @params
 
+    # Workaround: BC v24 artifacts predate manifest.json, so BcContainerHelper cannot determine the required .NET major
+    # and falls back to "C:\Program Files\dotnet\shared", which causes AL0196 ambiguous TimeSpan.FromSeconds errors on runner images shipping .NET 10.
+    # Inject a synthetic manifest so Compile-AppInBcContainer pins probing to .NET 8.
+    # Drop this once navcontainerhelper#4136 (or equivalent platform-version fallback) ships.
+    if ($Version.StartsWith("24")) {
+        $manifestPath = Join-Path $bcContainerHelperConfig.hostHelperFolder "Extensions\$ContainerName\manifest.json"
+        if (-not (Test-Path $manifestPath)) {
+            Write-Log "Injecting synthetic manifest.json (dotNetVersion=8.0.0) for v24 compatibility" -Level Info
+            '{"dotNetVersion":"8.0.0"}' | Set-Content -Path $manifestPath -Encoding UTF8
+        }
+    }
+
     Write-Log "Container created successfully: $ContainerName" -Level Success
 }
 

--- a/scripts/BCContainerManagement.psm1
+++ b/scripts/BCContainerManagement.psm1
@@ -324,11 +324,9 @@ function New-BCContainerSync {
     # Inject a synthetic manifest so Compile-AppInBcContainer pins probing to .NET 8.
     # Drop this once navcontainerhelper#4136 (or equivalent platform-version fallback) ships.
     if ($Version.StartsWith("24")) {
-        $manifestPath = Join-Path $bcContainerHelperConfig.hostHelperFolder "Extensions\$ContainerName\manifest.json"
-        if (-not (Test-Path $manifestPath)) {
-            Write-Log "Injecting synthetic manifest.json (dotNetVersion=8.0.0) for v24 compatibility" -Level Info
-            '{"dotNetVersion":"8.0.0"}' | Set-Content -Path $manifestPath -Encoding UTF8
-        }
+        $manifestPath = "C:\ProgramData\BcContainerHelper\Extensions\$ContainerName\manifest.json"
+        Write-Log "Injecting synthetic manifest.json (dotNetVersion=8.0.0) at $manifestPath for v24 compatibility" -Level Info
+        '{"dotNetVersion":"8.0.0"}' | Set-Content -Path $manifestPath -Encoding UTF8 -Force
     }
 
     Write-Log "Container created successfully: $ContainerName" -Level Success


### PR DESCRIPTION
The v24 related tasks were failing due to the latest .NET 10 platform update.

Mitigating the issue for now by injecting manifest json so it points to .NET 8.