### PR TITLE
Improve extensibility for new categories with updated workflows and docs

### DIFF
--- a/.github/actions/setup-bc-container-repo/action.yml
+++ b/.github/actions/setup-bc-container-repo/action.yml
@@ -1,5 +1,5 @@
-name: Setup BC Container
-description: Install BcContainerHelper and setup BC container with repository
+name: Setup BC Container and Repository
+description: Install BcContainerHelper and setup BC container along with repository
 
 inputs:
   instance-id:

--- a/.github/actions/setup-bc-container-repo/action.yml
+++ b/.github/actions/setup-bc-container-repo/action.yml
@@ -5,6 +5,9 @@ inputs:
   instance-id:
     description: Instance ID for the dataset entry
     required: true
+  category:
+    description: Category for the dataset entry
+    required: true
   azure-client-id:
     description: Azure AD application client ID for OIDC authentication
     required: true
@@ -66,5 +69,5 @@ runs:
         $env:ADO_TOKEN = az account get-access-token --resource "499b84ac-1321-427f-aa17-267ca6975798" --query accessToken -o tsv
         Write-Output "::add-mask::$env:ADO_TOKEN"
 
-        .\scripts\Setup-ContainerAndRepository.ps1 -InstanceId "${{ inputs.instance-id }}" ${{ inputs.skip-container == 'true' && '-SkipContainer' || '' }}
+        .\scripts\Setup-ContainerAndRepository.ps1 -InstanceId "${{ inputs.instance-id }}" -Category "${{ inputs.category }}" ${{ inputs.skip-container == 'true' && '-SkipContainer' || '' }}
       shell: pwsh

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,7 +5,7 @@ This is a benchmark for evaluating coding agents on real-world Business Central 
 - **Dataset**: Benchmark entries following SWE-Bench schema with BC-specific adjustments
 - **Python Package** (`src/bcbench/`): CLI tools, agent implementations, and validation utilities
 - **PowerShell Scripts** (`scripts/`): Environment setup and dataset verification using AL-GO/BCContainerHelper
-- **Tools** (`tools/`): Standalone scripts for downloading and analyzing GitHub Actions artifacts
+- **Tools** (`tools/`): Ad-hoc scripts for GitHub Artifacts download, etc
 - **Agent Evaluations**: Focuses on GitHub Copilot CLI and Claude Code
 - **Experiments**: MCP Servers, custom instructions, custom agents, skills, etc. and their performance on the benchmark
 - **Notebooks** (`notebooks/`): Analysis and visualization of benchmark results

--- a/.github/workflows/claude-evaluation.yml
+++ b/.github/workflows/claude-evaluation.yml
@@ -87,6 +87,7 @@ jobs:
         uses: ./.github/actions/setup-bc-container-repo
         with:
           instance-id: ${{ matrix.entry }}
+          category: ${{ inputs.category }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-evaluation.yml
+++ b/.github/workflows/claude-evaluation.yml
@@ -81,10 +81,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-      - name: Setup BC container
+      - name: Setup BC Container and Repository
         id: setup-env
         timeout-minutes: 40
-        uses: ./.github/actions/setup-bc-container
+        uses: ./.github/actions/setup-bc-container-repo
         with:
           instance-id: ${{ matrix.entry }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}

--- a/.github/workflows/copilot-evaluation.yml
+++ b/.github/workflows/copilot-evaluation.yml
@@ -88,10 +88,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-      - name: Setup BC container
+      - name: Setup BC Container and Repository
         id: setup-env
         timeout-minutes: 40
-        uses: ./.github/actions/setup-bc-container
+        uses: ./.github/actions/setup-bc-container-repo
         with:
           instance-id: ${{ matrix.entry }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}

--- a/.github/workflows/copilot-evaluation.yml
+++ b/.github/workflows/copilot-evaluation.yml
@@ -94,6 +94,7 @@ jobs:
         uses: ./.github/actions/setup-bc-container-repo
         with:
           instance-id: ${{ matrix.entry }}
+          category: ${{ inputs.category }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dataset-validation.yml
+++ b/.github/workflows/dataset-validation.yml
@@ -1,5 +1,7 @@
+# Designed for bug-fix and test-generation dataset, verifies the flow of building and
+# testing still works as expected, avoiding regressions caused by underlying
+# infrastructure changes.
 name: Dataset Validation and Verification
-description: Designed for bug-fix and test-generation dataset, verifies the flow of building and testing still works as expected, avoiding regressions caused by underlying infrastructure changes.
 permissions:
   contents: read
 

--- a/.github/workflows/dataset-validation.yml
+++ b/.github/workflows/dataset-validation.yml
@@ -1,4 +1,5 @@
 name: Dataset Validation and Verification
+description: Designed for bug-fix and test-generation dataset, verifies the flow of building and testing still works as expected, avoiding regressions caused by underlying infrastructure changes.
 permissions:
   contents: read
 
@@ -51,6 +52,7 @@ jobs:
         uses: ./.github/actions/setup-bc-container-repo
         with:
           instance-id: ${{ matrix.entry }}
+          category: "bug-fix"
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dataset-validation.yml
+++ b/.github/workflows/dataset-validation.yml
@@ -45,10 +45,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-      - name: Setup BC container
+      - name: Setup BC Container and Repository
         id: setup-env
         timeout-minutes: 40
-        uses: ./.github/actions/setup-bc-container
+        uses: ./.github/actions/setup-bc-container-repo
         with:
           instance-id: ${{ matrix.entry }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,6 @@ repos:
     hooks:
       - id: ty
         name: ty check
-        entry: uv run ty check . --ignore=unresolved-import --exclude "notebooks/**"
+        entry: uv run ty check . --ignore=unresolved-import --exclude "notebooks/"
         language: python
         pass_filenames: false

--- a/CATEGORIES.md
+++ b/CATEGORIES.md
@@ -1,0 +1,43 @@
+# Adding a New Category
+
+BC-Bench is **category-based**. A category is a distinct evaluation scenario: `bug-fix` asks an agent to patch buggy code, while `test-generation` asks it to write reproduction tests.
+
+The `bug-fix` and `test-generation` categories happen to share one dataset today. A new category should have its own: dataset schema, entry type, result type, pipeline, etc.
+
+This doc is a map; the source files and their comments are the source of truth. To experiment with agent setup on existing categories, see [EXPERIMENT.md](EXPERIMENT.md).
+
+## Architecture
+
+Start with `EvaluationCategory` in [src/bcbench/types.py](src/bcbench/types.py). It is the category registry. Each enum value maps to the pieces the rest of the CLI and workflows consume:
+
+- `dataset_path` — the dataset file for raw tasks.
+- `entry_class` — the typed Python model for one dataset row (aka one task).
+- `result_class` — the recorded outcome for one evaluated task.
+- `summary_class` — the aggregate view used by result summaries and leaderboards.
+- `pipeline` — the category-specific setup, agent run, and evaluation behavior.
+- Prompt template — the category-specific prompt in [src/bcbench/agent/shared/config.yaml](src/bcbench/agent/shared/config.yaml), loaded by [src/bcbench/agent/shared/prompt.py](src/bcbench/agent/shared/prompt.py).
+
+Keep dataset entry classes and result classes focused on typed data. Put category-specific behavior in the pipeline.
+
+## Checklist
+
+Use the existing `bug-fix` and `test-generation` implementations as examples.
+
+1. Add the enum value and mappings in [src/bcbench/types.py](src/bcbench/types.py).
+2. Add the category dataset JSONL and entry class in [src/bcbench/dataset/dataset_entry.py](src/bcbench/dataset/dataset_entry.py).
+3. Add a result class under [src/bcbench/results/](src/bcbench/results/) and map it from `EvaluationCategory.result_class`.
+4. Add a pipeline under [src/bcbench/evaluate/](src/bcbench/evaluate/).
+5. Add the prompt template to [src/bcbench/agent/shared/config.yaml](src/bcbench/agent/shared/config.yaml).
+6. Add the category to workflow choice lists in [.github/workflows/](.github/workflows/), especially evaluation workflows and CI category selection.
+7. Add docs, leaderboard data, notebooks, and tests for the category where relevant.
+
+## Validation
+
+At minimum, run the exhaustiveness tests and one local smoke test:
+
+```powershell
+uv run pytest tests/test_type_exhaustiveness.py
+uv run bcbench run copilot <some-instance-id> --category <new-category> --repo-path /path/to/repo
+```
+
+Then trigger a CI test run before running the full dataset.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,12 @@ Thank you for your interest in BC-Bench.
 
 BC-Bench is open source, and you're welcome to fork and adapt it for your own use. We are not accepting external contributions in this repository at this time.
 
-The instructions below are for teams that fork BC-Bench and replace the dataset with their own tasks.
+This document covers both audiences:
+
+- **Fork users** — read [Setup](#setup) and [After Forking](#after-forking).
+- **Maintainers** — skip the `gh repo fork` step in [Setup](#setup), ignore [After Forking](#after-forking).
+
+For related workflows see [EXPERIMENT.md](EXPERIMENT.md) (tweak agent setup) and [CATEGORIES.md](CATEGORIES.md) (add a new evaluation category).
 
 ## Repo Structure
 
@@ -62,11 +67,15 @@ uv run pre-commit run --all-files
 
 ## After Forking
 
+> Fork users only. Maintainers on `microsoft/BC-Bench` can skip this section.
+
 ### Dataset
 
 Replace the dataset tasks with your own, you can keep the ones from `BCApps` as the repository is public. The tasks follow `<organization>__<repo>-<PR#number>`, the `<organization>/<repo>` by default points to GitHub repositories. If your tasks come from Azure DevOps, update the ADO branch in `scripts/BCBenchUtils.psm1` (currently hardcoded to `microsoftinternal`).
 
 ### GitHub Actions
+
+The upstream workflows are wired for Microsoft's internal environment. To run them on your fork:
 
 - Replace self-hosted runner label `GitHub-BCBench` with the standard GitHub Action runners.
 - Remove or update GitHub environment `ado-read`, it is used to clone from Azure DevOps.
@@ -97,7 +106,9 @@ This ensures the leaderboard always compares apples-to-apples. When bumping vers
 3. Clear old results from `docs/_data/*.json` if needed
 4. Re-run evaluations with the new version
 
-## Frequently Used Operations
+## Maintainer Operations
+
+> Routine tasks for maintainers working on `microsoft/BC-Bench` directly. Fork users will rarely need these unless mirroring upstream changes.
 
 ### Bump Coding Agent/Tool versions
 

--- a/EXPERIMENT.md
+++ b/EXPERIMENT.md
@@ -4,13 +4,15 @@ This document assumes you are either using the upstream repo, or you have alread
 
 ## What is an Experiment?
 
-An experiment compares agent performance under different configurations against the same dataset. Typical examples:
+An experiment compares agent performance under different configurations against the **same dataset and the same category**. Typical examples:
 
 - Toggling custom instructions / skills / a custom agent
 - Adding an MCP server (e.g. the AL MCP) and measuring impact
 - Comparing models under the same setup
 
-The dataset, evaluation pipeline, and result format should stay constant. Only [`src/bcbench/agent/shared/config.yaml`](src/bcbench/agent/shared/config.yaml) (and the files it references) change between experiments.
+The dataset, category, evaluation pipeline, and result format stay constant. Only [`src/bcbench/agent/shared/config.yaml`](src/bcbench/agent/shared/config.yaml) (and the files it references) change between experiments.
+
+> If you want to evaluate a **different kind of output** (e.g. code review instead of bug fix), that's a new category, not an experiment — see [CATEGORIES.md](CATEGORIES.md).
 
 ## Configuring an Experiment
 
@@ -123,7 +125,7 @@ Each run uploads artifacts and updates a `leaderboard/<category>/<run_id>` branc
 
 - **Agent:**
 - **Model:**
-- **Category:**
+- **Category:** <!-- bug-fix | test-generation | ... -->
 
 ### Hypothesis / Expected Outcome
 

--- a/README.md
+++ b/README.md
@@ -35,5 +35,8 @@ The [GitHub Copilot CLI](https://github.com/github/copilot-cli) supports MCP ser
 
 BC-Bench is open source, and you're welcome to fork and adapt it for your own use. We are not accepting external contributions in this repository at this time. You can run evaluations locally and replace the dataset under `dataset/` with tasks from your own codebase.
 
-- **[Setup for Forks](CONTRIBUTING.md)**
-- **[Running Experiments](EXPERIMENT.md)**
+### Documentation map
+
+- **[CONTRIBUTING.md](CONTRIBUTING.md)** — fork setup, repo layout, versioning, day-to-day maintainer ops
+- **[EXPERIMENT.md](EXPERIMENT.md)** — run an experiment (toggle instructions / skills / agents / MCP / model) against an existing category
+- **[CATEGORIES.md](CATEGORIES.md)** — add a new evaluation category (e.g. code-review) alongside `bug-fix` / `test-generation`

--- a/scripts/BCBenchUtils.psm1
+++ b/scripts/BCBenchUtils.psm1
@@ -474,13 +474,30 @@ function Get-RepoCloneInfo {
     }
 }
 
+<#
+.SYNOPSIS
+    Gets the default dataset path for a given category
+.DESCRIPTION
+    Get the dataset path based on the provided category, must be maintained when adding new categories.
+.PARAMETER Category
+    The category for which to get the dataset path
+.OUTPUTS
+    String representing the dataset path
+#>
 function Get-BCBenchDatasetPath {
     [CmdletBinding()]
     [OutputType([string])]
     param(
-        [Parameter(Mandatory = $false)]
-        [string]$DatasetName = "bcbench.jsonl"
+        [Parameter(Mandatory = $true)]
+        # Category validation lives only here: every caller resolves the dataset path through this function, so there's no need to duplicate ValidateSet on each caller.
+        [ValidateSet("bug-fix", "test-generation")]
+        [string] $Category
     )
+
+    switch ($Category) {
+        "bug-fix" { $DatasetName = "bcbench.jsonl" }
+        "test-generation" { $DatasetName = "bcbench.jsonl" }
+    }
 
     [string] $projectRoot = Split-Path $PSScriptRoot -Parent
     return Join-Path $projectRoot "dataset" $DatasetName

--- a/scripts/Setup-ContainerAndRepository.ps1
+++ b/scripts/Setup-ContainerAndRepository.ps1
@@ -1,3 +1,10 @@
+<#
+.SYNOPSIS
+    Sets up the BC container and clones the repository based on the provided dataset entry.
+.DESCRIPTION
+    This script is designed for categories that require a BC container environment or repository setup, should be skipped if not needed.
+#>
+
 using module .\DatasetEntry.psm1
 using module .\BCBenchUtils.psm1
 using module .\BCContainerManagement.psm1
@@ -9,8 +16,11 @@ param(
     [Parameter(Mandatory = $false)]
     [string]$InstanceId,
 
+    [Parameter(Mandatory = $true)]
+    [string]$Category,
+
     [Parameter(Mandatory = $false)]
-    [string]$DatasetPath = (Get-BCBenchDatasetPath),
+    [string]$DatasetPath = (Get-BCBenchDatasetPath -Category $Category),
 
     [Parameter(Mandatory = $false)]
     [string]$Country = "w1",

--- a/scripts/Verify-BuildAndTests.ps1
+++ b/scripts/Verify-BuildAndTests.ps1
@@ -1,3 +1,12 @@
+<#
+.SYNOPSIS
+    Verifies that the projects build and tests run successfully for "bug-fix" and "test-generation" dataset.
+.DESCRIPTION
+    This script is designed specifically for the "bug-fix" and "test-generation" dataset.
+
+    It verifies the flow of building and testing still works as expected, avoiding regressions caused by underlying infrastructure changes.
+#>
+
 using module .\DatasetEntry.psm1
 using module .\BCBenchUtils.psm1
 using module .\AppUtils.psm1
@@ -11,7 +20,7 @@ param(
     [string]$InstanceId,
 
     [Parameter(Mandatory = $false)]
-    [string]$DatasetPath = (Get-BCBenchDatasetPath),
+    [string]$DatasetPath = (Get-BCBenchDatasetPath -Category "bug-fix"),
 
     [Parameter(Mandatory = $true)]
     [string]$RepoPath,


### PR DESCRIPTION
Realized the GitHub workflows and PowerShell scripts were not designed for adding new categories, doing a small refactor to improve the new category onboarding experience.

* Renamed the BC Container Setup flow to be clearer that it will setup repository as well
* Update powershell functions with descriptions and extensible for newer categories (e.g. `Get-BCBenchDatasetPath`)
*  Updated documentation to be clearer how to add a new category