### PR TITLE
Add bcal evaluation workflow

### DIFF
--- a/.github/workflows/bcal-evaluation.yml
+++ b/.github/workflows/bcal-evaluation.yml
@@ -1,0 +1,129 @@
+name: Evaluation with bcal
+permissions:
+  contents: read
+  actions: write
+
+on:
+  workflow_dispatch:
+    inputs:
+      model:
+        description: "Azure OpenAI deployment name to use for bcal"
+        required: false
+        default: "gpt-5.2"
+        type: string
+      test-run:
+        description: "Indicate this is a test run (with few entries)"
+        required: false
+        default: true
+        type: boolean
+
+concurrency:
+  group: bcal-evaluation-${{ inputs.test-run && 'test' || 'full' }}
+  cancel-in-progress: false
+
+env:
+  EVALUATION_RESULTS_DIR: evaluation_results
+
+jobs:
+  get-entries:
+    uses: ./.github/workflows/get-entries.yml
+    with:
+      test-run: ${{ inputs.test-run }}
+      category: nl2al
+
+  evaluate-with-bcal:
+    runs-on: windows-latest
+    needs: get-entries
+    outputs:
+      results-dir: ${{ env.EVALUATION_RESULTS_DIR }}
+    if: needs.get-entries.outputs.entries != '[]'
+    environment:
+      name: ado-read
+      deployment: false
+    permissions:
+      contents: read
+      id-token: write
+    name: ${{ matrix.entry }}
+    strategy:
+      fail-fast: false
+      max-parallel: 8
+      matrix:
+        entry: ${{ fromJson(needs.get-entries.outputs.entries) }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup Python with UV
+        uses: ./.github/actions/setup-python-uv
+
+      - name: Azure Login (OIDC) for bcal feed and symbols
+        uses: azure/login@v3
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          allow-no-subscriptions: true
+
+      - name: Install bcal CLI from internal feed
+        shell: pwsh
+        env:
+          BCAL_PACKAGE_ID: ${{ secrets.BCAL_PACKAGE_ID }}
+          BCAL_FEED_URL: ${{ secrets.BCAL_FEED_URL }}
+        run: |
+          if (-not $env:BCAL_PACKAGE_ID -or -not $env:BCAL_FEED_URL) {
+            throw "BCAL_PACKAGE_ID / BCAL_FEED_URL secrets are not configured."
+          }
+
+          iex "& { $(irm https://aka.ms/install-artifacts-credprovider.ps1) }"
+
+          $adoToken = az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv
+          Write-Output "::add-mask::$adoToken"
+
+          $endpoints = @{
+            endpointCredentials = @(
+              @{
+                endpoint = $env:BCAL_FEED_URL
+                username = "anything"
+                password = $adoToken
+              }
+            )
+          } | ConvertTo-Json -Compress -Depth 5
+          $env:VSS_NUGET_EXTERNAL_FEED_ENDPOINTS = $endpoints
+
+          dotnet tool install -g $env:BCAL_PACKAGE_ID --prerelease --add-source $env:BCAL_FEED_URL
+          echo "$HOME\.dotnet\tools" >> $env:GITHUB_PATH
+
+      - name: Download BC Application symbols
+        shell: pwsh
+        run: |
+          Install-Module -Name BcContainerHelper -Force -AllowClobber -AllowPrerelease
+          .\scripts\Download-BCSymbols.ps1 -InstanceId "${{ matrix.entry }}"
+
+      - name: Run bcal for entry ${{ matrix.entry }}
+        timeout-minutes: 120
+        env:
+          AZURE_OPENAI_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
+          AZURE_OPENAI_DEPLOYMENT: ${{ inputs.model }}
+        run: |
+          uv run bcbench evaluate bcal "${{ matrix.entry }}" --output-dir "${{ env.EVALUATION_RESULTS_DIR }}"
+
+      - name: Upload evaluation results
+        uses: actions/upload-artifact@v6
+        if: always()
+        with:
+          name: evaluation-results-${{ github.run_id }}-${{ matrix.entry }}
+          path: ${{ env.EVALUATION_RESULTS_DIR }}/**/*.jsonl
+          retention-days: ${{ inputs.test-run && 1 || 30 }}
+
+  summarize-results:
+    needs: evaluate-with-bcal
+    uses: ./.github/workflows/summarize-results.yml
+    permissions:
+      contents: write
+      id-token: write
+    with:
+      results-dir: ${{ needs.evaluate-with-bcal.outputs.results-dir }}
+      model: ${{ inputs.model }}
+      agent: bcal
+      mock: ${{ inputs.test-run }}
+      category: nl2al
+    secrets: inherit


### PR DESCRIPTION
## What

Adds a new `Evaluation with bcal` workflow (`.github/workflows/bcal-evaluation.yml`) that runs the NL2AL evaluation against the `bcal` dotnet tool on `windows-latest` (GitHub-hosted) runners.

## Why

`workflow_dispatch` workflows are only discoverable (UI dropdown / `gh workflow run`) when the file exists on the default branch. Merging this small file to `main` first unblocks dispatching the workflow against the `category/nl2al` feature branch (which carries the actual `bcbench evaluate bcal` CLI and dataset). Without this, we can't iterate on NL2AL runs.

Splitting it out also separates an Azure-OpenAI-tenant authentication issue from the rest of the NL2AL feature work — see thread context for the `DefaultAzureCredential` / managed-identity tenant collision that motivated moving the bcal job off the self-hosted runner.

## Notes

- The workflow's `bcbench evaluate bcal` subcommand does not exist on `main` yet, so dispatching this workflow against `main` would fail. It is only intended to be dispatched against `category/nl2al` (and eventually `main`, once that branch lands).
- Uses `windows-latest` deliberately — the self-hosted `GitHub-BCBench` runner is Azure-VM-based and its managed identity preempts `AzureCliCredential` in bcal's `DefaultAzureCredential` chain, causing AOAI to reject the token with "Token tenant does not match resource tenant". Hosted runners have no MI, so the chain reaches `AzureCliCredential` (which `azure/login` has already federated to the correct tenant).
- The `ado-read` environment must be configured to allow the `category/nl2al` branch ref, otherwise dispatches will fail with "environment not allowed".
