### PR TITLE
Fix metrics collection caused by latest Copilot CLI

### DIFF
--- a/src/bcbench/agent/copilot/agent.py
+++ b/src/bcbench/agent/copilot/agent.py
@@ -1,5 +1,6 @@
 """GitHub Copilot CLI Agent implementation."""
 
+import os
 import shutil
 import subprocess
 import sys
@@ -88,6 +89,7 @@ def run_copilot_agent(
         result = subprocess.run(
             cmd_args,
             cwd=str(repo_path),
+            env={**os.environ, "GITHUB_COPILOT_PROMPT_MODE_REPO_HOOKS": "true"},
             stderr=subprocess.PIPE,  # only capture stderr where metrics are printed
             timeout=_config.timeout.agent_execution,
             check=True,

--- a/src/bcbench/agent/copilot/metrics.py
+++ b/src/bcbench/agent/copilot/metrics.py
@@ -34,10 +34,10 @@ def parse_metrics(output_lines: Sequence[str], session_log_path: Path | None = N
         output_lines: Lines from Copilot CLI stderr output
         session_log_path: Optional path to session log file for tool usage parsing
 
-    Expected output format (new, v1.0.2+):
-        Changes   +17 -0
-        Requests  0.33 Premium (1m 45s)
-        Tokens    ↑ 317.5k • ↓ 4.3k • 255.0k (cached)
+    Expected output format (v1.0.57):
+        Changes    +67 -0
+        Requests   15 Premium (6m 47s)
+        Tokens     ↑ 1.6m (1.6m cached) • ↓ 20.7k (3.2k reasoning)
 
     Legacy output format:
         Total usage est:        0.33 Premium requests
@@ -97,9 +97,10 @@ def parse_metrics(output_lines: Sequence[str], session_log_path: Path | None = N
             prompt_tokens = _parse_token_count(usage_match.group(1))
             completion_tokens = _parse_token_count(usage_match.group(2))
 
-        # New format: "Tokens    ↑ 317.5k • ↓ 4.3k • 255.0k (cached)"
+        # New format: "Tokens    ↑ 1.6m (1.6m cached) • ↓ 20.7k (3.2k reasoning)"
+        # Anchor on the ↑/↓ arrows so parenthesized annotations between the numbers don't break parsing.
         if prompt_tokens is None:
-            tokens_match = re.search(r"Tokens\s+[^\d]*(\d+(?:\.\d+)?[km]?)\s*[•·]\s*[^\d]*(\d+(?:\.\d+)?[km]?)", output_text)
+            tokens_match = re.search(r"Tokens\s+.*?↑\s*(\d+(?:\.\d+)?[km]?).*?↓\s*(\d+(?:\.\d+)?[km]?)", output_text)
             if tokens_match:
                 prompt_tokens = _parse_token_count(tokens_match.group(1))
                 completion_tokens = _parse_token_count(tokens_match.group(2))

--- a/tests/test_copilot_metrics_parsing.py
+++ b/tests/test_copilot_metrics_parsing.py
@@ -200,23 +200,23 @@ def test_parse_metrics_minimal_real_output():
 
 def test_parse_metrics_new_format_full():
     output_lines = [
-        "Changes   +17 -0\n",
-        "Requests  0.33 Premium (1m 45s)\n",
-        "Tokens    ↑ 317.5k • ↓ 4.3k • 255.0k (cached)\n",
+        "Changes    +67 -0\n",
+        "Requests   15 Premium (6m 47s)\n",
+        "Tokens     ↑ 1.6m (1.6m cached) • ↓ 20.7k (3.2k reasoning)\n",
     ]
 
     result = parse_metrics(output_lines)
 
     assert result is not None
-    assert result.execution_time == 105.0
-    assert result.prompt_tokens == 317500
-    assert result.completion_tokens == 4300
+    assert result.execution_time == 407.0
+    assert result.prompt_tokens == 1600000
+    assert result.completion_tokens == 20700
 
 
 def test_parse_metrics_new_format_seconds_only():
     output_lines = [
         "Requests  1 Premium (45s)\n",
-        "Tokens    ↑ 125.5k • ↓ 3.6k • 0 (cached)\n",
+        "Tokens    ↑ 125.5k (0 cached) • ↓ 3.6k (0 reasoning)\n",
     ]
 
     result = parse_metrics(output_lines)
@@ -229,7 +229,7 @@ def test_parse_metrics_new_format_seconds_only():
 
 def test_parse_metrics_new_format_tokens_with_m():
     output_lines = [
-        "Tokens    ↑ 1.3m • ↓ 11.6k • 1.2m (cached)\n",
+        "Tokens    ↑ 1.3m (1.2m cached) • ↓ 11.6k (500 reasoning)\n",
     ]
 
     result = parse_metrics(output_lines)


### PR DESCRIPTION
Realized that after https://github.com/microsoft/BC-Bench/pull/656, there are few changes from the harness breaking us.

* Metrics are printed out using different formats => token consumptions are broken
* Hooks are not running => tool usages are not logged