### PR TITLE
Enable AL-LSP for evaluation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -30,6 +30,7 @@ BC-Bench is category-based and designed to grow over time. It currently has two 
 
 ### Readable code over documentation or comments
 Function names should be self-explanatory. Do NOT add docstrings to functions unless absolutely necessary.
+When a docstring is necessary, keep it short and use Google style. Include only useful sections such as `Args:` and `Returns:`; skip details that are obvious from names and type hints.
 
 Bad:
 ```python

--- a/.github/workflows/claude-evaluation.yml
+++ b/.github/workflows/claude-evaluation.yml
@@ -109,7 +109,7 @@ jobs:
         if: ${{ inputs.al-mcp || inputs.al-lsp }}
         shell: pwsh
         run: |
-          dotnet tool install -g Microsoft.Dynamics.BusinessCentral.Development.Tools --version 18.0.36.64936-beta
+          dotnet tool install -g Microsoft.Dynamics.BusinessCentral.Development.Tools --version 18.0.37.11445-beta
           echo "$HOME\.dotnet\tools" >> $env:GITHUB_PATH
 
       - name: Install Claude Code

--- a/.github/workflows/claude-evaluation.yml
+++ b/.github/workflows/claude-evaluation.yml
@@ -33,6 +33,11 @@ on:
         required: false
         default: false
         type: boolean
+      al-lsp:
+        description: "Enable AL LSP server"
+        required: false
+        default: false
+        type: boolean
       repeat:
         description: "Number of times to run sequentially (ignored for test runs)"
         required: false
@@ -100,9 +105,9 @@ jobs:
           node-version: 24
 
       - name: Install AL Tool
-        if: ${{ inputs.al-mcp }}
+        if: ${{ inputs.al-mcp || inputs.al-lsp }}
         run: |
-          dotnet tool install -g Microsoft.Dynamics.BusinessCentral.Development.Tools --version 17.0.33.55542
+          dotnet tool install -g Microsoft.Dynamics.BusinessCentral.Development.Tools --version 18.0.36.64936-beta
           echo "$HOME\.dotnet\tools" >> $env:GITHUB_PATH
 
       - name: Install Claude Code
@@ -120,7 +125,8 @@ jobs:
             --category "${{ inputs.category }}" `
             --repo-path "${{ steps.setup-env.outputs.repo_path }}" `
             --output-dir "${{ env.EVALUATION_RESULTS_DIR }}" `
-            ${{ inputs.al-mcp && '--al-mcp' || '' }}
+            ${{ inputs.al-mcp && '--al-mcp' || '' }} `
+            ${{ inputs.al-lsp && '--al-lsp' || '' }}
 
       - name: Upload evaluation results
         uses: actions/upload-artifact@v6
@@ -155,4 +161,4 @@ jobs:
       workflow-file: claude-evaluation.yml
       repeat: ${{ inputs.repeat }}
       workflow-inputs: |
-        {"model": "${{ inputs.model }}", "category": "${{ inputs.category }}", "test-run": "${{ inputs.test-run }}", "al-mcp": "${{ inputs.al-mcp }}"}
+        {"model": "${{ inputs.model }}", "category": "${{ inputs.category }}", "test-run": "${{ inputs.test-run }}", "al-mcp": "${{ inputs.al-mcp }}", "al-lsp": "${{ inputs.al-lsp }}"}

--- a/.github/workflows/claude-evaluation.yml
+++ b/.github/workflows/claude-evaluation.yml
@@ -107,6 +107,7 @@ jobs:
 
       - name: Install AL Tool
         if: ${{ inputs.al-mcp || inputs.al-lsp }}
+        shell: pwsh
         run: |
           dotnet tool install -g Microsoft.Dynamics.BusinessCentral.Development.Tools --version 18.0.36.64936-beta
           echo "$HOME\.dotnet\tools" >> $env:GITHUB_PATH

--- a/.github/workflows/copilot-evaluation.yml
+++ b/.github/workflows/copilot-evaluation.yml
@@ -72,7 +72,7 @@ jobs:
       category: ${{ inputs.category }}
 
   evaluate-with-copilot-cli:
-    runs-on: [GitHub-BCBench]
+    runs-on: [ GitHub-BCBench ]
     needs: get-entries
     outputs:
       results-dir: ${{ env.EVALUATION_RESULTS_DIR }}

--- a/.github/workflows/copilot-evaluation.yml
+++ b/.github/workflows/copilot-evaluation.yml
@@ -116,7 +116,7 @@ jobs:
         if: ${{ inputs.al-mcp || inputs.al-lsp }}
         shell: pwsh
         run: |
-          dotnet tool install -g Microsoft.Dynamics.BusinessCentral.Development.Tools --version 18.0.36.64936-beta
+          dotnet tool install -g Microsoft.Dynamics.BusinessCentral.Development.Tools --version 18.0.37.11445-beta
           echo "$HOME\.dotnet\tools" >> $env:GITHUB_PATH
 
       - name: Install GitHub Copilot CLI

--- a/.github/workflows/copilot-evaluation.yml
+++ b/.github/workflows/copilot-evaluation.yml
@@ -40,6 +40,11 @@ on:
         required: false
         default: false
         type: boolean
+      al-lsp:
+        description: "Enable AL LSP server"
+        required: false
+        default: false
+        type: boolean
       repeat:
         description: "Number of times to run sequentially (ignored for test runs)"
         required: false
@@ -67,7 +72,7 @@ jobs:
       category: ${{ inputs.category }}
 
   evaluate-with-copilot-cli:
-    runs-on: [ GitHub-BCBench ]
+    runs-on: [GitHub-BCBench]
     needs: get-entries
     outputs:
       results-dir: ${{ env.EVALUATION_RESULTS_DIR }}
@@ -107,9 +112,9 @@ jobs:
           node-version: 24
 
       - name: Install AL Tool
-        if: ${{ inputs.al-mcp }}
+        if: ${{ inputs.al-mcp || inputs.al-lsp }}
         run: |
-          dotnet tool install -g Microsoft.Dynamics.BusinessCentral.Development.Tools --version 17.0.33.55542
+          dotnet tool install -g Microsoft.Dynamics.BusinessCentral.Development.Tools --version 18.0.36.64936-beta
           echo "$HOME\.dotnet\tools" >> $env:GITHUB_PATH
 
       - name: Install GitHub Copilot CLI
@@ -136,7 +141,8 @@ jobs:
             --category "${{ inputs.category }}" `
             --repo-path "${{ steps.setup-env.outputs.repo_path }}" `
             --output-dir "${{ env.EVALUATION_RESULTS_DIR }}" `
-            ${{ inputs.al-mcp && '--al-mcp' || '' }}
+            ${{ inputs.al-mcp && '--al-mcp' || '' }} `
+            ${{ inputs.al-lsp && '--al-lsp' || '' }}
 
       - name: Upload evaluation results
         uses: actions/upload-artifact@v6
@@ -171,4 +177,4 @@ jobs:
       workflow-file: copilot-evaluation.yml
       repeat: ${{ inputs.repeat }}
       workflow-inputs: |
-        {"model": "${{ inputs.model }}", "category": "${{ inputs.category }}", "test-run": "${{ inputs.test-run }}", "al-mcp": "${{ inputs.al-mcp }}"}
+        {"model": "${{ inputs.model }}", "category": "${{ inputs.category }}", "test-run": "${{ inputs.test-run }}", "al-mcp": "${{ inputs.al-mcp }}", "al-lsp": "${{ inputs.al-lsp }}"}

--- a/EXPERIMENT.md
+++ b/EXPERIMENT.md
@@ -77,7 +77,7 @@ Trigger the evaluation workflow from the **Actions** tab:
 
 - **Workflow:** `Evaluation with GitHub Copilot` or `Evaluation with Claude Code`
 - **`test-run`:** `true` (default — runs 4 entries, ~10 min)
-- **`model`**, **`category`**, **`al-mcp`**: as needed
+- **`model`**, **`category`**, **`al-mcp`**, **`al-lsp`**: as needed
 
 This catches configuration mistakes cheaply. Do not skip it.
 

--- a/scripts/Download-BCSymbols.ps1
+++ b/scripts/Download-BCSymbols.ps1
@@ -30,7 +30,7 @@ param(
     [string]$DatasetPath = (Get-BCBenchDatasetPath -Category $Category),
 
     [Parameter(Mandatory = $false)]
-    [string]$Country = "W1"
+    [string]$Country = "w1"
 )
 
 $ErrorActionPreference = 'Stop'

--- a/scripts/Download-BCSymbols.ps1
+++ b/scripts/Download-BCSymbols.ps1
@@ -1,0 +1,56 @@
+using module .\DatasetEntry.psm1
+using module .\BCBenchUtils.psm1
+
+<#
+.SYNOPSIS
+    Downloads the BC artifact for a dataset entry into the BCContainerHelper cache.
+.DESCRIPTION
+    Looks up the BC version for the given InstanceId in the dataset and downloads the matching BC artifact via BcContainerHelper.
+    The artifact (including all *.app symbol packages) lands in BCContainerHelper's default cache (using default path: C:\bcartifacts.cache),
+    where the pipeline copies them at evaluation time.
+.PARAMETER InstanceId
+    The dataset instance_id to resolve the BC version for.
+.PARAMETER Category
+    The dataset category (e.g. nl2al) to resolve the dataset path for (if DatasetPath not explicitly provided).
+.PARAMETER DatasetPath
+    Path to the dataset (.jsonl). Defaults to dataset/nl2al.jsonl in the repo.
+.PARAMETER Country
+    BC artifact country (default: w1).
+.EXAMPLE
+    .\scripts\Download-BCSymbols.ps1 -Category nl2al -InstanceId nl2al__job-budget-report-1
+#>
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$InstanceId,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Category,
+
+    [Parameter(Mandatory = $false)]
+    [string]$DatasetPath = (Get-BCBenchDatasetPath -Category $Category),
+
+    [Parameter(Mandatory = $false)]
+    [string]$Country = "W1"
+)
+
+$ErrorActionPreference = 'Stop'
+
+[DatasetEntry[]] $entries = Get-DatasetEntries -DatasetPath $DatasetPath -InstanceId $InstanceId
+if (-not $entries -or $entries.Count -eq 0) {
+    throw "Entry '$InstanceId' not found in $DatasetPath"
+}
+[string] $version = $entries[0].environment_setup_version
+Write-Log "Resolved BC version $version for InstanceId $InstanceId" -Level Info
+
+Import-Module BcContainerHelper -Force -DisableNameChecking
+
+[string] $artifactUrl = Get-BCArtifactUrl -version $version -country $Country -select 'Latest'
+if (-not $artifactUrl) { throw "No BC artifact URL resolved for version $version ($Country)" }
+Write-Log "Downloading artifact: $artifactUrl" -Level Info
+
+$paths = Download-Artifacts -artifactUrl $artifactUrl -includePlatform
+
+$appCount = (Get-ChildItem -Path $paths -Recurse -File -Filter '*.app' -ErrorAction SilentlyContinue | Measure-Object).Count
+if ($appCount -eq 0) { throw "No *.app symbol files found under: $($paths -join ', ')" }
+
+Write-Log "Artifact ready: $appCount *.app files cached under $($paths -join ', ')" -Level Success

--- a/scripts/Download-BCSymbols.ps1
+++ b/scripts/Download-BCSymbols.ps1
@@ -11,13 +11,13 @@ using module .\BCBenchUtils.psm1
 .PARAMETER InstanceId
     The dataset instance_id to resolve the BC version for.
 .PARAMETER Category
-    The dataset category (e.g. nl2al) to resolve the dataset path for (if DatasetPath not explicitly provided).
+    The dataset category (`bug-fix` or `test-generation`) to resolve the dataset path for (if DatasetPath is not explicitly provided).
 .PARAMETER DatasetPath
-    Path to the dataset (.jsonl). Defaults to dataset/nl2al.jsonl in the repo.
+    Path to the dataset (.jsonl). Defaults to the category-specific dataset path in the repo, for example dataset/bug-fix.jsonl or dataset/test-generation.jsonl.
 .PARAMETER Country
     BC artifact country (default: w1).
 .EXAMPLE
-    .\scripts\Download-BCSymbols.ps1 -Category nl2al -InstanceId nl2al__job-budget-report-1
+    .\scripts\Download-BCSymbols.ps1 -Category bug-fix -InstanceId bug-fix__job-budget-report-1
 #>
 param(
     [Parameter(Mandatory = $true)]

--- a/src/bcbench/agent/claude/agent.py
+++ b/src/bcbench/agent/claude/agent.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import yaml
 
 from bcbench.agent.claude.metrics import parse_metrics
-from bcbench.agent.shared import build_mcp_config, build_prompt, parse_tool_usage_from_hooks
+from bcbench.agent.shared import build_al_lsp_plugin, build_mcp_config, build_prompt, parse_tool_usage_from_hooks
 from bcbench.config import get_config
 from bcbench.dataset import BaseDatasetEntry
 from bcbench.exceptions import AgentError, AgentTimeoutError
@@ -19,7 +19,14 @@ _config = get_config()
 
 
 def run_claude_code(
-    entry: BaseDatasetEntry, model: str, category: EvaluationCategory, repo_path: Path, output_dir: Path, al_mcp: bool = False, container_name: str = "bcbench"
+    entry: BaseDatasetEntry,
+    model: str,
+    category: EvaluationCategory,
+    repo_path: Path,
+    output_dir: Path,
+    al_mcp: bool = False,
+    al_lsp: bool = False,
+    container_name: str = "bcbench",
 ) -> tuple[AgentMetrics | None, ExperimentConfiguration]:
     """Run Claude Code on a single dataset entry.
 
@@ -33,12 +40,14 @@ def run_claude_code(
 
     prompt: str = build_prompt(entry, repo_path, claude_config, category, al_mcp=al_mcp)
     mcp_config_json, mcp_server_names = build_mcp_config(claude_config, entry, repo_path, al_mcp=al_mcp, container_name=container_name)
+    lsp_plugin_dir: Path | None = build_al_lsp_plugin(entry, category, repo_path, AgentType.CLAUDE, al_lsp=al_lsp, container_name=container_name)
     instructions_enabled: bool = setup_instructions_from_config(claude_config, entry, repo_path, agent_type=AgentType.CLAUDE)
     skills_enabled: bool = setup_agent_skills(claude_config, entry, repo_path, agent_type=AgentType.CLAUDE)
     custom_agent: str | None = setup_custom_agent(claude_config, entry, repo_path, agent_type=AgentType.CLAUDE)
     tool_log_path: Path = setup_hooks(repo_path, AgentType.CLAUDE, output_dir)
     config = ExperimentConfiguration(
         mcp_servers=mcp_server_names,
+        al_lsp_enabled=lsp_plugin_dir is not None,
         custom_instructions=instructions_enabled,
         skills_enabled=skills_enabled,
         custom_agent=custom_agent,
@@ -65,6 +74,8 @@ def run_claude_code(
         ]
         if mcp_config_json:
             cmd_args.append(f"--mcp-config={mcp_config_json}")
+        if lsp_plugin_dir is not None:
+            cmd_args.append(f"--plugin-dir={lsp_plugin_dir}")
         if custom_agent:
             cmd_args.append(f"--agent={custom_agent}")
         cmd_args.extend(

--- a/src/bcbench/agent/copilot/agent.py
+++ b/src/bcbench/agent/copilot/agent.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import yaml
 
 from bcbench.agent.copilot.metrics import parse_metrics
-from bcbench.agent.shared import build_lsp_config, build_mcp_config, build_prompt, parse_tool_usage_from_hooks
+from bcbench.agent.shared import build_al_lsp_plugin, build_mcp_config, build_prompt, parse_tool_usage_from_hooks
 from bcbench.config import get_config
 from bcbench.dataset import BaseDatasetEntry
 from bcbench.exceptions import AgentError, AgentTimeoutError
@@ -42,14 +42,14 @@ def run_copilot_agent(
 
     prompt: str = build_prompt(entry, repo_path, copilot_config, category, al_mcp=al_mcp)
     mcp_config_json, mcp_server_names = build_mcp_config(copilot_config, entry, repo_path, al_mcp=al_mcp, container_name=container_name)
-    al_lsp_enabled: bool = build_lsp_config(entry, category, repo_path, al_lsp=al_lsp, container_name=container_name)
+    lsp_plugin_dir: Path | None = build_al_lsp_plugin(entry, category, repo_path, AgentType.COPILOT, al_lsp=al_lsp, container_name=container_name)
     instructions_enabled: bool = setup_instructions_from_config(copilot_config, entry, repo_path, agent_type=AgentType.COPILOT)
     skills_enabled: bool = setup_agent_skills(copilot_config, entry, repo_path, agent_type=AgentType.COPILOT)
     custom_agent: str | None = setup_custom_agent(copilot_config, entry, repo_path, agent_type=AgentType.COPILOT)
     tool_log_path: Path = setup_hooks(repo_path, AgentType.COPILOT, output_dir)
     config = ExperimentConfiguration(
         mcp_servers=mcp_server_names,
-        al_lsp_enabled=al_lsp_enabled,
+        al_lsp_enabled=lsp_plugin_dir is not None,
         custom_instructions=instructions_enabled,
         skills_enabled=skills_enabled,
         custom_agent=custom_agent,
@@ -76,6 +76,8 @@ def run_copilot_agent(
             cmd_args.append("--no-custom-instructions")
         if mcp_config_json:
             cmd_args.append(f"--additional-mcp-config={mcp_config_json}")
+        if lsp_plugin_dir is not None:
+            cmd_args.append(f"--plugin-dir={lsp_plugin_dir}")
         if custom_agent:
             cmd_args.append(f"--agent={custom_agent}")
 

--- a/src/bcbench/agent/copilot/agent.py
+++ b/src/bcbench/agent/copilot/agent.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import yaml
 
 from bcbench.agent.copilot.metrics import parse_metrics
-from bcbench.agent.shared import build_mcp_config, build_prompt, parse_tool_usage_from_hooks
+from bcbench.agent.shared import build_lsp_config, build_mcp_config, build_prompt, parse_tool_usage_from_hooks
 from bcbench.config import get_config
 from bcbench.dataset import BaseDatasetEntry
 from bcbench.exceptions import AgentError, AgentTimeoutError
@@ -21,7 +21,14 @@ _config = get_config()
 
 
 def run_copilot_agent(
-    entry: BaseDatasetEntry, model: str, category: EvaluationCategory, repo_path: Path, output_dir: Path, al_mcp: bool = False, container_name: str = "bcbench"
+    entry: BaseDatasetEntry,
+    model: str,
+    category: EvaluationCategory,
+    repo_path: Path,
+    output_dir: Path,
+    al_mcp: bool = False,
+    al_lsp: bool = False,
+    container_name: str = "bcbench",
 ) -> tuple[AgentMetrics | None, ExperimentConfiguration]:
     """Run GitHub Copilot CLI agent on a single dataset entry.
 
@@ -35,12 +42,14 @@ def run_copilot_agent(
 
     prompt: str = build_prompt(entry, repo_path, copilot_config, category, al_mcp=al_mcp)
     mcp_config_json, mcp_server_names = build_mcp_config(copilot_config, entry, repo_path, al_mcp=al_mcp, container_name=container_name)
+    al_lsp_enabled: bool = build_lsp_config(entry, category, repo_path, al_lsp=al_lsp, container_name=container_name)
     instructions_enabled: bool = setup_instructions_from_config(copilot_config, entry, repo_path, agent_type=AgentType.COPILOT)
     skills_enabled: bool = setup_agent_skills(copilot_config, entry, repo_path, agent_type=AgentType.COPILOT)
     custom_agent: str | None = setup_custom_agent(copilot_config, entry, repo_path, agent_type=AgentType.COPILOT)
     tool_log_path: Path = setup_hooks(repo_path, AgentType.COPILOT, output_dir)
     config = ExperimentConfiguration(
         mcp_servers=mcp_server_names,
+        al_lsp_enabled=al_lsp_enabled,
         custom_instructions=instructions_enabled,
         skills_enabled=skills_enabled,
         custom_agent=custom_agent,

--- a/src/bcbench/agent/shared/__init__.py
+++ b/src/bcbench/agent/shared/__init__.py
@@ -1,7 +1,8 @@
 """Shared code for CLI-based agents (Claude, Copilot)."""
 
 from bcbench.agent.shared.hooks_parser import parse_tool_usage_from_hooks
+from bcbench.agent.shared.lsp import build_lsp_config
 from bcbench.agent.shared.mcp import build_mcp_config
 from bcbench.agent.shared.prompt import build_prompt
 
-__all__ = ["build_mcp_config", "build_prompt", "parse_tool_usage_from_hooks"]
+__all__ = ["build_lsp_config", "build_mcp_config", "build_prompt", "parse_tool_usage_from_hooks"]

--- a/src/bcbench/agent/shared/__init__.py
+++ b/src/bcbench/agent/shared/__init__.py
@@ -1,8 +1,8 @@
 """Shared code for CLI-based agents (Claude, Copilot)."""
 
 from bcbench.agent.shared.hooks_parser import parse_tool_usage_from_hooks
-from bcbench.agent.shared.lsp import build_lsp_config
+from bcbench.agent.shared.lsp import build_al_lsp_plugin
 from bcbench.agent.shared.mcp import build_mcp_config
 from bcbench.agent.shared.prompt import build_prompt
 
-__all__ = ["build_lsp_config", "build_mcp_config", "build_prompt", "parse_tool_usage_from_hooks"]
+__all__ = ["build_al_lsp_plugin", "build_mcp_config", "build_prompt", "parse_tool_usage_from_hooks"]

--- a/src/bcbench/agent/shared/altool_paths.py
+++ b/src/bcbench/agent/shared/altool_paths.py
@@ -1,0 +1,169 @@
+"""Shared altool helpers used by both AL-MCP and AL-LSP integrations.
+
+Both `altool launchmcpserver` and `altool launchlspserver` need the same
+package-cache layout, assembly probing paths, and runtime-version handling.
+"""
+
+import json
+from pathlib import Path
+
+from packaging.version import Version
+
+from bcbench.logger import get_logger
+
+logger = get_logger(__name__)
+
+# .NET major versions excluded from runtime detection (unstable/preview)
+# See: navcontainerhelper/InitializeModule.ps1 line 62
+_EXCLUDED_DOTNET_MAJORS = {9, 10}
+_DOTNET_SHARED = Path(r"C:\Program Files\dotnet\shared")
+
+# Offset from BC platform major version to AL runtime version.
+# E.g. platform 25.0 (BC 2024w2) → runtime 14.0, platform 27.0 → runtime 16.0
+# See: BC-DeveloperExperience RuntimeVersion.cs
+_PLATFORM_TO_RUNTIME_OFFSET = 11
+
+# Default location of BCContainerHelper-downloaded artifacts (symbols, reference assemblies, etc.)
+_BCARTIFACTS_CACHE = Path(r"C:\bcartifacts.cache")
+
+
+def _detect_dotnet_runtime_version() -> Version | None:
+    dotnet_shared = _DOTNET_SHARED
+    netcore_folder = dotnet_shared / "Microsoft.NETCore.App"
+    aspnetcore_folder = dotnet_shared / "Microsoft.AspNetCore.App"
+
+    if not netcore_folder.is_dir():
+        return None
+
+    versions: list[Version] = []
+    for entry in netcore_folder.iterdir():
+        if not entry.is_dir() or not (aspnetcore_folder / entry.name).is_dir():
+            continue
+        try:
+            v = Version(entry.name)
+            if v.major not in _EXCLUDED_DOTNET_MAJORS:
+                versions.append(v)
+        except Exception:
+            continue
+
+    return max(versions) if versions else None
+
+
+def build_assembly_probing_paths(compiler_folder: Path) -> list[str]:
+    """Build list of assembly probing paths for the AL compiler.
+
+    The AL compiler recursively searches subdirectories (AssemblyLocatorBase.cs uses
+    SearchOption.AllDirectories), so a single ``dlls`` entry covers Service, OpenXML,
+    Mock Assemblies, etc. System .NET runtime paths must be added separately since
+    they live outside the compiler folder.
+
+    Path order matters: .NET runtime paths must come BEFORE dlls to avoid stale
+    type-forwarding stubs (e.g. XrmV91's 5.0.0.0 DLLs) shadowing the real types.
+    This matches BCContainerHelper's ordering (OpenXML → dotnet → Service).
+
+    Each path must be a separate CLI argument (System.CommandLine with
+    AllowMultipleArgumentsPerToken expects space-separated values, NOT semicolons).
+    """
+    paths: list[str] = []
+    dlls_path = compiler_folder / "dlls"
+
+    # .NET runtime paths first — avoids stale type-forwarding stubs in dlls\ subfolders
+    shared_folder = dlls_path / "shared"
+    if shared_folder.is_dir():
+        paths.append(str(shared_folder))
+    else:
+        dotnet_version = _detect_dotnet_runtime_version()
+        if dotnet_version:
+            paths.append(str(_DOTNET_SHARED / "Microsoft.NETCore.App" / str(dotnet_version)))
+            paths.append(str(_DOTNET_SHARED / "Microsoft.AspNetCore.App" / str(dotnet_version)))
+            logger.info(f"Using system .NET runtime {dotnet_version} for assembly probing")
+        else:
+            logger.warning("No compatible .NET runtime found. DotNet interop types may not resolve.")
+
+    # dlls\ after dotnet — recursively covers Service, OpenXML, Mock Assemblies, etc.
+    if dlls_path.is_dir():
+        paths.append(str(dlls_path))
+
+    return paths
+
+
+def set_runtime_version(project_paths: list[str]) -> None:
+    """Set the AL runtime version in each project's app.json based on platform version.
+
+    The AL compiler (altool 17.0+) defaults to the latest runtime when "runtime"
+    is not set in app.json, enabling newer validation rules that reject older code.
+    Setting the runtime to match the platform version makes the compiler behave
+    like the version that originally compiled the code.
+    """
+    for project_path in project_paths:
+        app_json_path = Path(project_path) / "app.json"
+        if not app_json_path.is_file():
+            continue
+
+        try:
+            app_json = json.loads(app_json_path.read_text(encoding="utf-8-sig"))
+        except (json.JSONDecodeError, OSError):
+            continue
+
+        if app_json.get("runtime"):
+            continue
+
+        platform = app_json.get("platform", "")
+        try:
+            platform_major = int(platform.split(".")[0])
+        except (ValueError, IndexError):
+            continue
+
+        runtime_major = platform_major - _PLATFORM_TO_RUNTIME_OFFSET
+        if runtime_major < 1:
+            continue
+
+        runtime = f"{runtime_major}.0"
+        app_json["runtime"] = runtime
+        app_json_path.write_text(json.dumps(app_json, indent=2, ensure_ascii=False), encoding="utf-8")
+        logger.info(f"Set runtime={runtime} in {app_json_path} (platform {platform})")
+
+
+def compiler_symbol_folder_for_container(container_name: str) -> tuple[Path, Path]:
+    """Return the BCContainerHelper compiler and symbol folder for a given container."""
+    folder = Path(r"C:\ProgramData\BcContainerHelper\compiler") / container_name
+    return folder, folder / "symbols"
+
+
+def resolve_artifact_lsp_paths(environment_setup_version: str, country: str = "w1") -> tuple[list[str], list[str]] | None:
+    """Resolve (package_cache_paths, assembly_probing_paths) from the BC artifact cache.
+
+    BCContainerHelper's `Download-Artifacts` (driven by `scripts/Download-BCSymbols.ps1`
+    or by the CI container setup) lands the artifact under
+    ``C:\\bcartifacts.cache\\sandbox\\<full-version>\\``. The dataset's
+    ``environment_setup_version`` is major.minor (e.g. "27.2"); BCContainerHelper
+    expands that to a full ``<major>.<minor>.<build>.<revision>``. We glob the cache
+    for matching versions, lexically sort, and pick the newest — BC's full-version
+    fields are constant-width in practice, so a lexical sort matches a numeric one.
+
+    Returns None when the artifact has not been downloaded yet — caller should fall
+    back or surface an actionable error.
+    """
+    version_roots = sorted((_BCARTIFACTS_CACHE / "sandbox").glob(f"{environment_setup_version}.*"))
+    if not version_roots:
+        return None
+    version_root = version_roots[-1]  # newest revision
+
+    # Country-specific app symbols (e.g. W1 BaseApp), then platform symbols (System app etc.)
+    package_cache_paths = [str(p) for p in (version_root / country / "Extensions", version_root / "platform" / "Applications") if p.is_dir()]
+    if not package_cache_paths:
+        return None
+
+    # platform/ alone — the AL compiler recursively scans `--assemblyprobingpaths`
+    # (SearchOption.AllDirectories), so a single root covers ServiceTier, Test Assemblies, etc.
+    platform_dir = version_root / "platform"
+    assembly_probing_paths = [str(platform_dir)] if platform_dir.is_dir() else []
+
+    # System .NET runtime — same fallback as the container-derived path so DotNet
+    # interop types resolve even without BC-shipped reference assemblies.
+    dotnet_version = _detect_dotnet_runtime_version()
+    if dotnet_version:
+        assembly_probing_paths.append(str(_DOTNET_SHARED / "Microsoft.NETCore.App" / str(dotnet_version)))
+        assembly_probing_paths.append(str(_DOTNET_SHARED / "Microsoft.AspNetCore.App" / str(dotnet_version)))
+
+    return package_cache_paths, assembly_probing_paths

--- a/src/bcbench/agent/shared/altool_paths.py
+++ b/src/bcbench/agent/shared/altool_paths.py
@@ -149,7 +149,7 @@ def resolve_artifact_lsp_paths(environment_setup_version: str, country: str = "w
         return None
     version_root = version_roots[-1]  # newest revision
 
-    # Country-specific app symbols (e.g. W1 BaseApp), then platform symbols (System app etc.)
+    # Country-specific app symbols (e.g. w1 BaseApp), then platform symbols (System app etc.)
     package_cache_paths = [str(p) for p in (version_root / country / "Extensions", version_root / "platform" / "Applications") if p.is_dir()]
     if not package_cache_paths:
         return None

--- a/src/bcbench/agent/shared/altool_paths.py
+++ b/src/bcbench/agent/shared/altool_paths.py
@@ -1,10 +1,8 @@
 """Shared altool helpers used by both AL-MCP and AL-LSP integrations.
 
-Both `altool launchmcpserver` and `altool launchlspserver` need the same
-package-cache layout, assembly probing paths, and runtime-version handling.
+Both `altool launchmcpserver` and `altool launchlspserver` need the same package-cache layout and assembly probing paths.
 """
 
-import json
 from pathlib import Path
 
 from packaging.version import Version
@@ -17,11 +15,6 @@ logger = get_logger(__name__)
 # See: navcontainerhelper/InitializeModule.ps1 line 62
 _EXCLUDED_DOTNET_MAJORS = {9, 10}
 _DOTNET_SHARED = Path(r"C:\Program Files\dotnet\shared")
-
-# Offset from BC platform major version to AL runtime version.
-# E.g. platform 25.0 (BC 2024w2) → runtime 14.0, platform 27.0 → runtime 16.0
-# See: BC-DeveloperExperience RuntimeVersion.cs
-_PLATFORM_TO_RUNTIME_OFFSET = 11
 
 # Default location of BCContainerHelper-downloaded artifacts (symbols, reference assemblies, etc.)
 _BCARTIFACTS_CACHE = Path(r"C:\bcartifacts.cache")
@@ -93,43 +86,6 @@ def build_assembly_probing_paths(compiler_folder: Path) -> list[str]:
         paths.append(str(dlls_path))
 
     return paths
-
-
-def set_runtime_version(project_paths: list[str]) -> None:
-    """Set the AL runtime version in each project's app.json based on platform version.
-
-    The AL compiler (altool 17.0+) defaults to the latest runtime when "runtime"
-    is not set in app.json, enabling newer validation rules that reject older code.
-    Setting the runtime to match the platform version makes the compiler behave
-    like the version that originally compiled the code.
-    """
-    for project_path in project_paths:
-        app_json_path = Path(project_path) / "app.json"
-        if not app_json_path.is_file():
-            continue
-
-        try:
-            app_json = json.loads(app_json_path.read_text(encoding="utf-8-sig"))
-        except (json.JSONDecodeError, OSError):
-            continue
-
-        if app_json.get("runtime"):
-            continue
-
-        platform = app_json.get("platform", "")
-        try:
-            platform_major = int(platform.split(".")[0])
-        except (ValueError, IndexError):
-            continue
-
-        runtime_major = platform_major - _PLATFORM_TO_RUNTIME_OFFSET
-        if runtime_major < 1:
-            continue
-
-        runtime = f"{runtime_major}.0"
-        app_json["runtime"] = runtime
-        app_json_path.write_text(json.dumps(app_json, indent=2, ensure_ascii=False), encoding="utf-8")
-        logger.info(f"Set runtime={runtime} in {app_json_path} (platform {platform})")
 
 
 def compiler_symbol_folder_for_container(container_name: str) -> tuple[Path, Path]:

--- a/src/bcbench/agent/shared/altool_paths.py
+++ b/src/bcbench/agent/shared/altool_paths.py
@@ -49,6 +49,20 @@ def _detect_dotnet_runtime_version() -> Version | None:
     return max(versions) if versions else None
 
 
+def _dotnet_runtime_probing_paths() -> list[str]:
+    """Probing paths for the latest compatible system .NET runtime (empty if none found)."""
+    dotnet_version = _detect_dotnet_runtime_version()
+    if not dotnet_version:
+        logger.warning("No compatible .NET runtime found. DotNet interop types may not resolve.")
+        return []
+
+    logger.info(f"Using system .NET runtime {dotnet_version} for assembly probing")
+    return [
+        str(_DOTNET_SHARED / "Microsoft.NETCore.App" / str(dotnet_version)),
+        str(_DOTNET_SHARED / "Microsoft.AspNetCore.App" / str(dotnet_version)),
+    ]
+
+
 def build_assembly_probing_paths(compiler_folder: Path) -> list[str]:
     """Build list of assembly probing paths for the AL compiler.
 
@@ -72,13 +86,7 @@ def build_assembly_probing_paths(compiler_folder: Path) -> list[str]:
     if shared_folder.is_dir():
         paths.append(str(shared_folder))
     else:
-        dotnet_version = _detect_dotnet_runtime_version()
-        if dotnet_version:
-            paths.append(str(_DOTNET_SHARED / "Microsoft.NETCore.App" / str(dotnet_version)))
-            paths.append(str(_DOTNET_SHARED / "Microsoft.AspNetCore.App" / str(dotnet_version)))
-            logger.info(f"Using system .NET runtime {dotnet_version} for assembly probing")
-        else:
-            logger.warning("No compatible .NET runtime found. DotNet interop types may not resolve.")
+        paths.extend(_dotnet_runtime_probing_paths())
 
     # dlls\ after dotnet — recursively covers Service, OpenXML, Mock Assemblies, etc.
     if dlls_path.is_dir():
@@ -159,11 +167,7 @@ def resolve_artifact_lsp_paths(environment_setup_version: str, country: str = "w
     platform_dir = version_root / "platform"
     assembly_probing_paths = [str(platform_dir)] if platform_dir.is_dir() else []
 
-    # System .NET runtime — same fallback as the container-derived path so DotNet
-    # interop types resolve even without BC-shipped reference assemblies.
-    dotnet_version = _detect_dotnet_runtime_version()
-    if dotnet_version:
-        assembly_probing_paths.append(str(_DOTNET_SHARED / "Microsoft.NETCore.App" / str(dotnet_version)))
-        assembly_probing_paths.append(str(_DOTNET_SHARED / "Microsoft.AspNetCore.App" / str(dotnet_version)))
+    # System .NET runtime — same fallback as the container-derived path so DotNet interop types resolve even without BC-shipped reference assemblies.
+    assembly_probing_paths.extend(_dotnet_runtime_probing_paths())
 
     return package_cache_paths, assembly_probing_paths

--- a/src/bcbench/agent/shared/config.yaml
+++ b/src/bcbench/agent/shared/config.yaml
@@ -12,6 +12,8 @@ prompt:
 
     Task: Fix the issue described below {% if include_project_paths %}in the following projects: {{project_paths}}{% endif %}
 
+    CRITICAL: You MUST leverage the AL LSP and MCP server to navigate the codebase and validate the your code changes.
+
     Important constraints:
     - Do NOT modify any testing logic or test files
     - Focus solely on fixing the reported issue
@@ -36,6 +38,8 @@ prompt:
     Task: Generate ONE NEW test case that reproduce the issue described below {% if include_project_paths %}in the following projects: {{project_paths}}{% endif %}
       The tests should fail against the current codebase (unfixed) and should pass once the issue is fixed.
     {% endif %}
+
+    CRITICAL: You MUST leverage the AL LSP and MCP server to navigate the codebase and validate the your code changes.
 
     Important constraints:
     - Do NOT modify any production code or existing tests

--- a/src/bcbench/agent/shared/config.yaml
+++ b/src/bcbench/agent/shared/config.yaml
@@ -12,8 +12,6 @@ prompt:
 
     Task: Fix the issue described below {% if include_project_paths %}in the following projects: {{project_paths}}{% endif %}
 
-    CRITICAL: You MUST leverage the AL LSP and MCP server to navigate the codebase and validate the your code changes.
-
     Important constraints:
     - Do NOT modify any testing logic or test files
     - Focus solely on fixing the reported issue
@@ -38,8 +36,6 @@ prompt:
     Task: Generate ONE NEW test case that reproduce the issue described below {% if include_project_paths %}in the following projects: {{project_paths}}{% endif %}
       The tests should fail against the current codebase (unfixed) and should pass once the issue is fixed.
     {% endif %}
-
-    CRITICAL: You MUST leverage the AL LSP and MCP server to navigate the codebase and validate the your code changes.
 
     Important constraints:
     - Do NOT modify any production code or existing tests

--- a/src/bcbench/agent/shared/hooks/log-tool-usage.ps1
+++ b/src/bcbench/agent/shared/hooks/log-tool-usage.ps1
@@ -5,6 +5,18 @@ try {
     $toolName = if ($inputJson.tool_name) { $inputJson.tool_name } else { $inputJson.toolName }
     $timestamp = $inputJson.timestamp
 
+    # LSP calls share the tool name "lsp"; the specific operation (findReferences, goToDefinition, hover, ...) lives in the tool arguments.
+    # Capture it as an "lsp:<operation>" sub-label so usage stats stay meaningful.
+    if ($toolName -eq "lsp") {
+        $toolArgs = if ($null -ne $inputJson.toolArgs) { $inputJson.toolArgs } else { $inputJson.tool_input }
+        if ($toolArgs -is [string]) {
+            try { $toolArgs = $toolArgs | ConvertFrom-Json } catch { $toolArgs = $null }
+        }
+        if ($toolArgs -and $toolArgs.operation) {
+            $toolName = "lsp:$($toolArgs.operation)"
+        }
+    }
+
     if ($toolName -and $env:BCBENCH_TOOL_LOG) {
         $entry = @{ tool_name = $toolName; timestamp = $timestamp } | ConvertTo-Json -Compress
         Add-Content -Path $env:BCBENCH_TOOL_LOG -Value $entry -Encoding UTF8

--- a/src/bcbench/agent/shared/lsp.py
+++ b/src/bcbench/agent/shared/lsp.py
@@ -36,7 +36,7 @@ def _resolve_symbol_paths(entry: BaseDatasetEntry, category: EvaluationCategory,
         return package_cache_paths, assembly_probing_paths
 
     raise AgentError(
-        f"No AL symbols found for BC v{entry.environment_setup_version}. Run `./scripts/Download-BCSymbols.ps1 -Category {category} -InstanceId {entry.instance_id}` (no container required) and retry."
+        f"No AL symbols found for BC v{entry.environment_setup_version}. Run `./scripts/Download-BCSymbols.ps1 -Category {category.value} -InstanceId {entry.instance_id}` (no container required) and retry."
     )
 
 

--- a/src/bcbench/agent/shared/lsp.py
+++ b/src/bcbench/agent/shared/lsp.py
@@ -18,7 +18,7 @@ _AL_LSP_PLUGIN_FOLDER = "al-lsp-plugin"
 _AL_LSP_MANIFEST = {"name": "al-lsp"}
 
 
-def _resolve_symbol_paths(entry: BaseDatasetEntry, category: EvaluationCategory, container_name: str) -> tuple[list[str], list[str]]:
+def _resolve_symbol_paths(entry: BaseDatasetEntry, category: EvaluationCategory, container_name: str, country: str = "w1") -> tuple[list[str], list[str]]:
     """Resolve (package_cache_paths, assembly_probing_paths) for the LSP server.
 
     Prefers the container's compiler folder when available — its single flat layout is the exact same arg shape AL-MCP uses.
@@ -30,7 +30,7 @@ def _resolve_symbol_paths(entry: BaseDatasetEntry, category: EvaluationCategory,
             logger.info(f"Using container compiler-folder symbols: {symbols_folder}")
             return [str(symbols_folder)], build_assembly_probing_paths(compiler_folder)
 
-    artifact_paths = resolve_artifact_lsp_paths(entry.environment_setup_version)
+    artifact_paths = resolve_artifact_lsp_paths(entry.environment_setup_version, country)
     if artifact_paths is not None:
         package_cache_paths, assembly_probing_paths = artifact_paths
         logger.info(f"Using BC artifact cache symbols for v{entry.environment_setup_version}: {package_cache_paths}")

--- a/src/bcbench/agent/shared/lsp.py
+++ b/src/bcbench/agent/shared/lsp.py
@@ -1,0 +1,95 @@
+import json
+from pathlib import Path
+
+from bcbench.agent.shared.altool_paths import (
+    build_assembly_probing_paths,
+    compiler_symbol_folder_for_container,
+    resolve_artifact_lsp_paths,
+    set_runtime_version,
+)
+from bcbench.dataset import BaseDatasetEntry
+from bcbench.exceptions import AgentError
+from bcbench.logger import get_logger
+from bcbench.types import EvaluationCategory
+
+logger = get_logger(__name__)
+
+_AL_LSP_RELATIVE_PATH = Path(".github") / "lsp.json"
+
+
+def _resolve_symbol_paths(entry: BaseDatasetEntry, category: EvaluationCategory, container_name: str) -> tuple[list[str], list[str]]:
+    """Resolve (package_cache_paths, assembly_probing_paths) for the LSP server.
+
+    Prefers the container's compiler folder when available — its single flat layout is the exact same arg shape AL-MCP uses.
+    Falls back to the raw BC artifact cache for container-free local runs. Raises a clear error pointing at the symbol-download script when neither is present.
+    """
+    if container_name:
+        compiler_folder, symbols_folder = compiler_symbol_folder_for_container(container_name)
+        if symbols_folder.is_dir():
+            logger.info(f"Using container compiler-folder symbols: {symbols_folder}")
+            return [str(symbols_folder)], build_assembly_probing_paths(compiler_folder)
+
+    artifact_paths = resolve_artifact_lsp_paths(entry.environment_setup_version)
+    if artifact_paths is not None:
+        package_cache_paths, assembly_probing_paths = artifact_paths
+        logger.info(f"Using BC artifact cache symbols for v{entry.environment_setup_version}: {package_cache_paths}")
+        return package_cache_paths, assembly_probing_paths
+
+    raise AgentError(
+        f"No AL symbols found for BC v{entry.environment_setup_version}. Run `./scripts/Download-BCSymbols.ps1 -Category {category} -InstanceId {entry.instance_id}` (no container required) and retry."
+    )
+
+
+def _build_lsp_args(project_paths: list[str], package_cache_paths: list[str], assembly_probing_paths: list[str]) -> list[str]:
+    # `launchlspserver [<projects>...] [options]` — projects come first as positional args.
+    args: list[str] = ["launchlspserver", *project_paths, "--packagecachepath", *package_cache_paths]
+    if assembly_probing_paths:
+        args.extend(["--assemblyprobingpaths", *assembly_probing_paths])
+    return args
+
+
+def build_lsp_config(entry: BaseDatasetEntry, category: EvaluationCategory, repo_path: Path, al_lsp: bool, container_name: str = "") -> bool:
+    """Write Copilot's project-level LSP config to <repo_path>/.github/lsp.json.
+
+    When ``al_lsp=False``, removes any stale config left over from a previous run and returns False.
+    When True, writes the `lspServers.altool` entry pointing at `altool launchlspserver` and returns True.
+    """
+    lsp_config_path = repo_path / _AL_LSP_RELATIVE_PATH
+
+    if not al_lsp:
+        if lsp_config_path.is_file():
+            lsp_config_path.unlink()
+            logger.info(f"Removed stale LSP config: {lsp_config_path}")
+        return False
+
+    project_paths = [str(repo_path / p) for p in entry.project_paths]
+    set_runtime_version(project_paths)
+
+    package_cache_paths, assembly_probing_paths = _resolve_symbol_paths(entry, category, container_name)
+
+    args = _build_lsp_args(
+        project_paths=project_paths,
+        package_cache_paths=package_cache_paths,
+        assembly_probing_paths=assembly_probing_paths,
+    )
+
+    # Copilot CLI resolves `command` via PATH (absolute paths are silently rejected with
+    # "Server <name> is configured but not available"). `al` is the published altool
+    # wrapper installed via the .NET tool — it must be on PATH.
+    lsp_config = {
+        "lspServers": {
+            "altool": {
+                "command": "al",
+                "args": args,
+                "fileExtensions": {".al": "al"},
+            }
+        }
+    }
+
+    lsp_config_path.parent.mkdir(parents=True, exist_ok=True)
+    lsp_config_path.write_text(json.dumps(lsp_config, indent=2), encoding="utf-8")
+
+    logger.info(f"Wrote AL LSP config: {lsp_config_path}")
+    logger.debug(f"LSP configuration: {json.dumps(lsp_config, indent=2)}")
+
+    return True

--- a/src/bcbench/agent/shared/lsp.py
+++ b/src/bcbench/agent/shared/lsp.py
@@ -1,5 +1,3 @@
-import json
-import shutil
 from pathlib import Path
 
 from bcbench.agent.shared.altool_paths import (
@@ -8,6 +6,7 @@ from bcbench.agent.shared.altool_paths import (
     resolve_artifact_lsp_paths,
     set_runtime_version,
 )
+from bcbench.agent.shared.plugin import remove_agent_plugin, write_agent_plugin
 from bcbench.dataset import BaseDatasetEntry
 from bcbench.exceptions import AgentError
 from bcbench.logger import get_logger
@@ -15,12 +14,8 @@ from bcbench.types import AgentType, EvaluationCategory
 
 logger = get_logger(__name__)
 
-# Per-task plugin folder location. Both Copilot CLI and Claude Code accept
-# `--plugin-dir <path>` for ad-hoc plugin loading and both look for the
-# manifest under `.claude-plugin/plugin.json`, so a single neutral path works
-# for either agent. Lives under `.bcbench/` so it's visibly BC-Bench-owned
-# and won't collide with either agent's auto-discovery paths.
-_AL_LSP_PLUGIN_RELATIVE_PATH = Path(".bcbench") / "al-lsp-plugin"
+_AL_LSP_PLUGIN_FOLDER = "al-lsp-plugin"
+_AL_LSP_MANIFEST = {"name": "al-lsp"}
 
 
 def _resolve_symbol_paths(entry: BaseDatasetEntry, category: EvaluationCategory, container_name: str) -> tuple[list[str], list[str]]:
@@ -57,8 +52,7 @@ def _build_lsp_args(project_paths: list[str], package_cache_paths: list[str], as
 def _lsp_config_for(agent_type: AgentType, args: list[str]) -> dict:
     """Build the agent-specific `.lsp.json` content.
 
-    Both agents launch the same `al launchlspserver` process — only the surrounding
-    LSP-routing schema differs:
+    Both agents launch the same `al launchlspserver` process — only the surrounding LSP-routing schema differs:
 
     - Copilot CLI expects `{ "lspServers": { name: { ..., "fileExtensions": {".ext": "lang"} } } }`
     - Claude Code expects `{ name: { ..., "extensionToLanguage": {".ext": "lang"} } }` (no wrapper, different extension key)
@@ -76,46 +70,23 @@ def _lsp_config_for(agent_type: AgentType, args: list[str]) -> dict:
 
 
 def build_al_lsp_plugin(entry: BaseDatasetEntry, category: EvaluationCategory, repo_path: Path, agent_type: AgentType, al_lsp: bool, container_name: str = "") -> Path | None:
-    """Build a per-task plugin folder containing the AL LSP server, return its path or None.
+    """Build a per-task AL-LSP plugin folder, return its path or None.
 
-    Both Copilot CLI and Claude Code load this via ``--plugin-dir <path>`` for a single session
-    — no marketplace registration, no global state, no cross-run plugin leakage. The plugin
-    folder layout is identical between agents; only the LSP-routing schema in ``.lsp.json``
-    differs (see :func:`_lsp_config_for`).
-
-    Layout written under ``<repo>/.bcbench/al-lsp-plugin/``::
-
-        .claude-plugin/plugin.json   — minimal manifest (only ``name`` is required;
-                                       both CLIs check this path)
-        .lsp.json                    — LSP server config in the agent's schema
-
-    Returns the plugin folder path (to be passed as ``--plugin-dir``), or None when disabled.
+    Loaded by both Copilot CLI and Claude Code via ``--plugin-dir <path>`` for a single
+    session — no marketplace registration, no global state, no cross-run plugin leakage.
+    Folder layout is identical between agents; only the LSP-routing schema in
+    ``.lsp.json`` differs (see :func:`_lsp_config_for`).
     """
-    plugin_dir = repo_path / _AL_LSP_PLUGIN_RELATIVE_PATH
-
     if not al_lsp:
-        if plugin_dir.exists():
-            shutil.rmtree(plugin_dir)
-            logger.info(f"Removed stale AL LSP plugin: {plugin_dir}")
+        remove_agent_plugin(repo_path, _AL_LSP_PLUGIN_FOLDER)
         return None
 
     project_paths = [str(repo_path / p) for p in entry.project_paths]
     set_runtime_version(project_paths)
     package_cache_paths, assembly_probing_paths = _resolve_symbol_paths(entry, category, container_name)
     args = _build_lsp_args(project_paths, package_cache_paths, assembly_probing_paths)
-
-    plugin_manifest = {
-        "name": "al-lsp",
-        "version": "1.0.0",
-        "description": "AL Language Server for Business Central agentic development",
-    }
     lsp_config = _lsp_config_for(agent_type, args)
 
-    (plugin_dir / ".claude-plugin").mkdir(parents=True, exist_ok=True)
-    (plugin_dir / ".claude-plugin" / "plugin.json").write_text(json.dumps(plugin_manifest, indent=2), encoding="utf-8")
-    (plugin_dir / ".lsp.json").write_text(json.dumps(lsp_config, indent=2), encoding="utf-8")
-
-    logger.info(f"Wrote AL LSP plugin for {agent_type.value}: {plugin_dir}")
-    logger.debug(f"LSP configuration: {json.dumps(lsp_config, indent=2)}")
-
+    plugin_dir = write_agent_plugin(repo_path, _AL_LSP_PLUGIN_FOLDER, _AL_LSP_MANIFEST, {".lsp.json": lsp_config})
+    logger.debug(f"AL LSP configuration for {agent_type.value}: {lsp_config}")
     return plugin_dir

--- a/src/bcbench/agent/shared/lsp.py
+++ b/src/bcbench/agent/shared/lsp.py
@@ -4,7 +4,6 @@ from bcbench.agent.shared.altool_paths import (
     build_assembly_probing_paths,
     compiler_symbol_folder_for_container,
     resolve_artifact_lsp_paths,
-    set_runtime_version,
 )
 from bcbench.agent.shared.plugin import remove_agent_plugin, write_agent_plugin
 from bcbench.dataset import BaseDatasetEntry
@@ -84,7 +83,6 @@ def build_al_lsp_plugin(entry: BaseDatasetEntry, category: EvaluationCategory, r
         return None
 
     project_paths = [str(repo_path / p) for p in entry.project_paths]
-    set_runtime_version(project_paths)
     package_cache_paths, assembly_probing_paths = _resolve_symbol_paths(entry, category, container_name)
     args = _build_lsp_args(project_paths, package_cache_paths, assembly_probing_paths)
     lsp_config = _lsp_config_for(agent_type, args)

--- a/src/bcbench/agent/shared/lsp.py
+++ b/src/bcbench/agent/shared/lsp.py
@@ -1,4 +1,5 @@
 import json
+import shutil
 from pathlib import Path
 
 from bcbench.agent.shared.altool_paths import (
@@ -10,11 +11,16 @@ from bcbench.agent.shared.altool_paths import (
 from bcbench.dataset import BaseDatasetEntry
 from bcbench.exceptions import AgentError
 from bcbench.logger import get_logger
-from bcbench.types import EvaluationCategory
+from bcbench.types import AgentType, EvaluationCategory
 
 logger = get_logger(__name__)
 
-_AL_LSP_RELATIVE_PATH = Path(".github") / "lsp.json"
+# Per-task plugin folder location. Both Copilot CLI and Claude Code accept
+# `--plugin-dir <path>` for ad-hoc plugin loading and both look for the
+# manifest under `.claude-plugin/plugin.json`, so a single neutral path works
+# for either agent. Lives under `.bcbench/` so it's visibly BC-Bench-owned
+# and won't collide with either agent's auto-discovery paths.
+_AL_LSP_PLUGIN_RELATIVE_PATH = Path(".bcbench") / "al-lsp-plugin"
 
 
 def _resolve_symbol_paths(entry: BaseDatasetEntry, category: EvaluationCategory, container_name: str) -> tuple[list[str], list[str]]:
@@ -48,48 +54,68 @@ def _build_lsp_args(project_paths: list[str], package_cache_paths: list[str], as
     return args
 
 
-def build_lsp_config(entry: BaseDatasetEntry, category: EvaluationCategory, repo_path: Path, al_lsp: bool, container_name: str = "") -> bool:
-    """Write Copilot's project-level LSP config to <repo_path>/.github/lsp.json.
+def _lsp_config_for(agent_type: AgentType, args: list[str]) -> dict:
+    """Build the agent-specific `.lsp.json` content.
 
-    When ``al_lsp=False``, removes any stale config left over from a previous run and returns False.
-    When True, writes the `lspServers.altool` entry pointing at `altool launchlspserver` and returns True.
+    Both agents launch the same `al launchlspserver` process — only the surrounding
+    LSP-routing schema differs:
+
+    - Copilot CLI expects `{ "lspServers": { name: { ..., "fileExtensions": {".ext": "lang"} } } }`
+    - Claude Code expects `{ name: { ..., "extensionToLanguage": {".ext": "lang"} } }` (no wrapper, different extension key)
+
+    `command: "al"` is unqualified by design: Copilot CLI silently rejects absolute paths in LSP
+    `command` ("Server <name> is configured but not available"), so the published `altool` wrapper
+    (`al`) must resolve via PATH on both sides.
     """
-    lsp_config_path = repo_path / _AL_LSP_RELATIVE_PATH
+    server = {"command": "al", "args": args}
+    match agent_type:
+        case AgentType.COPILOT:
+            return {"lspServers": {"altool": {**server, "fileExtensions": {".al": "al"}}}}
+        case AgentType.CLAUDE:
+            return {"altool": {**server, "extensionToLanguage": {".al": "al"}}}
+
+
+def build_al_lsp_plugin(entry: BaseDatasetEntry, category: EvaluationCategory, repo_path: Path, agent_type: AgentType, al_lsp: bool, container_name: str = "") -> Path | None:
+    """Build a per-task plugin folder containing the AL LSP server, return its path or None.
+
+    Both Copilot CLI and Claude Code load this via ``--plugin-dir <path>`` for a single session
+    — no marketplace registration, no global state, no cross-run plugin leakage. The plugin
+    folder layout is identical between agents; only the LSP-routing schema in ``.lsp.json``
+    differs (see :func:`_lsp_config_for`).
+
+    Layout written under ``<repo>/.bcbench/al-lsp-plugin/``::
+
+        .claude-plugin/plugin.json   — minimal manifest (only ``name`` is required;
+                                       both CLIs check this path)
+        .lsp.json                    — LSP server config in the agent's schema
+
+    Returns the plugin folder path (to be passed as ``--plugin-dir``), or None when disabled.
+    """
+    plugin_dir = repo_path / _AL_LSP_PLUGIN_RELATIVE_PATH
 
     if not al_lsp:
-        if lsp_config_path.is_file():
-            lsp_config_path.unlink()
-            logger.info(f"Removed stale LSP config: {lsp_config_path}")
-        return False
+        if plugin_dir.exists():
+            shutil.rmtree(plugin_dir)
+            logger.info(f"Removed stale AL LSP plugin: {plugin_dir}")
+        return None
 
     project_paths = [str(repo_path / p) for p in entry.project_paths]
     set_runtime_version(project_paths)
-
     package_cache_paths, assembly_probing_paths = _resolve_symbol_paths(entry, category, container_name)
+    args = _build_lsp_args(project_paths, package_cache_paths, assembly_probing_paths)
 
-    args = _build_lsp_args(
-        project_paths=project_paths,
-        package_cache_paths=package_cache_paths,
-        assembly_probing_paths=assembly_probing_paths,
-    )
-
-    # Copilot CLI resolves `command` via PATH (absolute paths are silently rejected with
-    # "Server <name> is configured but not available"). `al` is the published altool
-    # wrapper installed via the .NET tool — it must be on PATH.
-    lsp_config = {
-        "lspServers": {
-            "altool": {
-                "command": "al",
-                "args": args,
-                "fileExtensions": {".al": "al"},
-            }
-        }
+    plugin_manifest = {
+        "name": "al-lsp",
+        "version": "1.0.0",
+        "description": "AL Language Server for Business Central agentic development",
     }
+    lsp_config = _lsp_config_for(agent_type, args)
 
-    lsp_config_path.parent.mkdir(parents=True, exist_ok=True)
-    lsp_config_path.write_text(json.dumps(lsp_config, indent=2), encoding="utf-8")
+    (plugin_dir / ".claude-plugin").mkdir(parents=True, exist_ok=True)
+    (plugin_dir / ".claude-plugin" / "plugin.json").write_text(json.dumps(plugin_manifest, indent=2), encoding="utf-8")
+    (plugin_dir / ".lsp.json").write_text(json.dumps(lsp_config, indent=2), encoding="utf-8")
 
-    logger.info(f"Wrote AL LSP config: {lsp_config_path}")
+    logger.info(f"Wrote AL LSP plugin for {agent_type.value}: {plugin_dir}")
     logger.debug(f"LSP configuration: {json.dumps(lsp_config, indent=2)}")
 
-    return True
+    return plugin_dir

--- a/src/bcbench/agent/shared/lsp.py
+++ b/src/bcbench/agent/shared/lsp.py
@@ -67,6 +67,8 @@ def _lsp_config_for(agent_type: AgentType, args: list[str]) -> dict:
             return {"lspServers": {"altool": {**server, "fileExtensions": {".al": "al"}}}}
         case AgentType.CLAUDE:
             return {"altool": {**server, "extensionToLanguage": {".al": "al"}}}
+        case _:
+            raise AgentError(f"Unsupported agent type for AL LSP config: {agent_type}")
 
 
 def build_al_lsp_plugin(entry: BaseDatasetEntry, category: EvaluationCategory, repo_path: Path, agent_type: AgentType, al_lsp: bool, container_name: str = "") -> Path | None:

--- a/src/bcbench/agent/shared/mcp.py
+++ b/src/bcbench/agent/shared/mcp.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from jinja2 import Template
 
-from bcbench.agent.shared.altool_paths import build_assembly_probing_paths, compiler_symbol_folder_for_container, set_runtime_version
+from bcbench.agent.shared.altool_paths import build_assembly_probing_paths, compiler_symbol_folder_for_container
 from bcbench.dataset import BaseDatasetEntry
 from bcbench.exceptions import AgentError
 from bcbench.logger import get_logger
@@ -63,8 +63,6 @@ def build_mcp_config(config: dict[str, Any], entry: BaseDatasetEntry, repo_path:
         # Insert project paths right after "launchmcpserver" (positional args must precede options)
         insert_idx: int = al_server["args"].index("launchmcpserver") + 1
         al_server["args"][insert_idx:insert_idx] = project_paths
-
-        set_runtime_version(project_paths)
 
         # Each path must be a separate arg (System.CommandLine expects space-separated values)
         assembly_probing_paths = build_assembly_probing_paths(compiler_folder)

--- a/src/bcbench/agent/shared/mcp.py
+++ b/src/bcbench/agent/shared/mcp.py
@@ -4,120 +4,13 @@ from pathlib import Path
 from typing import Any
 
 from jinja2 import Template
-from packaging.version import Version
 
+from bcbench.agent.shared.altool_paths import build_assembly_probing_paths, compiler_symbol_folder_for_container, set_runtime_version
 from bcbench.dataset import BaseDatasetEntry
 from bcbench.exceptions import AgentError
 from bcbench.logger import get_logger
 
 logger = get_logger(__name__)
-
-# .NET major versions excluded from runtime detection (unstable/preview)
-# See: navcontainerhelper/InitializeModule.ps1 line 62
-_EXCLUDED_DOTNET_MAJORS = {9, 10}
-_DOTNET_SHARED = Path(r"C:\Program Files\dotnet\shared")
-
-# Offset from BC platform major version to AL runtime version.
-# E.g. platform 25.0 (BC 2024w2) → runtime 14.0, platform 27.0 → runtime 16.0
-# See: BC-DeveloperExperience RuntimeVersion.cs
-_PLATFORM_TO_RUNTIME_OFFSET = 11
-
-
-def _detect_dotnet_runtime_version() -> Version | None:
-    dotnet_shared = _DOTNET_SHARED
-    netcore_folder = dotnet_shared / "Microsoft.NETCore.App"
-    aspnetcore_folder = dotnet_shared / "Microsoft.AspNetCore.App"
-
-    if not netcore_folder.is_dir():
-        return None
-
-    versions: list[Version] = []
-    for entry in netcore_folder.iterdir():
-        if not entry.is_dir() or not (aspnetcore_folder / entry.name).is_dir():
-            continue
-        try:
-            v = Version(entry.name)
-            if v.major not in _EXCLUDED_DOTNET_MAJORS:
-                versions.append(v)
-        except Exception:
-            continue
-
-    return max(versions) if versions else None
-
-
-def _build_assembly_probing_paths(compiler_folder: Path) -> list[str]:
-    """Build list of assembly probing paths for the AL compiler.
-
-    The AL compiler recursively searches subdirectories (AssemblyLocatorBase.cs uses
-    SearchOption.AllDirectories), so a single ``dlls`` entry covers Service, OpenXML,
-    Mock Assemblies, etc. System .NET runtime paths must be added separately since
-    they live outside the compiler folder.
-
-    Path order matters: .NET runtime paths must come BEFORE dlls to avoid stale
-    type-forwarding stubs (e.g. XrmV91's 5.0.0.0 DLLs) shadowing the real types.
-    This matches BCContainerHelper's ordering (OpenXML → dotnet → Service).
-
-    Each path must be a separate CLI argument (System.CommandLine with
-    AllowMultipleArgumentsPerToken expects space-separated values, NOT semicolons).
-    """
-    paths: list[str] = []
-    dlls_path = compiler_folder / "dlls"
-
-    # .NET runtime paths first — avoids stale type-forwarding stubs in dlls\ subfolders
-    shared_folder = dlls_path / "shared"
-    if shared_folder.is_dir():
-        paths.append(str(shared_folder))
-    else:
-        dotnet_version = _detect_dotnet_runtime_version()
-        if dotnet_version:
-            paths.append(str(_DOTNET_SHARED / "Microsoft.NETCore.App" / str(dotnet_version)))
-            paths.append(str(_DOTNET_SHARED / "Microsoft.AspNetCore.App" / str(dotnet_version)))
-            logger.info(f"Using system .NET runtime {dotnet_version} for assembly probing")
-        else:
-            logger.warning("No compatible .NET runtime found. DotNet interop types may not resolve.")
-
-    # dlls\ after dotnet — recursively covers Service, OpenXML, Mock Assemblies, etc.
-    if dlls_path.is_dir():
-        paths.append(str(dlls_path))
-
-    return paths
-
-
-def _set_runtime_version(project_paths: list[str]) -> None:
-    """Set the AL runtime version in each project's app.json based on platform version.
-
-    The AL MCP compiler (altool 17.0+) defaults to the latest runtime when "runtime"
-    is not set in app.json, enabling newer validation rules that reject older code.
-    Setting the runtime to match the platform version makes the compiler behave
-    like the version that originally compiled the code.
-    """
-    for project_path in project_paths:
-        app_json_path = Path(project_path) / "app.json"
-        if not app_json_path.is_file():
-            continue
-
-        try:
-            app_json = json.loads(app_json_path.read_text(encoding="utf-8-sig"))
-        except (json.JSONDecodeError, OSError):
-            continue
-
-        if app_json.get("runtime"):
-            continue
-
-        platform = app_json.get("platform", "")
-        try:
-            platform_major = int(platform.split(".")[0])
-        except (ValueError, IndexError):
-            continue
-
-        runtime_major = platform_major - _PLATFORM_TO_RUNTIME_OFFSET
-        if runtime_major < 1:
-            continue
-
-        runtime = f"{runtime_major}.0"
-        app_json["runtime"] = runtime
-        app_json_path.write_text(json.dumps(app_json, indent=2, ensure_ascii=False), encoding="utf-8")
-        logger.info(f"Set runtime={runtime} in {app_json_path} (platform {platform})")
 
 
 def _build_server_entry(server: dict[str, Any], template_context: dict[str, Any]) -> tuple[str, dict[str, Any]]:
@@ -156,8 +49,8 @@ def build_mcp_config(config: dict[str, Any], entry: BaseDatasetEntry, repo_path:
     template_context: dict[str, str | Path] = {"repo_path": repo_path}
 
     if al_mcp:
-        compiler_folder = Path(r"C:\ProgramData\BcContainerHelper\compiler") / container_name
-        template_context["package_cache_path"] = str(compiler_folder / "symbols")
+        compiler_folder, symbols_folder = compiler_symbol_folder_for_container(container_name)
+        template_context["package_cache_path"] = str(symbols_folder)
 
         al_server = next(s for s in mcp_servers if s["name"] == "altool")
         project_paths = [str(repo_path / p) for p in entry.project_paths]
@@ -166,10 +59,10 @@ def build_mcp_config(config: dict[str, Any], entry: BaseDatasetEntry, repo_path:
         insert_idx: int = al_server["args"].index("launchmcpserver") + 1
         al_server["args"][insert_idx:insert_idx] = project_paths
 
-        _set_runtime_version(project_paths)
+        set_runtime_version(project_paths)
 
         # Each path must be a separate arg (System.CommandLine expects space-separated values)
-        assembly_probing_paths = _build_assembly_probing_paths(compiler_folder)
+        assembly_probing_paths = build_assembly_probing_paths(compiler_folder)
         if assembly_probing_paths:
             al_server["args"].extend(["--assemblyprobingpaths", *assembly_probing_paths])
             logger.info(f"Assembly probing paths: {assembly_probing_paths}")

--- a/src/bcbench/agent/shared/plugin.py
+++ b/src/bcbench/agent/shared/plugin.py
@@ -1,0 +1,47 @@
+import json
+import shutil
+from pathlib import Path
+
+from bcbench.logger import get_logger
+
+logger = get_logger(__name__)
+
+# Both Copilot CLI and Claude Code accept `--plugin-dir <path>` (repeatable) for ad-hoc plugin loading, and both look for the manifest at `.claude-plugin/plugin.json`
+# We keep plugins under `.bcbench/` to avoid colliding with agent-reserved dirs (`.claude/`, `.github/`)
+_PLUGIN_ROOT = Path(".bcbench")
+
+
+def _plugin_dir_for(repo_path: Path, folder: str) -> Path:
+    return repo_path / _PLUGIN_ROOT / folder
+
+
+def write_agent_plugin(repo_path: Path, folder: str, manifest: dict, files: dict[str, dict]) -> Path:
+    """Write a plugin folder and return its path.
+
+    Args:
+        repo_path: Repository root.
+        folder: Directory name under ``<repo>/.bcbench/``.
+        manifest: Manifest written to ``.claude-plugin/plugin.json``.
+        files: Plugin-relative paths mapped to JSON-serializable content.
+
+    Returns:
+        The plugin directory path for ``--plugin-dir``.
+    """
+    plugin_dir = _plugin_dir_for(repo_path, folder)
+
+    (plugin_dir / ".claude-plugin").mkdir(parents=True, exist_ok=True)
+    (plugin_dir / ".claude-plugin" / "plugin.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    for rel_path, content in files.items():
+        target = plugin_dir / rel_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(json.dumps(content, indent=2), encoding="utf-8")
+
+    logger.info(f"Wrote agent plugin '{folder}': {plugin_dir}")
+    return plugin_dir
+
+
+def remove_agent_plugin(repo_path: Path, folder: str) -> None:
+    plugin_dir = _plugin_dir_for(repo_path, folder)
+    if plugin_dir.exists():
+        shutil.rmtree(plugin_dir)
+        logger.info(f"Removed stale agent plugin '{folder}': {plugin_dir}")

--- a/src/bcbench/agent/shared/plugin.py
+++ b/src/bcbench/agent/shared/plugin.py
@@ -1,5 +1,6 @@
 import json
 import shutil
+from collections.abc import Mapping
 from pathlib import Path
 
 from bcbench.logger import get_logger
@@ -15,7 +16,7 @@ def _plugin_dir_for(repo_path: Path, folder: str) -> Path:
     return repo_path / _PLUGIN_ROOT / folder
 
 
-def write_agent_plugin(repo_path: Path, folder: str, manifest: dict[str, object], files: dict[str, object]) -> Path:
+def write_agent_plugin(repo_path: Path, folder: str, manifest: Mapping[str, object], files: Mapping[str, object]) -> Path:
     """Write a plugin folder and return its path.
 
     Args:

--- a/src/bcbench/agent/shared/plugin.py
+++ b/src/bcbench/agent/shared/plugin.py
@@ -32,7 +32,7 @@ def write_agent_plugin(repo_path: Path, folder: str, manifest: dict, files: dict
     (plugin_dir / ".claude-plugin").mkdir(parents=True, exist_ok=True)
     (plugin_dir / ".claude-plugin" / "plugin.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
     for rel_path, content in files.items():
-        target = plugin_dir / rel_path
+        target: Path = plugin_dir / rel_path
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_text(json.dumps(content, indent=2), encoding="utf-8")
 

--- a/src/bcbench/agent/shared/plugin.py
+++ b/src/bcbench/agent/shared/plugin.py
@@ -15,7 +15,7 @@ def _plugin_dir_for(repo_path: Path, folder: str) -> Path:
     return repo_path / _PLUGIN_ROOT / folder
 
 
-def write_agent_plugin(repo_path: Path, folder: str, manifest: dict, files: dict[str, dict]) -> Path:
+def write_agent_plugin(repo_path: Path, folder: str, manifest: dict[str, object], files: dict[str, object]) -> Path:
     """Write a plugin folder and return its path.
 
     Args:

--- a/src/bcbench/commands/evaluate.py
+++ b/src/bcbench/commands/evaluate.py
@@ -51,6 +51,7 @@ def evaluate_copilot(
     output_dir: OutputDir = _config.paths.evaluation_results_path,
     run_id: RunId = "copilot_test_run",
     al_mcp: Annotated[bool, typer.Option("--al-mcp", help="Enable AL MCP server")] = False,
+    al_lsp: Annotated[bool, typer.Option("--al-lsp", help="Enable AL LSP server")] = False,
 ) -> None:
     """
     Evaluate GitHub Copilot CLI on single dataset entry.
@@ -84,6 +85,7 @@ def evaluate_copilot(
             model=ctx.model,
             output_dir=ctx.result_dir,
             al_mcp=al_mcp if ctx.container else False,
+            al_lsp=al_lsp,
             container_name=ctx.get_container().name if ctx.container else "",
         ),
     )

--- a/src/bcbench/commands/evaluate.py
+++ b/src/bcbench/commands/evaluate.py
@@ -106,6 +106,7 @@ def evaluate_claude_code(
     output_dir: OutputDir = _config.paths.evaluation_results_path,
     run_id: RunId = "claude_code_test_run",
     al_mcp: Annotated[bool, typer.Option("--al-mcp", help="Enable AL MCP server")] = False,
+    al_lsp: Annotated[bool, typer.Option("--al-lsp", help="Enable AL LSP server")] = False,
 ) -> None:
     """
     Evaluate Claude Code on single dataset entry.
@@ -139,6 +140,7 @@ def evaluate_claude_code(
             model=ctx.model,
             output_dir=ctx.result_dir,
             al_mcp=al_mcp if ctx.container else False,
+            al_lsp=al_lsp,
             container_name=ctx.get_container().name if ctx.container else "",
         ),
     )

--- a/src/bcbench/commands/run.py
+++ b/src/bcbench/commands/run.py
@@ -65,6 +65,7 @@ def run_claude(
     repo_path: RepoPath = _config.paths.testbed_path,
     output_dir: OutputDir = _config.paths.evaluation_results_path,
     al_mcp: Annotated[bool, typer.Option("--al-mcp", help="Enable AL MCP server")] = False,
+    al_lsp: Annotated[bool, typer.Option("--al-lsp", help="Enable AL LSP server")] = False,
 ) -> None:
     """
     Run Claude Code on a single entry to generate a patch (without building/testing).
@@ -77,4 +78,13 @@ def run_claude(
     entry = category.entry_class.load(category.dataset_path, entry_id=entry_id)[0]
     category.pipeline.setup_workspace(entry, repo_path)
 
-    run_claude_code(entry=entry, repo_path=repo_path, model=model, category=category, output_dir=output_dir, al_mcp=al_mcp, container_name=container_name)
+    run_claude_code(
+        entry=entry,
+        repo_path=repo_path,
+        model=model,
+        category=category,
+        output_dir=output_dir,
+        al_mcp=al_mcp if container_name else False,
+        al_lsp=al_lsp,
+        container_name=container_name or "",
+    )

--- a/src/bcbench/commands/run.py
+++ b/src/bcbench/commands/run.py
@@ -31,6 +31,7 @@ def run_copilot(
     repo_path: RepoPath = _config.paths.testbed_path,
     output_dir: OutputDir = _config.paths.evaluation_results_path,
     al_mcp: Annotated[bool, typer.Option("--al-mcp", help="Enable AL MCP server")] = False,
+    al_lsp: Annotated[bool, typer.Option("--al-lsp", help="Enable AL LSP server")] = False,
 ) -> None:
     """
     Run GitHub Copilot CLI on a single entry to generate a patch (without building/testing).
@@ -50,6 +51,7 @@ def run_copilot(
         category=category,
         output_dir=output_dir,
         al_mcp=al_mcp if container_name else False,
+        al_lsp=al_lsp,
         container_name=container_name or "",
     )
 

--- a/src/bcbench/commands/run.py
+++ b/src/bcbench/commands/run.py
@@ -52,7 +52,7 @@ def run_copilot(
         output_dir=output_dir,
         al_mcp=al_mcp if container_name else False,
         al_lsp=al_lsp,
-        container_name=container_name or "",
+        container_name=container_name,
     )
 
 
@@ -86,5 +86,5 @@ def run_claude(
         output_dir=output_dir,
         al_mcp=al_mcp if container_name else False,
         al_lsp=al_lsp,
-        container_name=container_name or "",
+        container_name=container_name,
     )

--- a/src/bcbench/evaluate/bugfix.py
+++ b/src/bcbench/evaluate/bugfix.py
@@ -13,6 +13,7 @@ from bcbench.operations import (
     clean_project_paths,
     copy_problem_statement_folder,
     run_tests,
+    set_runtime_version,
     setup_repo_prebuild,
     stage_and_get_diff,
 )
@@ -30,6 +31,7 @@ class BugFixPipeline(EvaluationPipeline[BugFixEntry]):
     def setup_workspace(self, entry: BugFixEntry, repo_path: Path) -> None:
         setup_repo_prebuild(entry, repo_path)
         copy_problem_statement_folder(entry, repo_path)
+        set_runtime_version(entry.project_paths)
 
     def setup(self, context: EvaluationContext[BugFixEntry]) -> None:
         setup_repo_prebuild(context.entry, context.repo_path)
@@ -42,6 +44,7 @@ class BugFixPipeline(EvaluationPipeline[BugFixEntry]):
         )
 
         copy_problem_statement_folder(context.entry, context.repo_path)
+        set_runtime_version(context.entry.project_paths)
 
     def run_agent(self, context: EvaluationContext[BugFixEntry], agent_runner: Callable) -> None:
         with github_log_group(f"{context.agent_name} -- Entry: {context.entry.instance_id}"):

--- a/src/bcbench/evaluate/bugfix.py
+++ b/src/bcbench/evaluate/bugfix.py
@@ -31,7 +31,7 @@ class BugFixPipeline(EvaluationPipeline[BugFixEntry]):
     def setup_workspace(self, entry: BugFixEntry, repo_path: Path) -> None:
         setup_repo_prebuild(entry, repo_path)
         copy_problem_statement_folder(entry, repo_path)
-        set_runtime_version(entry.project_paths)
+        set_runtime_version(repo_path, entry.project_paths)
 
     def setup(self, context: EvaluationContext[BugFixEntry]) -> None:
         setup_repo_prebuild(context.entry, context.repo_path)
@@ -44,7 +44,7 @@ class BugFixPipeline(EvaluationPipeline[BugFixEntry]):
         )
 
         copy_problem_statement_folder(context.entry, context.repo_path)
-        set_runtime_version(context.entry.project_paths)
+        set_runtime_version(context.repo_path, context.entry.project_paths)
 
     def run_agent(self, context: EvaluationContext[BugFixEntry], agent_runner: Callable) -> None:
         with github_log_group(f"{context.agent_name} -- Entry: {context.entry.instance_id}"):

--- a/src/bcbench/evaluate/testgeneration.py
+++ b/src/bcbench/evaluate/testgeneration.py
@@ -63,7 +63,7 @@ class TestGenerationPipeline(EvaluationPipeline[TestGenEntry]):
     def setup_workspace(self, entry: TestGenEntry, repo_path: Path) -> None:
         setup_repo_prebuild(entry, repo_path)
         self._apply_input_postbuild(entry, repo_path)
-        set_runtime_version(entry.project_paths)
+        set_runtime_version(repo_path, entry.project_paths)
 
     def setup(self, context: EvaluationContext[TestGenEntry]) -> None:
         setup_repo_prebuild(context.entry, context.repo_path)
@@ -76,7 +76,7 @@ class TestGenerationPipeline(EvaluationPipeline[TestGenEntry]):
         )
 
         self._apply_input_postbuild(context.entry, context.repo_path)
-        set_runtime_version(context.entry.project_paths)
+        set_runtime_version(context.repo_path, context.entry.project_paths)
 
     def run_agent(self, context: EvaluationContext[TestGenEntry], agent_runner: Callable) -> None:
         with github_log_group(f"{context.agent_name} -- Entry: {context.entry.instance_id}"):

--- a/src/bcbench/evaluate/testgeneration.py
+++ b/src/bcbench/evaluate/testgeneration.py
@@ -21,6 +21,7 @@ from bcbench.operations import (
     stage_and_get_diff,
 )
 from bcbench.operations.bc_operations import run_test_suite
+from bcbench.operations.setup_operations import set_runtime_version
 from bcbench.results.testgeneration import TestGenerationResult
 from bcbench.types import EvaluationContext
 
@@ -62,6 +63,7 @@ class TestGenerationPipeline(EvaluationPipeline[TestGenEntry]):
     def setup_workspace(self, entry: TestGenEntry, repo_path: Path) -> None:
         setup_repo_prebuild(entry, repo_path)
         self._apply_input_postbuild(entry, repo_path)
+        set_runtime_version(entry.project_paths)
 
     def setup(self, context: EvaluationContext[TestGenEntry]) -> None:
         setup_repo_prebuild(context.entry, context.repo_path)
@@ -74,6 +76,7 @@ class TestGenerationPipeline(EvaluationPipeline[TestGenEntry]):
         )
 
         self._apply_input_postbuild(context.entry, context.repo_path)
+        set_runtime_version(context.entry.project_paths)
 
     def run_agent(self, context: EvaluationContext[TestGenEntry], agent_runner: Callable) -> None:
         with github_log_group(f"{context.agent_name} -- Entry: {context.entry.instance_id}"):

--- a/src/bcbench/operations/__init__.py
+++ b/src/bcbench/operations/__init__.py
@@ -18,7 +18,7 @@ from bcbench.operations.git_operations import (
 from bcbench.operations.hooks_operations import setup_hooks
 from bcbench.operations.instruction_operations import copy_problem_statement_folder, setup_custom_agent, setup_instructions_from_config
 from bcbench.operations.project_operations import categorize_projects
-from bcbench.operations.setup_operations import setup_repo_prebuild
+from bcbench.operations.setup_operations import set_runtime_version, setup_repo_prebuild
 from bcbench.operations.skills_operations import setup_agent_skills
 from bcbench.operations.test_operations import extract_tests_from_patch
 
@@ -36,6 +36,7 @@ __all__ = [
     "copy_problem_statement_folder",
     "extract_tests_from_patch",
     "run_tests",
+    "set_runtime_version",
     "setup_agent_skills",
     "setup_custom_agent",
     "setup_hooks",

--- a/src/bcbench/operations/setup_operations.py
+++ b/src/bcbench/operations/setup_operations.py
@@ -9,7 +9,7 @@ from bcbench.operations.git_operations import checkout_commit, clean_repo
 
 logger = get_logger(__name__)
 
-__all__ = ["setup_repo_prebuild"]
+__all__ = ["setup_repo_prebuild", "set_runtime_version"]
 
 # Offset from BC platform major version to AL runtime version.
 # E.g. platform 25.0 (BC 2024w2) → runtime 14.0, platform 27.0 → runtime 16.0

--- a/src/bcbench/operations/setup_operations.py
+++ b/src/bcbench/operations/setup_operations.py
@@ -36,7 +36,7 @@ def setup_repo_prebuild(entry: BaseDatasetEntry, repo_path: Path) -> None:
     checkout_commit(repo_path, entry.base_commit)
 
 
-def set_runtime_version(project_paths: list[str]) -> None:
+def set_runtime_version(repo_path: Path, project_paths: list[str]) -> None:
     """Set the AL runtime version in each project's app.json based on platform version.
 
     The AL compiler (altool) defaults to the latest runtime, enabling newer validation rules that reject older code.
@@ -45,7 +45,7 @@ def set_runtime_version(project_paths: list[str]) -> None:
     Can be skippped when altool is not used.
     """
     for project_path in project_paths:
-        app_json_path = Path(project_path) / "app.json"
+        app_json_path = repo_path / project_path / "app.json"
         if not app_json_path.is_file():
             continue
 

--- a/src/bcbench/operations/setup_operations.py
+++ b/src/bcbench/operations/setup_operations.py
@@ -1,5 +1,6 @@
 """Setup operations for repository preparation."""
 
+import json
 from pathlib import Path
 
 from bcbench.dataset.dataset_entry import BaseDatasetEntry
@@ -9,6 +10,11 @@ from bcbench.operations.git_operations import checkout_commit, clean_repo
 logger = get_logger(__name__)
 
 __all__ = ["setup_repo_prebuild"]
+
+# Offset from BC platform major version to AL runtime version.
+# E.g. platform 25.0 (BC 2024w2) → runtime 14.0, platform 27.0 → runtime 16.0
+# See: BC-DeveloperExperience RuntimeVersion.cs
+_PLATFORM_TO_RUNTIME_OFFSET = 11
 
 
 def setup_repo_prebuild(entry: BaseDatasetEntry, repo_path: Path) -> None:
@@ -28,3 +34,40 @@ def setup_repo_prebuild(entry: BaseDatasetEntry, repo_path: Path) -> None:
 
     clean_repo(repo_path)
     checkout_commit(repo_path, entry.base_commit)
+
+
+def set_runtime_version(project_paths: list[str]) -> None:
+    """Set the AL runtime version in each project's app.json based on platform version.
+
+    The AL compiler (altool) defaults to the latest runtime, enabling newer validation rules that reject older code.
+    Setting the runtime to match the platform version makes the compiler behave like the version that originally compiled the code.
+
+    Can be skippped when altool is not used.
+    """
+    for project_path in project_paths:
+        app_json_path = Path(project_path) / "app.json"
+        if not app_json_path.is_file():
+            continue
+
+        try:
+            app_json = json.loads(app_json_path.read_text(encoding="utf-8-sig"))
+        except (json.JSONDecodeError, OSError):
+            continue
+
+        if app_json.get("runtime"):
+            continue
+
+        platform: str = app_json.get("platform", "")
+        try:
+            platform_major = int(platform.split(".")[0])
+        except (ValueError, IndexError):
+            continue
+
+        runtime_major: int = platform_major - _PLATFORM_TO_RUNTIME_OFFSET
+        if runtime_major < 1:
+            continue
+
+        runtime: str = f"{runtime_major}.0"
+        app_json["runtime"] = runtime
+        app_json_path.write_text(json.dumps(app_json, indent=2, ensure_ascii=False), encoding="utf-8")
+        logger.info(f"Set runtime={runtime} in {app_json_path} (platform {platform})")

--- a/src/bcbench/operations/setup_operations.py
+++ b/src/bcbench/operations/setup_operations.py
@@ -9,7 +9,7 @@ from bcbench.operations.git_operations import checkout_commit, clean_repo
 
 logger = get_logger(__name__)
 
-__all__ = ["setup_repo_prebuild", "set_runtime_version"]
+__all__ = ["set_runtime_version", "setup_repo_prebuild"]
 
 # Offset from BC platform major version to AL runtime version.
 # E.g. platform 25.0 (BC 2024w2) → runtime 14.0, platform 27.0 → runtime 16.0

--- a/src/bcbench/operations/setup_operations.py
+++ b/src/bcbench/operations/setup_operations.py
@@ -42,7 +42,7 @@ def set_runtime_version(repo_path: Path, project_paths: list[str]) -> None:
     The AL compiler (altool) defaults to the latest runtime, enabling newer validation rules that reject older code.
     Setting the runtime to match the platform version makes the compiler behave like the version that originally compiled the code.
 
-    Can be skippped when altool is not used.
+    Can be skipped when altool is not used.
     """
     for project_path in project_paths:
         app_json_path = repo_path / project_path / "app.json"

--- a/src/bcbench/results/display.py
+++ b/src/bcbench/results/display.py
@@ -76,6 +76,7 @@ def create_github_job_summary(results: Sequence[BaseEvaluationResult], summary: 
     display_metrics: dict[str, int | float | bool] = summary.display_summary()
 
     mcp_servers = ", ".join(results[0].experiment.mcp_servers) if results[0].experiment and results[0].experiment.mcp_servers else "None"
+    al_lsp_enabled = "Yes" if results[0].experiment and results[0].experiment.al_lsp_enabled else "No"
     custom_instructions = "Yes" if results[0].experiment and results[0].experiment.custom_instructions else "No"
     skills = "Yes" if results[0].experiment and results[0].experiment.skills_enabled else "No"
     custom_agent = results[0].experiment.custom_agent if results[0].experiment and results[0].experiment.custom_agent else "N/A"
@@ -100,6 +101,7 @@ def create_github_job_summary(results: Sequence[BaseEvaluationResult], summary: 
         f"Total entries processed: {total}, using **{results[0].agent_name} ({results[0].model})**\n"
         f"- Category: `{results[0].category.value}`\n"
         f"- MCP Servers used: {mcp_servers}\n"
+        f"- AL LSP: {al_lsp_enabled}\n"
         f"- Custom Instructions: {custom_instructions}\n"
         f"- Skills: {skills}\n"
         f"- Custom Agent: {custom_agent}\n"

--- a/src/bcbench/types.py
+++ b/src/bcbench/types.py
@@ -80,6 +80,9 @@ class ExperimentConfiguration(BaseModel):
     # MCP server names used in experiment (if any)
     mcp_servers: list[str] | None = None
 
+    # Whether the AL LSP server was enabled for this experiment
+    al_lsp_enabled: bool = False
+
     # Custom instructions enabled in experiment
     custom_instructions: bool = False
 
@@ -95,7 +98,7 @@ class ExperimentConfiguration(BaseModel):
         An empty configuration means no special experiment settings were used.
         This is useful for comparing with None (no experiment) vs default experiment.
         """
-        return self.mcp_servers is None and self.custom_instructions is False and self.skills_enabled is False and self.custom_agent is None
+        return self.mcp_servers is None and self.al_lsp_enabled is False and self.custom_instructions is False and self.skills_enabled is False and self.custom_agent is None
 
 
 class AgentType(StrEnum):

--- a/tests/test_experiment_configuration.py
+++ b/tests/test_experiment_configuration.py
@@ -8,6 +8,7 @@ class TestExperimentConfiguration:
         config = ExperimentConfiguration()
 
         assert config.mcp_servers is None
+        assert config.al_lsp_enabled is False
         assert config.custom_instructions is False
         assert config.skills_enabled is False
         assert config.custom_agent is None
@@ -17,9 +18,23 @@ class TestExperimentConfiguration:
         config = ExperimentConfiguration(mcp_servers=mcp_servers)
 
         assert config.mcp_servers == mcp_servers
+        assert config.al_lsp_enabled is False
         assert config.custom_instructions is False
         assert config.skills_enabled is False
         assert config.custom_agent is None
+
+    def test_with_al_lsp_enabled(self):
+        config = ExperimentConfiguration(al_lsp_enabled=True)
+
+        assert config.mcp_servers is None
+        assert config.al_lsp_enabled is True
+
+    def test_with_both_mcp_and_al_lsp(self):
+        config = ExperimentConfiguration(mcp_servers=["altool"], al_lsp_enabled=True)
+
+        assert config.mcp_servers == ["altool"]
+        assert config.al_lsp_enabled is True
+        assert not config.is_empty()
 
     def test_with_custom_instructions(self):
         config = ExperimentConfiguration(custom_instructions=True)

--- a/tests/test_lsp_config.py
+++ b/tests/test_lsp_config.py
@@ -4,10 +4,12 @@ from unittest.mock import patch
 
 import pytest
 
-from bcbench.agent.shared.lsp import build_lsp_config
+from bcbench.agent.shared.lsp import build_al_lsp_plugin
 from bcbench.exceptions import AgentError
-from bcbench.types import EvaluationCategory
+from bcbench.types import AgentType, EvaluationCategory
 from tests.conftest import create_dataset_entry
+
+_PLUGIN_REL = Path(".bcbench") / "al-lsp-plugin"
 
 
 @pytest.fixture
@@ -18,14 +20,6 @@ def entry():
 @pytest.fixture
 def repo_path(tmp_path) -> Path:
     return tmp_path / "repo"
-
-
-def _read_lsp(repo_path: Path) -> dict:
-    return json.loads((repo_path / ".github" / "lsp.json").read_text(encoding="utf-8"))
-
-
-def _build(entry, repo_path, **kwargs):
-    return build_lsp_config(entry, EvaluationCategory.BUG_FIX, repo_path, **kwargs)
 
 
 @pytest.fixture
@@ -43,106 +37,136 @@ def no_artifacts():
         yield m
 
 
-class TestBuildLspConfig:
-    def test_returns_false_when_disabled(self, entry, repo_path):
-        result = _build(entry, repo_path, al_lsp=False)
-        assert result is False
-        assert not (repo_path / ".github" / "lsp.json").exists()
+def _read_lsp(repo_path: Path) -> dict:
+    return json.loads((repo_path / _PLUGIN_REL / ".lsp.json").read_text(encoding="utf-8"))
 
-    def test_removes_stale_config_when_disabled(self, entry, repo_path):
-        lsp_path = repo_path / ".github" / "lsp.json"
-        lsp_path.parent.mkdir(parents=True)
-        lsp_path.write_text("{}")
 
-        _build(entry, repo_path, al_lsp=False)
+def _read_manifest(repo_path: Path) -> dict:
+    return json.loads((repo_path / _PLUGIN_REL / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8"))
 
-        assert not lsp_path.exists()
+
+def _build(entry, repo_path, agent_type: AgentType, **kwargs):
+    return build_al_lsp_plugin(entry, EvaluationCategory.BUG_FIX, repo_path, agent_type, **kwargs)
+
+
+@pytest.fixture(params=[AgentType.COPILOT, AgentType.CLAUDE], ids=lambda a: a.value)
+def agent_type(request) -> AgentType:
+    """Parametrize across both agents — every shared behavior gets tested twice."""
+    return request.param
+
+
+class TestSharedBehavior:
+    """Behavior that must hold for both Copilot and Claude variants."""
+
+    def test_returns_none_when_disabled(self, entry, repo_path, agent_type):
+        assert _build(entry, repo_path, agent_type, al_lsp=False) is None
+        assert not (repo_path / _PLUGIN_REL).exists()
+
+    def test_removes_stale_plugin_when_disabled(self, entry, repo_path, agent_type):
+        plugin_dir = repo_path / _PLUGIN_REL
+        (plugin_dir / ".claude-plugin").mkdir(parents=True)
+        (plugin_dir / ".claude-plugin" / "plugin.json").write_text("{}")
+        (plugin_dir / ".lsp.json").write_text("{}")
+
+        _build(entry, repo_path, agent_type, al_lsp=False)
+
+        assert not plugin_dir.exists()
 
     @pytest.mark.usefixtures("artifact_paths")
-    def test_returns_true_when_enabled(self, entry, repo_path):
-        assert _build(entry, repo_path, al_lsp=True) is True
+    def test_returns_plugin_dir_when_enabled(self, entry, repo_path, agent_type):
+        assert _build(entry, repo_path, agent_type, al_lsp=True) == repo_path / _PLUGIN_REL
 
     @pytest.mark.usefixtures("artifact_paths")
-    def test_writes_project_lsp_config(self, entry, repo_path):
-        _build(entry, repo_path, al_lsp=True)
+    def test_writes_minimal_manifest(self, entry, repo_path, agent_type):
+        _build(entry, repo_path, agent_type, al_lsp=True)
+        assert _read_manifest(repo_path)["name"] == "al-lsp"  # only required field
 
+    @pytest.mark.usefixtures("artifact_paths")
+    def test_command_is_unqualified_al(self, entry, repo_path, agent_type):
+        # Copilot CLI silently rejects absolute command paths in LSP `command`; must resolve via PATH.
+        _build(entry, repo_path, agent_type, al_lsp=True)
         config = _read_lsp(repo_path)
-        assert "lspServers" in config
-        assert "altool" in config["lspServers"]
-
-    @pytest.mark.usefixtures("artifact_paths")
-    def test_command_is_unqualified_al(self, entry, repo_path):
-        _build(entry, repo_path, al_lsp=True)
-
-        server = _read_lsp(repo_path)["lspServers"]["altool"]
-        # Copilot CLI silently rejects absolute command paths — must resolve via PATH.
+        # Navigate to the server entry regardless of schema wrapper:
+        server = config["lspServers"]["altool"] if "lspServers" in config else config["altool"]
         assert server["command"] == "al"
 
     @pytest.mark.usefixtures("artifact_paths")
-    def test_al_file_extension_registered(self, entry, repo_path):
-        _build(entry, repo_path, al_lsp=True)
-
-        server = _read_lsp(repo_path)["lspServers"]["altool"]
-        assert server["fileExtensions"] == {".al": "al"}
-
-    @pytest.mark.usefixtures("artifact_paths")
-    def test_project_paths_inserted_after_launchlspserver(self, entry, repo_path):
-        _build(entry, repo_path, al_lsp=True)
-
-        args = _read_lsp(repo_path)["lspServers"]["altool"]["args"]
+    def test_project_paths_inserted_after_launchlspserver(self, entry, repo_path, agent_type):
+        _build(entry, repo_path, agent_type, al_lsp=True)
+        config = _read_lsp(repo_path)
+        server = config["lspServers"]["altool"] if "lspServers" in config else config["altool"]
+        args = server["args"]
         launch_idx = args.index("launchlspserver")
         assert args[launch_idx + 1] == str(repo_path / "src/App")
         assert args[launch_idx + 2] == str(repo_path / "src/TestApp")
 
     @pytest.mark.usefixtures("artifact_paths")
-    def test_artifact_cache_paths_used_for_package_cache(self, entry, repo_path):
-        _build(entry, repo_path, al_lsp=True)
-
-        args = _read_lsp(repo_path)["lspServers"]["altool"]["args"]
+    def test_artifact_cache_paths_used_for_package_cache(self, entry, repo_path, agent_type):
+        _build(entry, repo_path, agent_type, al_lsp=True)
+        config = _read_lsp(repo_path)
+        server = config["lspServers"]["altool"] if "lspServers" in config else config["altool"]
+        args = server["args"]
         cache_idx = args.index("--packagecachepath")
         probing_idx = args.index("--assemblyprobingpaths")
-        # All entries between --packagecachepath and --assemblyprobingpaths are package paths.
         assert args[cache_idx + 1 : probing_idx] == ["C:/cache/w1/Extensions", "C:/cache/platform/Applications"]
 
-    @pytest.mark.usefixtures("artifact_paths")
-    def test_does_not_require_container_when_artifacts_present(self, entry, repo_path):
-        # No container_name supplied — should still succeed via artifact cache.
-        assert _build(entry, repo_path, al_lsp=True, container_name="") is True
-
     @pytest.mark.usefixtures("no_artifacts")
-    def test_uses_container_compiler_folder_when_present(self, entry, repo_path, tmp_path):
+    def test_uses_container_compiler_folder_when_present(self, entry, repo_path, agent_type, tmp_path):
         compiler_root = tmp_path / "compiler" / "test-container"
         (compiler_root / "symbols").mkdir(parents=True)
         with patch(
             "bcbench.agent.shared.lsp.compiler_symbol_folder_for_container",
             return_value=(compiler_root, compiler_root / "symbols"),
         ):
-            result = _build(entry, repo_path, al_lsp=True, container_name="test-container")
+            _build(entry, repo_path, agent_type, al_lsp=True, container_name="test-container")
 
-        assert result is True
-        args = _read_lsp(repo_path)["lspServers"]["altool"]["args"]
-        cache_idx = args.index("--packagecachepath")
-        assert args[cache_idx + 1] == str(compiler_root / "symbols")
+        config = _read_lsp(repo_path)
+        server = config["lspServers"]["altool"] if "lspServers" in config else config["altool"]
+        cache_idx = server["args"].index("--packagecachepath")
+        assert server["args"][cache_idx + 1] == str(compiler_root / "symbols")
 
     @pytest.mark.usefixtures("artifact_paths")
-    def test_container_compiler_folder_wins_over_artifact_cache(self, entry, repo_path, tmp_path):
-        # When BOTH sources exist, the container compiler folder must win — same
-        # arg shape as AL-MCP, easier to debug a "which symbols set is this?" question.
+    def test_container_compiler_folder_wins_over_artifact_cache(self, entry, repo_path, agent_type, tmp_path):
+        # When BOTH sources exist, the container compiler folder must win — same arg
+        # shape as AL-MCP, easier to debug a "which symbols set is this?" question.
         compiler_root = tmp_path / "compiler" / "test-container"
         (compiler_root / "symbols").mkdir(parents=True)
         with patch(
             "bcbench.agent.shared.lsp.compiler_symbol_folder_for_container",
             return_value=(compiler_root, compiler_root / "symbols"),
         ):
-            _build(entry, repo_path, al_lsp=True, container_name="test-container")
+            _build(entry, repo_path, agent_type, al_lsp=True, container_name="test-container")
 
-        args = _read_lsp(repo_path)["lspServers"]["altool"]["args"]
+        config = _read_lsp(repo_path)
+        server = config["lspServers"]["altool"] if "lspServers" in config else config["altool"]
+        args = server["args"]
         cache_idx = args.index("--packagecachepath")
-        # Probing paths may be absent when neither dlls/ nor system .NET is found — slice to end-of-list in that case.
         end_idx = args.index("--assemblyprobingpaths") if "--assemblyprobingpaths" in args else len(args)
-        assert args[cache_idx + 1 : end_idx] == [str(compiler_root / "symbols")]  # single path, not the 2-path artifact-cache layout
+        assert args[cache_idx + 1 : end_idx] == [str(compiler_root / "symbols")]
 
     @pytest.mark.usefixtures("no_artifacts")
-    def test_raises_with_download_hint_when_neither_source_available(self, entry, repo_path):
+    def test_raises_with_download_hint_when_neither_source_available(self, entry, repo_path, agent_type):
         with pytest.raises(AgentError, match=r"Download-BCSymbols\.ps1"):
-            _build(entry, repo_path, al_lsp=True, container_name="")
+            _build(entry, repo_path, agent_type, al_lsp=True, container_name="")
+
+
+class TestAgentSpecificSchema:
+    """Each agent's `.lsp.json` schema differs slightly — verify the right keys land for each."""
+
+    @pytest.mark.usefixtures("artifact_paths")
+    def test_copilot_uses_lspservers_wrapper_with_file_extensions(self, entry, repo_path):
+        _build(entry, repo_path, AgentType.COPILOT, al_lsp=True)
+        config = _read_lsp(repo_path)
+        # Copilot: `lspServers` wrapper + `fileExtensions`.
+        assert "lspServers" in config
+        assert config["lspServers"]["altool"]["fileExtensions"] == {".al": "al"}
+        assert "extensionToLanguage" not in config["lspServers"]["altool"]
+
+    @pytest.mark.usefixtures("artifact_paths")
+    def test_claude_uses_flat_schema_with_extension_to_language(self, entry, repo_path):
+        _build(entry, repo_path, AgentType.CLAUDE, al_lsp=True)
+        config = _read_lsp(repo_path)
+        # Claude: top-level server name (no wrapper) + `extensionToLanguage`.
+        assert "lspServers" not in config
+        assert config["altool"]["extensionToLanguage"] == {".al": "al"}
+        assert "fileExtensions" not in config["altool"]

--- a/tests/test_lsp_config.py
+++ b/tests/test_lsp_config.py
@@ -6,6 +6,7 @@ import pytest
 
 from bcbench.agent.shared.lsp import build_lsp_config
 from bcbench.exceptions import AgentError
+from bcbench.types import EvaluationCategory
 from tests.conftest import create_dataset_entry
 
 
@@ -23,9 +24,12 @@ def _read_lsp(repo_path: Path) -> dict:
     return json.loads((repo_path / ".github" / "lsp.json").read_text(encoding="utf-8"))
 
 
+def _build(entry, repo_path, **kwargs):
+    return build_lsp_config(entry, EvaluationCategory.BUG_FIX, repo_path, **kwargs)
+
+
 @pytest.fixture
-def _artifact_paths():
-    """Stub artifact-cache resolution so tests don't depend on a populated cache."""
+def artifact_paths():
     with patch(
         "bcbench.agent.shared.lsp.resolve_artifact_lsp_paths",
         return_value=(["C:/cache/w1/Extensions", "C:/cache/platform/Applications"], ["C:/cache/platform"]),
@@ -34,15 +38,14 @@ def _artifact_paths():
 
 
 @pytest.fixture
-def _no_artifacts():
-    """Stub artifact-cache miss so the fallback / error paths can be tested."""
+def no_artifacts():
     with patch("bcbench.agent.shared.lsp.resolve_artifact_lsp_paths", return_value=None) as m:
         yield m
 
 
 class TestBuildLspConfig:
     def test_returns_false_when_disabled(self, entry, repo_path):
-        result = build_lsp_config(entry, repo_path, al_lsp=False)
+        result = _build(entry, repo_path, al_lsp=False)
         assert result is False
         assert not (repo_path / ".github" / "lsp.json").exists()
 
@@ -51,43 +54,49 @@ class TestBuildLspConfig:
         lsp_path.parent.mkdir(parents=True)
         lsp_path.write_text("{}")
 
-        build_lsp_config(entry, repo_path, al_lsp=False)
+        _build(entry, repo_path, al_lsp=False)
 
         assert not lsp_path.exists()
 
-    def test_returns_true_when_enabled(self, entry, repo_path, _artifact_paths):
-        assert build_lsp_config(entry, repo_path, al_lsp=True) is True
+    @pytest.mark.usefixtures("artifact_paths")
+    def test_returns_true_when_enabled(self, entry, repo_path):
+        assert _build(entry, repo_path, al_lsp=True) is True
 
-    def test_writes_project_lsp_config(self, entry, repo_path, _artifact_paths):
-        build_lsp_config(entry, repo_path, al_lsp=True)
+    @pytest.mark.usefixtures("artifact_paths")
+    def test_writes_project_lsp_config(self, entry, repo_path):
+        _build(entry, repo_path, al_lsp=True)
 
         config = _read_lsp(repo_path)
         assert "lspServers" in config
         assert "altool" in config["lspServers"]
 
-    def test_command_is_unqualified_al(self, entry, repo_path, _artifact_paths):
-        build_lsp_config(entry, repo_path, al_lsp=True)
+    @pytest.mark.usefixtures("artifact_paths")
+    def test_command_is_unqualified_al(self, entry, repo_path):
+        _build(entry, repo_path, al_lsp=True)
 
         server = _read_lsp(repo_path)["lspServers"]["altool"]
         # Copilot CLI silently rejects absolute command paths — must resolve via PATH.
         assert server["command"] == "al"
 
-    def test_al_file_extension_registered(self, entry, repo_path, _artifact_paths):
-        build_lsp_config(entry, repo_path, al_lsp=True)
+    @pytest.mark.usefixtures("artifact_paths")
+    def test_al_file_extension_registered(self, entry, repo_path):
+        _build(entry, repo_path, al_lsp=True)
 
         server = _read_lsp(repo_path)["lspServers"]["altool"]
         assert server["fileExtensions"] == {".al": "al"}
 
-    def test_project_paths_inserted_after_launchlspserver(self, entry, repo_path, _artifact_paths):
-        build_lsp_config(entry, repo_path, al_lsp=True)
+    @pytest.mark.usefixtures("artifact_paths")
+    def test_project_paths_inserted_after_launchlspserver(self, entry, repo_path):
+        _build(entry, repo_path, al_lsp=True)
 
         args = _read_lsp(repo_path)["lspServers"]["altool"]["args"]
         launch_idx = args.index("launchlspserver")
         assert args[launch_idx + 1] == str(repo_path / "src/App")
         assert args[launch_idx + 2] == str(repo_path / "src/TestApp")
 
-    def test_artifact_cache_paths_used_for_package_cache(self, entry, repo_path, _artifact_paths):
-        build_lsp_config(entry, repo_path, al_lsp=True)
+    @pytest.mark.usefixtures("artifact_paths")
+    def test_artifact_cache_paths_used_for_package_cache(self, entry, repo_path):
+        _build(entry, repo_path, al_lsp=True)
 
         args = _read_lsp(repo_path)["lspServers"]["altool"]["args"]
         cache_idx = args.index("--packagecachepath")
@@ -95,34 +104,45 @@ class TestBuildLspConfig:
         # All entries between --packagecachepath and --assemblyprobingpaths are package paths.
         assert args[cache_idx + 1 : probing_idx] == ["C:/cache/w1/Extensions", "C:/cache/platform/Applications"]
 
-    def test_does_not_require_container_when_artifacts_present(self, entry, repo_path, _artifact_paths):
+    @pytest.mark.usefixtures("artifact_paths")
+    def test_does_not_require_container_when_artifacts_present(self, entry, repo_path):
         # No container_name supplied — should still succeed via artifact cache.
-        assert build_lsp_config(entry, repo_path, al_lsp=True, container_name="") is True
+        assert _build(entry, repo_path, al_lsp=True, container_name="") is True
 
-    def test_uses_container_compiler_folder_when_present(self, entry, repo_path, _no_artifacts, tmp_path):
+    @pytest.mark.usefixtures("no_artifacts")
+    def test_uses_container_compiler_folder_when_present(self, entry, repo_path, tmp_path):
         compiler_root = tmp_path / "compiler" / "test-container"
         (compiler_root / "symbols").mkdir(parents=True)
-        with patch("bcbench.agent.shared.lsp.compiler_folder_for_container", return_value=compiler_root):
-            result = build_lsp_config(entry, repo_path, al_lsp=True, container_name="test-container")
+        with patch(
+            "bcbench.agent.shared.lsp.compiler_symbol_folder_for_container",
+            return_value=(compiler_root, compiler_root / "symbols"),
+        ):
+            result = _build(entry, repo_path, al_lsp=True, container_name="test-container")
 
         assert result is True
         args = _read_lsp(repo_path)["lspServers"]["altool"]["args"]
         cache_idx = args.index("--packagecachepath")
         assert args[cache_idx + 1] == str(compiler_root / "symbols")
 
-    def test_container_compiler_folder_wins_over_artifact_cache(self, entry, repo_path, _artifact_paths, tmp_path):
+    @pytest.mark.usefixtures("artifact_paths")
+    def test_container_compiler_folder_wins_over_artifact_cache(self, entry, repo_path, tmp_path):
         # When BOTH sources exist, the container compiler folder must win — same
         # arg shape as AL-MCP, easier to debug a "which symbols set is this?" question.
         compiler_root = tmp_path / "compiler" / "test-container"
         (compiler_root / "symbols").mkdir(parents=True)
-        with patch("bcbench.agent.shared.lsp.compiler_folder_for_container", return_value=compiler_root):
-            build_lsp_config(entry, repo_path, al_lsp=True, container_name="test-container")
+        with patch(
+            "bcbench.agent.shared.lsp.compiler_symbol_folder_for_container",
+            return_value=(compiler_root, compiler_root / "symbols"),
+        ):
+            _build(entry, repo_path, al_lsp=True, container_name="test-container")
 
         args = _read_lsp(repo_path)["lspServers"]["altool"]["args"]
         cache_idx = args.index("--packagecachepath")
-        probing_idx = args.index("--assemblyprobingpaths")
-        assert args[cache_idx + 1 : probing_idx] == [str(compiler_root / "symbols")]  # single path, not the 2-path artifact-cache layout
+        # Probing paths may be absent when neither dlls/ nor system .NET is found — slice to end-of-list in that case.
+        end_idx = args.index("--assemblyprobingpaths") if "--assemblyprobingpaths" in args else len(args)
+        assert args[cache_idx + 1 : end_idx] == [str(compiler_root / "symbols")]  # single path, not the 2-path artifact-cache layout
 
-    def test_raises_with_download_hint_when_neither_source_available(self, entry, repo_path, _no_artifacts):
-        with pytest.raises(AgentError, match="Download-BCSymbols.ps1"):
-            build_lsp_config(entry, repo_path, al_lsp=True, container_name="")
+    @pytest.mark.usefixtures("no_artifacts")
+    def test_raises_with_download_hint_when_neither_source_available(self, entry, repo_path):
+        with pytest.raises(AgentError, match=r"Download-BCSymbols\.ps1"):
+            _build(entry, repo_path, al_lsp=True, container_name="")

--- a/tests/test_lsp_config.py
+++ b/tests/test_lsp_config.py
@@ -1,0 +1,128 @@
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from bcbench.agent.shared.lsp import build_lsp_config
+from bcbench.exceptions import AgentError
+from tests.conftest import create_dataset_entry
+
+
+@pytest.fixture
+def entry():
+    return create_dataset_entry(project_paths=["src/App", "src/TestApp"])
+
+
+@pytest.fixture
+def repo_path(tmp_path) -> Path:
+    return tmp_path / "repo"
+
+
+def _read_lsp(repo_path: Path) -> dict:
+    return json.loads((repo_path / ".github" / "lsp.json").read_text(encoding="utf-8"))
+
+
+@pytest.fixture
+def _artifact_paths():
+    """Stub artifact-cache resolution so tests don't depend on a populated cache."""
+    with patch(
+        "bcbench.agent.shared.lsp.resolve_artifact_lsp_paths",
+        return_value=(["C:/cache/w1/Extensions", "C:/cache/platform/Applications"], ["C:/cache/platform"]),
+    ) as m:
+        yield m
+
+
+@pytest.fixture
+def _no_artifacts():
+    """Stub artifact-cache miss so the fallback / error paths can be tested."""
+    with patch("bcbench.agent.shared.lsp.resolve_artifact_lsp_paths", return_value=None) as m:
+        yield m
+
+
+class TestBuildLspConfig:
+    def test_returns_false_when_disabled(self, entry, repo_path):
+        result = build_lsp_config(entry, repo_path, al_lsp=False)
+        assert result is False
+        assert not (repo_path / ".github" / "lsp.json").exists()
+
+    def test_removes_stale_config_when_disabled(self, entry, repo_path):
+        lsp_path = repo_path / ".github" / "lsp.json"
+        lsp_path.parent.mkdir(parents=True)
+        lsp_path.write_text("{}")
+
+        build_lsp_config(entry, repo_path, al_lsp=False)
+
+        assert not lsp_path.exists()
+
+    def test_returns_true_when_enabled(self, entry, repo_path, _artifact_paths):
+        assert build_lsp_config(entry, repo_path, al_lsp=True) is True
+
+    def test_writes_project_lsp_config(self, entry, repo_path, _artifact_paths):
+        build_lsp_config(entry, repo_path, al_lsp=True)
+
+        config = _read_lsp(repo_path)
+        assert "lspServers" in config
+        assert "altool" in config["lspServers"]
+
+    def test_command_is_unqualified_al(self, entry, repo_path, _artifact_paths):
+        build_lsp_config(entry, repo_path, al_lsp=True)
+
+        server = _read_lsp(repo_path)["lspServers"]["altool"]
+        # Copilot CLI silently rejects absolute command paths — must resolve via PATH.
+        assert server["command"] == "al"
+
+    def test_al_file_extension_registered(self, entry, repo_path, _artifact_paths):
+        build_lsp_config(entry, repo_path, al_lsp=True)
+
+        server = _read_lsp(repo_path)["lspServers"]["altool"]
+        assert server["fileExtensions"] == {".al": "al"}
+
+    def test_project_paths_inserted_after_launchlspserver(self, entry, repo_path, _artifact_paths):
+        build_lsp_config(entry, repo_path, al_lsp=True)
+
+        args = _read_lsp(repo_path)["lspServers"]["altool"]["args"]
+        launch_idx = args.index("launchlspserver")
+        assert args[launch_idx + 1] == str(repo_path / "src/App")
+        assert args[launch_idx + 2] == str(repo_path / "src/TestApp")
+
+    def test_artifact_cache_paths_used_for_package_cache(self, entry, repo_path, _artifact_paths):
+        build_lsp_config(entry, repo_path, al_lsp=True)
+
+        args = _read_lsp(repo_path)["lspServers"]["altool"]["args"]
+        cache_idx = args.index("--packagecachepath")
+        probing_idx = args.index("--assemblyprobingpaths")
+        # All entries between --packagecachepath and --assemblyprobingpaths are package paths.
+        assert args[cache_idx + 1 : probing_idx] == ["C:/cache/w1/Extensions", "C:/cache/platform/Applications"]
+
+    def test_does_not_require_container_when_artifacts_present(self, entry, repo_path, _artifact_paths):
+        # No container_name supplied — should still succeed via artifact cache.
+        assert build_lsp_config(entry, repo_path, al_lsp=True, container_name="") is True
+
+    def test_uses_container_compiler_folder_when_present(self, entry, repo_path, _no_artifacts, tmp_path):
+        compiler_root = tmp_path / "compiler" / "test-container"
+        (compiler_root / "symbols").mkdir(parents=True)
+        with patch("bcbench.agent.shared.lsp.compiler_folder_for_container", return_value=compiler_root):
+            result = build_lsp_config(entry, repo_path, al_lsp=True, container_name="test-container")
+
+        assert result is True
+        args = _read_lsp(repo_path)["lspServers"]["altool"]["args"]
+        cache_idx = args.index("--packagecachepath")
+        assert args[cache_idx + 1] == str(compiler_root / "symbols")
+
+    def test_container_compiler_folder_wins_over_artifact_cache(self, entry, repo_path, _artifact_paths, tmp_path):
+        # When BOTH sources exist, the container compiler folder must win — same
+        # arg shape as AL-MCP, easier to debug a "which symbols set is this?" question.
+        compiler_root = tmp_path / "compiler" / "test-container"
+        (compiler_root / "symbols").mkdir(parents=True)
+        with patch("bcbench.agent.shared.lsp.compiler_folder_for_container", return_value=compiler_root):
+            build_lsp_config(entry, repo_path, al_lsp=True, container_name="test-container")
+
+        args = _read_lsp(repo_path)["lspServers"]["altool"]["args"]
+        cache_idx = args.index("--packagecachepath")
+        probing_idx = args.index("--assemblyprobingpaths")
+        assert args[cache_idx + 1 : probing_idx] == [str(compiler_root / "symbols")]  # single path, not the 2-path artifact-cache layout
+
+    def test_raises_with_download_hint_when_neither_source_available(self, entry, repo_path, _no_artifacts):
+        with pytest.raises(AgentError, match="Download-BCSymbols.ps1"):
+            build_lsp_config(entry, repo_path, al_lsp=True, container_name="")

--- a/tests/test_mcp_config.py
+++ b/tests/test_mcp_config.py
@@ -5,7 +5,6 @@ from pathlib import Path
 import pytest
 
 from bcbench.agent.shared.altool_paths import build_assembly_probing_paths as _build_assembly_probing_paths
-from bcbench.agent.shared.altool_paths import set_runtime_version as _set_runtime_version
 from bcbench.agent.shared.mcp import build_mcp_config
 from tests.conftest import create_dataset_entry
 
@@ -194,35 +193,3 @@ class TestBuildAssemblyProbingPaths:
         result = _build_assembly_probing_paths(tmp_path)
 
         assert isinstance(result, list)
-
-
-class TestSetRuntimeVersion:
-    def test_sets_runtime_from_platform(self, tmp_path):
-        app_json = {"platform": "25.0.0.0", "version": "25.0.0.0"}
-        (tmp_path / "app.json").write_text(json.dumps(app_json))
-
-        _set_runtime_version([str(tmp_path)])
-
-        result = json.loads((tmp_path / "app.json").read_text())
-        assert result["runtime"] == "14.0"
-
-    def test_skips_when_runtime_already_set(self, tmp_path):
-        app_json = {"platform": "25.0.0.0", "runtime": "12.0"}
-        (tmp_path / "app.json").write_text(json.dumps(app_json))
-
-        _set_runtime_version([str(tmp_path)])
-
-        result = json.loads((tmp_path / "app.json").read_text())
-        assert result["runtime"] == "12.0"
-
-    def test_platform_27_maps_to_runtime_16(self, tmp_path):
-        app_json = {"platform": "27.0.0.0"}
-        (tmp_path / "app.json").write_text(json.dumps(app_json))
-
-        _set_runtime_version([str(tmp_path)])
-
-        result = json.loads((tmp_path / "app.json").read_text())
-        assert result["runtime"] == "16.0"
-
-    def test_skips_missing_app_json(self, tmp_path):
-        _set_runtime_version([str(tmp_path)])  # should not raise

--- a/tests/test_mcp_config.py
+++ b/tests/test_mcp_config.py
@@ -3,7 +3,9 @@ from pathlib import Path
 
 import pytest
 
-from bcbench.agent.shared.mcp import _build_assembly_probing_paths, _set_runtime_version, build_mcp_config
+from bcbench.agent.shared.altool_paths import build_assembly_probing_paths as _build_assembly_probing_paths
+from bcbench.agent.shared.altool_paths import set_runtime_version as _set_runtime_version
+from bcbench.agent.shared.mcp import build_mcp_config
 from tests.conftest import create_dataset_entry
 
 

--- a/tests/test_setup_operations.py
+++ b/tests/test_setup_operations.py
@@ -1,0 +1,35 @@
+import json
+
+from bcbench.operations.setup_operations import set_runtime_version
+
+
+class TestSetRuntimeVersion:
+    def test_sets_runtime_from_platform(self, tmp_path):
+        app_json = {"platform": "25.0.0.0", "version": "25.0.0.0"}
+        (tmp_path / "app.json").write_text(json.dumps(app_json))
+
+        set_runtime_version([str(tmp_path)])
+
+        result = json.loads((tmp_path / "app.json").read_text())
+        assert result["runtime"] == "14.0"
+
+    def test_skips_when_runtime_already_set(self, tmp_path):
+        app_json = {"platform": "25.0.0.0", "runtime": "12.0"}
+        (tmp_path / "app.json").write_text(json.dumps(app_json))
+
+        set_runtime_version([str(tmp_path)])
+
+        result = json.loads((tmp_path / "app.json").read_text())
+        assert result["runtime"] == "12.0"
+
+    def test_platform_27_maps_to_runtime_16(self, tmp_path):
+        app_json = {"platform": "27.0.0.0"}
+        (tmp_path / "app.json").write_text(json.dumps(app_json))
+
+        set_runtime_version([str(tmp_path)])
+
+        result = json.loads((tmp_path / "app.json").read_text())
+        assert result["runtime"] == "16.0"
+
+    def test_skips_missing_app_json(self, tmp_path):
+        set_runtime_version([str(tmp_path)])  # should not raise

--- a/tests/test_setup_operations.py
+++ b/tests/test_setup_operations.py
@@ -8,7 +8,7 @@ class TestSetRuntimeVersion:
         app_json = {"platform": "25.0.0.0", "version": "25.0.0.0"}
         (tmp_path / "app.json").write_text(json.dumps(app_json))
 
-        set_runtime_version(tmp_path, [str(tmp_path)])
+        set_runtime_version(tmp_path, ["."])
 
         result = json.loads((tmp_path / "app.json").read_text())
         assert result["runtime"] == "14.0"

--- a/tests/test_setup_operations.py
+++ b/tests/test_setup_operations.py
@@ -8,7 +8,7 @@ class TestSetRuntimeVersion:
         app_json = {"platform": "25.0.0.0", "version": "25.0.0.0"}
         (tmp_path / "app.json").write_text(json.dumps(app_json))
 
-        set_runtime_version([str(tmp_path)])
+        set_runtime_version(tmp_path, [str(tmp_path)])
 
         result = json.loads((tmp_path / "app.json").read_text())
         assert result["runtime"] == "14.0"
@@ -17,7 +17,7 @@ class TestSetRuntimeVersion:
         app_json = {"platform": "25.0.0.0", "runtime": "12.0"}
         (tmp_path / "app.json").write_text(json.dumps(app_json))
 
-        set_runtime_version([str(tmp_path)])
+        set_runtime_version(tmp_path, [str(tmp_path)])
 
         result = json.loads((tmp_path / "app.json").read_text())
         assert result["runtime"] == "12.0"
@@ -26,10 +26,10 @@ class TestSetRuntimeVersion:
         app_json = {"platform": "27.0.0.0"}
         (tmp_path / "app.json").write_text(json.dumps(app_json))
 
-        set_runtime_version([str(tmp_path)])
+        set_runtime_version(tmp_path, [str(tmp_path)])
 
         result = json.loads((tmp_path / "app.json").read_text())
         assert result["runtime"] == "16.0"
 
     def test_skips_missing_app_json(self, tmp_path):
-        set_runtime_version([str(tmp_path)])  # should not raise
+        set_runtime_version(tmp_path, [str(tmp_path)])  # should not raise


### PR DESCRIPTION
Enable latest AL-LSP for evaluation in BC-Bench, it is also shipped from `altool` but doesn't require a running container.

Also introduce a `scripts/Download-BCSymbols.ps1` script to download all the artifacts using BCContainerHelper, this is mostly used for local development.

Use the plugin pattern for Claude Code, it is also supported by GitHub Copilot.

~Currently, only enabled integration with Copilot.~

## Local Development

First follow [CONTRIBUTING.md](https://github.com/microsoft/BC-Bench/blob/main/CONTRIBUTING.md)

```powershell
# Only need if altool is not installed
dotnet tool install -g Microsoft.Dynamics.BusinessCentral.Development.Tools --version 18.0.36.64936-beta

# Only need to run once per instance/task
.\scripts\Download-BCSymbols.ps1 -Category bug-fix -InstanceId microsoft__BCApps-5633

uv run bcbench run copilot microsoft__BCApps-5633 --category bug-fix --repo-path C:\depot\BCApps\ --al-lsp
```

## TODO
- [x] Integration with Claude Code