### PR TITLE
Enable docker connection via environment variables

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -4,10 +4,14 @@
 # Azure DevOps Personal Access Token (required for reading NAV PRs, Work Items and connecting to bc-eval package)
 ADO_TOKEN=your_ado_token_here
 
-# BC Container
+# BC Container (Docker container name, consumed by BCContainerHelper)
 BC_CONTAINER_NAME=bcbench
-BC_CONTAINER_USERNAME=admin
-BC_CONTAINER_PASSWORD=your_container_password_here
+
+# BC server connection
+BC_SERVER_URL=http://bcbench
+BC_SERVER_INSTANCE=BC
+BC_SERVER_USERNAME=admin
+BC_SERVER_PASSWORD=your_container_password_here
 
 # Optional: Set to "1" to enable debug logging in GitHub Actions
 # RUNNER_DEBUG=1

--- a/.github/actions/setup-bc-container-repo/action.yml
+++ b/.github/actions/setup-bc-container-repo/action.yml
@@ -40,9 +40,14 @@ runs:
         # Mask the password in GitHub Actions logs
         Write-Output "::add-mask::$password"
 
-        "BC_CONTAINER_NAME=bcbench-$("${{ inputs.instance-id }}".Split('-')[1])" | Out-File -FilePath $env:GITHUB_ENV -Append
-        "BC_CONTAINER_USERNAME=admin" | Out-File -FilePath $env:GITHUB_ENV -Append
-        "BC_CONTAINER_PASSWORD=$password" | Out-File -FilePath $env:GITHUB_ENV -Append
+        $containerName = "bcbench-$("${{ inputs.instance-id }}".Split('-')[1])"
+        "BC_CONTAINER_NAME=$containerName" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+        # Connection target + credentials consumed by altool
+        "BC_SERVER_URL=http://$containerName" | Out-File -FilePath $env:GITHUB_ENV -Append
+        "BC_SERVER_INSTANCE=BC" | Out-File -FilePath $env:GITHUB_ENV -Append
+        "BC_SERVER_USERNAME=admin" | Out-File -FilePath $env:GITHUB_ENV -Append
+        "BC_SERVER_PASSWORD=$password" | Out-File -FilePath $env:GITHUB_ENV -Append
       shell: pwsh
 
     - name: Install BcContainerHelper module

--- a/.github/workflows/claude-evaluation.yml
+++ b/.github/workflows/claude-evaluation.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Install AL Tool
         if: ${{ inputs.al-mcp }}
         run: |
-          dotnet tool install -g Microsoft.Dynamics.BusinessCentral.Development.Tools --version 17.0.33.55542
+          dotnet tool install -g Microsoft.Dynamics.BusinessCentral.Development.Tools --version 18.0.36.64936-beta
           echo "$HOME\.dotnet\tools" >> $env:GITHUB_PATH
 
       - name: Install Claude Code

--- a/.github/workflows/copilot-evaluation.yml
+++ b/.github/workflows/copilot-evaluation.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Install AL Tool
         if: ${{ inputs.al-mcp }}
         run: |
-          dotnet tool install -g Microsoft.Dynamics.BusinessCentral.Development.Tools --version 17.0.33.55542
+          dotnet tool install -g Microsoft.Dynamics.BusinessCentral.Development.Tools --version 18.0.36.64936-beta
           echo "$HOME\.dotnet\tools" >> $env:GITHUB_PATH
 
       - name: Install GitHub Copilot CLI

--- a/scripts/BCBenchUtils.psm1
+++ b/scripts/BCBenchUtils.psm1
@@ -15,13 +15,13 @@
 .PARAMETER Password
     Optional SecureString password parameter
 .PARAMETER EnvironmentVariableName
-    Name of environment variable containing password (default: BC_CONTAINER_PASSWORD)
+    Name of environment variable containing password (default: BC_SERVER_PASSWORD)
 .OUTPUTS
     PSCredential object
 .EXAMPLE
     $cred = Get-BCCredential -Username "admin" -Password $securePassword
 .EXAMPLE
-    $cred = Get-BCCredential -Username "admin" # Uses BC_CONTAINER_PASSWORD env var
+    $cred = Get-BCCredential -Username "admin" # Uses BC_SERVER_PASSWORD env var
 #>
 function Get-BCCredential {
     [CmdletBinding()]
@@ -34,7 +34,7 @@ function Get-BCCredential {
         [SecureString]$Password,
 
         [Parameter(Mandatory = $false)]
-        [string]$EnvironmentVariableName = "BC_CONTAINER_PASSWORD"
+        [string]$EnvironmentVariableName = "BC_SERVER_PASSWORD"
     )
 
     # Get environment password

--- a/scripts/Setup-ContainerAndRepository.ps1
+++ b/scripts/Setup-ContainerAndRepository.ps1
@@ -29,7 +29,7 @@ param(
     [string]$ContainerName = $env:BC_CONTAINER_NAME ?? "bcbench",
 
     [Parameter(Mandatory = $false)]
-    [string]$Username = $env:BC_CONTAINER_USERNAME ?? "admin",
+    [string]$Username = $env:BC_SERVER_USERNAME ?? "admin",
 
     [Parameter(Mandatory = $false)]
     [SecureString]$Password,

--- a/scripts/Verify-BuildAndTests.ps1
+++ b/scripts/Verify-BuildAndTests.ps1
@@ -29,7 +29,7 @@ param(
     [string]$ContainerName = $env:BC_CONTAINER_NAME ?? "bcbench",
 
     [Parameter(Mandatory = $false)]
-    [string]$Username = $env:BC_CONTAINER_USERNAME ?? "admin",
+    [string]$Username = $env:BC_SERVER_USERNAME ?? "admin",
 
     [Parameter(Mandatory = $false)]
     [SecureString]$Password

--- a/src/bcbench/agent/shared/config.yaml
+++ b/src/bcbench/agent/shared/config.yaml
@@ -12,8 +12,6 @@ prompt:
 
     Task: Fix the issue described below {% if include_project_paths %}in the following projects: {{project_paths}}{% endif %}
 
-    CRITICAL: Use al mcp to pulish the fixed app after applying the fix.
-
     Important constraints:
     - Do NOT modify any testing logic or test files
     - Focus solely on fixing the reported issue

--- a/src/bcbench/agent/shared/config.yaml
+++ b/src/bcbench/agent/shared/config.yaml
@@ -15,9 +15,7 @@ prompt:
     Important constraints:
     - Do NOT modify any testing logic or test files
     - Focus solely on fixing the reported issue
-    {% if al_mcp %}
-    - Do NOT try to run tests
-    {% else %}
+    {% if not al_mcp %}
     - Do NOT try to build or run tests, just provide the code changes needed
     {% endif %}
     - Do NOT commit any changes to the repository
@@ -42,9 +40,7 @@ prompt:
     Important constraints:
     - Do NOT modify any production code or existing tests
     - Focus solely on generating tests {% if is_gold_patch %}that verify the fix works correctly{% else %}for the reported issue{% endif %}
-    {% if al_mcp %}
-    - Do NOT try to run tests
-    {% else %}
+    {% if not al_mcp %}
     - Do NOT try to build or run tests, just provide the code changes needed
     {% endif %}
     - Do NOT commit any changes to the repository

--- a/src/bcbench/agent/shared/config.yaml
+++ b/src/bcbench/agent/shared/config.yaml
@@ -12,6 +12,8 @@ prompt:
 
     Task: Fix the issue described below {% if include_project_paths %}in the following projects: {{project_paths}}{% endif %}
 
+    CRITICAL: Use al mcp to pulish the fixed app after applying the fix.
+
     Important constraints:
     - Do NOT modify any testing logic or test files
     - Focus solely on fixing the reported issue

--- a/src/bcbench/agent/shared/mcp.py
+++ b/src/bcbench/agent/shared/mcp.py
@@ -1,4 +1,5 @@
 import json
+import os
 import shutil
 from pathlib import Path
 from typing import Any
@@ -134,11 +135,15 @@ def _build_server_entry(server: dict[str, Any], template_context: dict[str, Any]
             args: list[str] = server["args"]
             rendered_args = [Template(arg).render(**template_context) for arg in args]
             command: str = shutil.which(server["command"]) or server["command"]
-            return server_name, {
+            entry: dict[str, Any] = {
                 "type": server_type,
                 "command": command,
                 "args": rendered_args,
             }
+            env: dict[str, str] = server.get("env", {})
+            if env:
+                entry["env"] = env
+            return server_name, entry
         case _:
             logger.error(f"Unsupported MCP server type: {server_type}, {server}")
             raise AgentError(f"Unsupported MCP server type: {server_type}")
@@ -173,6 +178,12 @@ def build_mcp_config(config: dict[str, Any], entry: BaseDatasetEntry, repo_path:
         if assembly_probing_paths:
             al_server["args"].extend(["--assemblyprobingpaths", *assembly_probing_paths])
             logger.info(f"Assembly probing paths: {assembly_probing_paths}")
+
+        # forward BC_SERVER_* environment variables explicitly
+        forwarded = {k: os.environ[k] for k in ("BC_SERVER_URL", "BC_SERVER_INSTANCE", "BC_SERVER_USERNAME", "BC_SERVER_PASSWORD") if os.environ.get(k)}
+        if forwarded:
+            al_server["env"] = forwarded
+            logger.info(f"Forwarding env vars to altool MCP: {list(forwarded.keys())}")
 
     mcp_server_names: list[str] = [server["name"] for server in mcp_servers]
     mcp_config = {"mcpServers": dict(map(lambda s: _build_server_entry(s, template_context), mcp_servers))}

--- a/src/bcbench/cli_options.py
+++ b/src/bcbench/cli_options.py
@@ -17,9 +17,9 @@ RunId = Annotated[str, typer.Option(envvar="GITHUB_RUN_ID", help="Unique identif
 
 ContainerName = Annotated[str, typer.Option(envvar="BC_CONTAINER_NAME", help="BC container name")]
 
-ContainerUsername = Annotated[str, typer.Option(envvar="BC_CONTAINER_USERNAME", help="Username for BC container")]
+ContainerUsername = Annotated[str, typer.Option(envvar="BC_SERVER_USERNAME", help="Username for BC container")]
 
-ContainerPassword = Annotated[str, typer.Option(envvar="BC_CONTAINER_PASSWORD", help="Password for BC container")]
+ContainerPassword = Annotated[str, typer.Option(envvar="BC_SERVER_PASSWORD", help="Password for BC container")]
 
 EvaluationCategoryOption = Annotated[EvaluationCategory, typer.Option(help="Category of evaluation to perform")]
 

--- a/tests/test_mcp_config.py
+++ b/tests/test_mcp_config.py
@@ -1,4 +1,5 @@
 import json
+from copy import deepcopy
 from pathlib import Path
 
 import pytest
@@ -8,7 +9,7 @@ from tests.conftest import create_dataset_entry
 
 
 def _make_config(*servers: dict) -> dict:
-    return {"mcp": {"servers": list(servers)}}
+    return {"mcp": {"servers": [deepcopy(s) for s in servers]}}
 
 
 ALTOOL_SERVER = {
@@ -84,6 +85,76 @@ class TestAlMcpProjectPaths:
         assert names is not None
 
         assert set(names) == {"altool", "mslearn"}
+
+
+class TestAltoolEnvForwarding:
+    _MANAGED_VARS = (
+        "BC_SERVER_URL",
+        "BC_SERVER_INSTANCE",
+        "BC_SERVER_USERNAME",
+        "BC_SERVER_PASSWORD",
+    )
+
+    @pytest.fixture(autouse=True)
+    def _isolate_env(self):
+        import os
+
+        saved = {var: os.environ.pop(var, None) for var in self._MANAGED_VARS}
+        yield
+        for var in self._MANAGED_VARS:
+            os.environ.pop(var, None)
+            value = saved[var]
+            if value is not None:
+                os.environ[var] = value
+
+    def test_forwards_set_bc_server_vars(self, entry, repo_path, monkeypatch):
+        monkeypatch.setenv("BC_SERVER_URL", "http://bcbench-210528")
+        monkeypatch.setenv("BC_SERVER_INSTANCE", "BC")
+        monkeypatch.setenv("BC_SERVER_USERNAME", "admin")
+        monkeypatch.setenv("BC_SERVER_PASSWORD", "secret")
+
+        config_json, _ = build_mcp_config(_make_config(ALTOOL_SERVER), entry, repo_path, al_mcp=True)
+        assert config_json is not None
+
+        env = json.loads(config_json)["mcpServers"]["altool"]["env"]
+        assert env == {
+            "BC_SERVER_URL": "http://bcbench-210528",
+            "BC_SERVER_INSTANCE": "BC",
+            "BC_SERVER_PASSWORD": "secret",
+            "BC_SERVER_USERNAME": "admin",
+        }
+
+    def test_omits_env_block_when_no_vars_set(self, entry, repo_path):
+        config_json, _ = build_mcp_config(_make_config(ALTOOL_SERVER), entry, repo_path, al_mcp=True)
+        assert config_json is not None
+
+        assert "env" not in json.loads(config_json)["mcpServers"]["altool"]
+
+    def test_skips_empty_string_values(self, entry, repo_path, monkeypatch):
+        monkeypatch.setenv("BC_SERVER_USERNAME", "admin")
+        monkeypatch.setenv("BC_SERVER_PASSWORD", "")
+
+        config_json, _ = build_mcp_config(_make_config(ALTOOL_SERVER), entry, repo_path, al_mcp=True)
+        assert config_json is not None
+
+        env = json.loads(config_json)["mcpServers"]["altool"]["env"]
+        assert env == {"BC_SERVER_USERNAME": "admin"}
+
+    def test_does_not_forward_to_other_stdio_servers(self, entry, repo_path, monkeypatch):
+        monkeypatch.setenv("BC_SERVER_USERNAME", "admin")
+        other_stdio = {
+            "name": "filesystem",
+            "type": "stdio",
+            "command": "node",
+            "args": ["server.js"],
+        }
+
+        config_json, _ = build_mcp_config(_make_config(ALTOOL_SERVER, other_stdio), entry, repo_path, al_mcp=True)
+        assert config_json is not None
+
+        parsed = json.loads(config_json)["mcpServers"]
+        assert "env" not in parsed["filesystem"]
+        assert parsed["altool"]["env"] == {"BC_SERVER_USERNAME": "admin"}
 
 
 class TestBuildAssemblyProbingPaths:


### PR DESCRIPTION
With the latest `altool`, we should be able to authenticate with docker environment (provisioned using BC ContainerHelper) using environment variables. 

This should enable coding agents to publish and run tests in the headless environment in BC-Bench