### PR TITLE
Each category gets their own queue

### DIFF
--- a/.github/workflows/copilot-evaluation.yml
+++ b/.github/workflows/copilot-evaluation.yml
@@ -58,7 +58,7 @@ on:
           - "5"
 
 concurrency:
-  group: copilot-evaluation-${{ inputs.test-run && 'test' || 'full' }}
+  group: copilot-evaluation-${{ inputs.test-run && 'test' || 'full' }}-${{ inputs.category }}
   cancel-in-progress: false
 
 env:


### PR DESCRIPTION
After switching to org-level token, we should get much better rate limit, allowing each category to have their own queue