### PR TITLE
Make result display extensible, category owner will handle their own metrics summary

### DIFF
--- a/src/bcbench/operations/hooks_operations.py
+++ b/src/bcbench/operations/hooks_operations.py
@@ -37,7 +37,7 @@ def _setup_copilot_hooks(repo_path: Path, script_path: str, tool_log_path: Path)
             "preToolUse": [
                 {
                     "type": "command",
-                    "powershell": f'powershell -ExecutionPolicy Bypass -File "{script_path}"',
+                    "command": f'pwsh -ExecutionPolicy Bypass -File "{script_path}"',
                     "env": {"BCBENCH_TOOL_LOG": str(tool_log_path.resolve())},
                     "timeoutSec": 5,
                 }
@@ -68,7 +68,7 @@ def _setup_claude_hooks(repo_path: Path, script_path: str, tool_log_path: Path) 
                 "hooks": [
                     {
                         "type": "command",
-                        "command": f'BCBENCH_TOOL_LOG="{tool_log_resolved}" powershell -ExecutionPolicy Bypass -File "{script_path}"',
+                        "command": f'BCBENCH_TOOL_LOG="{tool_log_resolved}" pwsh -ExecutionPolicy Bypass -File "{script_path}"',
                     }
                 ],
             }

--- a/src/bcbench/results/display.py
+++ b/src/bcbench/results/display.py
@@ -22,14 +22,18 @@ def _status_style(status_label: str) -> tuple[str, str]:
 
 
 def create_console_summary(results: Sequence[BaseEvaluationResult], summary: EvaluationResultSummary) -> None:
-    total = len(results)
-    display_metrics: dict[str, int | float | bool] = summary.display_summary()
-
     console.print("\n[bold cyan]Evaluation Results Summary[/bold cyan]")
-    console.print(f"Total Processed: [bold]{total}[/bold], using [bold]{results[0].agent_name}({results[0].model})[/bold]")
+    console.print(f"Total Processed: [bold]{len(results)}[/bold], using [bold]{results[0].agent_name}({results[0].model})[/bold]")
     console.print(f"Category: [bold]{results[0].category.value}[/bold]")
-    for key, value in display_metrics.items():
-        console.print(f"{key.replace('_', ' ').title()}: [bold]{value}[/bold]")
+    console.print(f"MCP Servers: [bold]{', '.join(results[0].experiment.mcp_servers) if results[0].experiment and results[0].experiment.mcp_servers else 'None'}[/bold]")
+    console.print(f"AL LSP: [bold]{'Yes' if results[0].experiment and results[0].experiment.al_lsp_enabled else 'No'}[/bold]")
+    console.print(f"Custom Instructions: [bold]{'Yes' if results[0].experiment and results[0].experiment.custom_instructions else 'No'}[/bold]")
+    console.print(f"Skills: [bold]{'Yes' if results[0].experiment and results[0].experiment.skills_enabled else 'No'}[/bold]")
+    console.print(f"Custom Agent: [bold]{results[0].experiment.custom_agent if results[0].experiment and results[0].experiment.custom_agent else 'N/A'}[/bold]")
+
+    metrics = summary.render_console_metrics()
+    if metrics is not None:
+        console.print(metrics)
 
     # Display average tool usage if available
     tool_usages = [r.metrics.tool_usage for r in results if r.metrics and r.metrics.tool_usage is not None]
@@ -72,43 +76,31 @@ def _get_short_error_message(error_message: str | None) -> str:
 
 
 def create_github_job_summary(results: Sequence[BaseEvaluationResult], summary: EvaluationResultSummary) -> None:
-    total = len(results)
-    display_metrics: dict[str, int | float | bool] = summary.display_summary()
-
-    mcp_servers = ", ".join(results[0].experiment.mcp_servers) if results[0].experiment and results[0].experiment.mcp_servers else "None"
-    al_lsp_enabled = "Yes" if results[0].experiment and results[0].experiment.al_lsp_enabled else "No"
-    custom_instructions = "Yes" if results[0].experiment and results[0].experiment.custom_instructions else "No"
-    skills = "Yes" if results[0].experiment and results[0].experiment.skills_enabled else "No"
-    custom_agent = results[0].experiment.custom_agent if results[0].experiment and results[0].experiment.custom_agent else "N/A"
+    metrics_section: str = summary.render_github_metrics_markdown().strip()
 
     # Calculate average tool usage
-    tool_usage_section = ""
+    tool_usage_section: str = ""
     tool_usages = [r.metrics.tool_usage for r in results if r.metrics and r.metrics.tool_usage is not None]
     if tool_usages:
         avg_usage = calculate_average_tool_usage(tool_usages)
         if avg_usage:
             sorted_tools = sorted(avg_usage.items(), key=lambda x: x[1], reverse=True)
             tool_lines = [f"  - `{tool}`: {count}" for tool, count in sorted_tools]
-            tool_usage_section = "\n\n## Average Tool Usage\n" + "\n".join(tool_lines)
+            tool_usage_section = "## Average Tool Usage\n" + "\n".join(tool_lines)
 
-    # Only render "## Result Summary" when the category has aggregates to show.
-    result_summary_section = ""
-    if display_metrics:
-        display_lines = "\n".join(f"- {key.replace('_', ' ').title()}: {value}" for key, value in display_metrics.items())
-        result_summary_section = f"\n## Result Summary\n{display_lines}\n"
-
-    markdown_summary = (
-        f"Total entries processed: {total}, using **{results[0].agent_name} ({results[0].model})**\n"
-        f"- Category: `{results[0].category.value}`\n"
-        f"- MCP Servers used: {mcp_servers}\n"
-        f"- AL LSP: {al_lsp_enabled}\n"
-        f"- Custom Instructions: {custom_instructions}\n"
-        f"- Skills: {skills}\n"
-        f"- Custom Agent: {custom_agent}\n"
-        f"{result_summary_section}"
-        f"{tool_usage_section}\n\n"
-        f"## Detailed Results\n\n"
+    header_section: str = "\n".join(
+        [
+            f"Total entries processed: {len(results)}, using **{results[0].agent_name} ({results[0].model})**",
+            f"- Category: `{results[0].category.value}`",
+            f"- MCP Servers used: {', '.join(results[0].experiment.mcp_servers) if results[0].experiment and results[0].experiment.mcp_servers else 'None'}",
+            f"- AL LSP: {'Yes' if results[0].experiment and results[0].experiment.al_lsp_enabled else 'No'}",
+            f"- Custom Instructions: {'Yes' if results[0].experiment and results[0].experiment.custom_instructions else 'No'}",
+            f"- Skills: {'Yes' if results[0].experiment and results[0].experiment.skills_enabled else 'No'}",
+            f"- Custom Agent: {results[0].experiment.custom_agent if results[0].experiment and results[0].experiment.custom_agent else 'N/A'}",
+        ]
     )
+    sections: list[str] = [header_section, *(section for section in [metrics_section, tool_usage_section] if section), "## Detailed Results\n\n"]
+    markdown_summary: str = "\n\n".join(sections)
 
     # Dynamic columns from display_row()
     extra_columns = list(results[0].display_row.keys()) if results else []

--- a/src/bcbench/results/summary.py
+++ b/src/bcbench/results/summary.py
@@ -5,13 +5,16 @@ from collections import Counter
 from collections.abc import Sequence
 from datetime import date
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, Field
 
 from bcbench.logger import get_logger
 from bcbench.results.base import BaseEvaluationResult
 from bcbench.types import EvaluationCategory, ExperimentConfiguration
+
+if TYPE_CHECKING:
+    from rich.console import RenderableType
 
 logger = get_logger(__name__)
 
@@ -56,11 +59,18 @@ class EvaluationResultSummary(BaseModel, ABC):
     benchmark_version: str
 
     @abstractmethod
-    def display_summary(self) -> dict[str, int | float]:
-        """Return category-specific metrics for console/GitHub summary display.
+    def render_github_metrics_markdown(self) -> str:
+        """Markdown metrics block between the run header and the Detailed Results table (GitHub Actions summary).
 
-        Subclasses must override. Keys become display labels (underscores replaced with spaces and title-cased). Values are shown as-is.
+        Shown after every CI run, so each category must explicitly decide what to surface (return "" for none).
         """
+
+    def render_console_metrics(self) -> "RenderableType | None":
+        """Rich renderable for the metrics block printed by display.py after each run (console).
+
+        Defaults to no metrics block. Subclasses override to add category-specific metrics.
+        """
+        return None
 
     @classmethod
     def from_results(cls, results: Sequence[BaseEvaluationResult], run_id: str) -> "EvaluationResultSummary":
@@ -140,12 +150,8 @@ class ExecutionBasedEvaluationResultSummary(EvaluationResultSummary):
     # Per-instance pass/fail for aggregate metrics (pass^k, CI)
     instance_results: dict[str, bool] = Field(default_factory=dict)
 
-    def display_summary(self) -> dict[str, int | float]:
-        return {
-            "resolved": self.resolved,
-            "failed": self.failed,
-            "build": self.build,
-        }
+    def render_github_metrics_markdown(self) -> str:
+        return f"## Result Summary\n- Resolved: {self.resolved}\n- Failed: {self.failed}\n- Build: {self.build}\n- Pass Rate: {self.percentage}%\n"
 
     @classmethod
     def from_results(cls, results: Sequence[BaseEvaluationResult], run_id: str) -> "ExecutionBasedEvaluationResultSummary":
@@ -177,8 +183,9 @@ class JudgeBasedEvaluationResultSummary(EvaluationResultSummary):
     this summary only carries the agent-execution aggregates from the base class.
     """
 
-    def display_summary(self) -> dict[str, int | float]:
-        return {}
+    def render_github_metrics_markdown(self) -> str:
+        """Judge scoring happens externally, so there are no in-run metrics to surface."""
+        return ""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_hooks_operations.py
+++ b/tests/test_hooks_operations.py
@@ -24,7 +24,7 @@ class TestSetupHooks:
 
         hook = hooks_config["hooks"]["preToolUse"][0]
         assert hook["type"] == "command"
-        assert "powershell" in hook
+        assert "command" in hook
         assert "BCBENCH_TOOL_LOG" in hook["env"]
         assert hook["timeoutSec"] == 5
 
@@ -83,7 +83,7 @@ class TestSetupHooks:
 
         hooks_file = repo_path / ".github" / "hooks" / "bcbench-hooks.json"
         hooks_config = json.loads(hooks_file.read_text(encoding="utf-8"))
-        powershell_cmd = hooks_config["hooks"]["preToolUse"][0]["powershell"]
+        powershell_cmd = hooks_config["hooks"]["preToolUse"][0]["command"]
 
         # The command should contain an absolute path to the script
         assert "log-tool-usage.ps1" in powershell_cmd

--- a/tests/test_result_hierarchy.py
+++ b/tests/test_result_hierarchy.py
@@ -6,7 +6,7 @@ Covers:
 - from_json dispatch to correct subclass
 - EvaluationResultSummary.from_results dispatch and super() chain
 - ExecutionBasedEvaluationResultSummary category-specific aggregation
-- display_summary on summaries
+- metrics rendering on summaries
 - display.py console/GitHub summary rendering
 """
 
@@ -20,6 +20,7 @@ from bcbench.results.display import create_console_summary, create_github_job_su
 from bcbench.results.summary import (
     EvaluationResultSummary,
     ExecutionBasedEvaluationResultSummary,
+    JudgeBasedEvaluationResultSummary,
 )
 from bcbench.results.testgeneration import TestGenerationResult
 from bcbench.types import AgentMetrics, EvaluationCategory
@@ -257,13 +258,13 @@ class TestSummaryFromResults:
 
 
 # ---------------------------------------------------------------------------
-# display_summary
+# metrics rendering
 # ---------------------------------------------------------------------------
 
 
-class TestDisplaySummary:
-    def test_execution_based_display_summary(self):
-        summary = ExecutionBasedEvaluationResultSummary(
+class TestMetricsRendering:
+    def _summary(self) -> ExecutionBasedEvaluationResultSummary:
+        return ExecutionBasedEvaluationResultSummary(
             total=10,
             resolved=7,
             failed=3,
@@ -278,8 +279,30 @@ class TestDisplaySummary:
             average_completion_tokens=500.0,
             benchmark_version="0.1.0",
         )
-        display = summary.display_summary()
-        assert display == {"resolved": 7, "failed": 3, "build": 9}
+
+    def test_execution_based_github_metrics_markdown(self):
+        markdown = self._summary().render_github_metrics_markdown()
+        assert markdown == "## Result Summary\n- Resolved: 7\n- Failed: 3\n- Build: 9\n- Pass Rate: 70.0%\n"
+
+    def test_execution_based_console_metrics_renders_nothing(self):
+        # execution-based categories intentionally render no console metrics block
+        assert self._summary().render_console_metrics() is None
+
+    def test_judge_based_renders_no_metrics(self):
+        # JudgeBased explicitly surfaces no GitHub metrics and inherits the console no-op default
+        summary = JudgeBasedEvaluationResultSummary(
+            total=3,
+            date=date.today(),
+            model="gpt-4o",
+            agent_name="copilot",
+            category=EvaluationCategory.BUG_FIX,
+            average_duration=1.0,
+            average_prompt_tokens=1.0,
+            average_completion_tokens=1.0,
+            benchmark_version="0.1.0",
+        )
+        assert summary.render_github_metrics_markdown() == ""
+        assert summary.render_console_metrics() is None
 
 
 # ---------------------------------------------------------------------------
@@ -365,6 +388,8 @@ class TestGitHubJobSummary:
         assert "test__1" in content
         assert "test__2" in content
         assert "bug-fix" in content
+        assert "- Custom Agent: N/A\n\n## Result Summary" in content
+        assert "- Pass Rate: 50.0%\n\n## Detailed Results" in content
 
     def test_github_summary_includes_testgen_columns(self, tmp_path, monkeypatch):
         summary_file = tmp_path / "summary.md"


### PR DESCRIPTION
Extract more extensible things identified from code review category

Making the tool usage logging hook OS agnostic