### PR TITLE
Leverage caching artifacts in the rest of categories

### DIFF
--- a/.github/actions/setup-bc-container-repo/action.yml
+++ b/.github/actions/setup-bc-container-repo/action.yml
@@ -63,6 +63,25 @@ runs:
         tenant-id: ${{ inputs.azure-tenant-id }}
         allow-no-subscriptions: true
 
+    - name: Resolve BC version for artifact cache
+      if: inputs.skip-container != 'true'
+      id: bcversion
+      shell: pwsh
+      run: |
+        Import-Module ./scripts/BCBenchUtils.psm1 -Force -DisableNameChecking
+        $version = Get-BCBenchEntryVersion -InstanceId "${{ inputs.instance-id }}" -Category "${{ inputs.category }}"
+        "version=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+    # Reuse BC artifacts (app + platform) at BcContainerHelper's default host cache so New-BcContainer /
+    # New-BcCompilerFolder skip the multi-GB download. Download-Artifacts is cache-first (useVolumes=$false),
+    # keyed by the entry's BC sandbox version and shared across workflows that use this action.
+    - name: Cache BC sandbox artifacts
+      if: inputs.skip-container != 'true'
+      uses: actions/cache@v5
+      with:
+        path: C:\bcartifacts.cache
+        key: bcartifacts-${{ steps.bcversion.outputs.version }}
+
     - name: Setup BC container and repository for ${{ inputs.instance-id }}
       id: setup
       env:

--- a/.github/actions/setup-bc-container-repo/action.yml
+++ b/.github/actions/setup-bc-container-repo/action.yml
@@ -72,9 +72,6 @@ runs:
         $version = Get-BCBenchEntryVersion -InstanceId "${{ inputs.instance-id }}" -Category "${{ inputs.category }}"
         "version=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
-    # Reuse BC artifacts (app + platform) at BcContainerHelper's default host cache so New-BcContainer /
-    # New-BcCompilerFolder skip the multi-GB download. Download-Artifacts is cache-first (useVolumes=$false),
-    # keyed by the entry's BC sandbox version and shared across workflows that use this action.
     - name: Cache BC sandbox artifacts
       if: inputs.skip-container != 'true'
       uses: actions/cache@v5

--- a/scripts/BCBenchUtils.psm1
+++ b/scripts/BCBenchUtils.psm1
@@ -507,6 +507,52 @@ function Get-BCBenchDatasetPath {
 
 <#
 .SYNOPSIS
+    Resolves the BC sandbox version (environment_setup_version) for a dataset entry.
+.DESCRIPTION
+    Centralizes the category -> dataset -> version lookup used by container setup, symbol download,
+    and the CI artifact cache key. Resolves the dataset file via Get-BCBenchDatasetPath.
+.PARAMETER InstanceId
+    The dataset instance_id to resolve.
+.PARAMETER Category
+    The dataset category, used to locate the dataset file.
+.PARAMETER DatasetPath
+    Optional override for the dataset (.jsonl) path. Defaults to the category-specific path via Get-BCBenchDatasetPath.
+.OUTPUTS
+    The environment_setup_version string, e.g. "26.5".
+.EXAMPLE
+    Get-BCBenchEntryVersion -InstanceId "bug-fix__job-budget-report-1" -Category "bug-fix"
+#>
+function Get-BCBenchEntryVersion {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $InstanceId,
+
+        [Parameter(Mandatory = $true)]
+        [string] $Category,
+
+        [Parameter(Mandatory = $false)]
+        [string] $DatasetPath = (Get-BCBenchDatasetPath -Category $Category)
+    )
+
+    if (-not (Test-Path $DatasetPath)) {
+        throw "Dataset file not found at: $DatasetPath"
+    }
+
+    foreach ($line in Get-Content -Path $DatasetPath) {
+        if ([string]::IsNullOrWhiteSpace($line)) { continue }
+        $entry = $line | ConvertFrom-Json
+        if ($entry.instance_id -eq $InstanceId) {
+            return $entry.environment_setup_version
+        }
+    }
+
+    throw "Entry '$InstanceId' not found in $DatasetPath"
+}
+
+<#
+.SYNOPSIS
     Returns the latest BCApps release branch name (e.g. "releases/28.5").
 .DESCRIPTION
     Lists all refs under refs/heads/releases/ via the GitHub API and returns
@@ -543,4 +589,4 @@ function Get-LatestReleaseBranch {
     return $latest.Name
 }
 
-Export-ModuleMember -Function Get-BCCredential, Invoke-GitCloneWithRetry, Get-EnvironmentVariable, Write-Log, Invoke-GitApplyPatch, Update-AppProjectVersion, Get-BCBenchDatasetPath, Get-RepoCloneInfo, Get-LatestReleaseBranch
+Export-ModuleMember -Function Get-BCCredential, Invoke-GitCloneWithRetry, Get-EnvironmentVariable, Write-Log, Invoke-GitApplyPatch, Update-AppProjectVersion, Get-BCBenchDatasetPath, Get-BCBenchEntryVersion, Get-RepoCloneInfo, Get-LatestReleaseBranch

--- a/scripts/Download-BCSymbols.ps1
+++ b/scripts/Download-BCSymbols.ps1
@@ -1,4 +1,3 @@
-using module .\DatasetEntry.psm1
 using module .\BCBenchUtils.psm1
 
 <#
@@ -11,9 +10,9 @@ using module .\BCBenchUtils.psm1
 .PARAMETER InstanceId
     The dataset instance_id to resolve the BC version for.
 .PARAMETER Category
-    The dataset category (`bug-fix` or `test-generation`) to resolve the dataset path for (if DatasetPath is not explicitly provided).
+    The dataset category used to resolve the dataset path (via Get-BCBenchDatasetPath).
 .PARAMETER DatasetPath
-    Path to the dataset (.jsonl). Defaults to the category-specific dataset path in the repo, for example dataset/bug-fix.jsonl or dataset/test-generation.jsonl.
+    Optional override for the dataset (.jsonl) path. Defaults to the category-specific path via Get-BCBenchDatasetPath.
 .PARAMETER Country
     BC artifact country (default: w1).
 .EXAMPLE
@@ -35,11 +34,7 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
-[DatasetEntry[]] $entries = Get-DatasetEntries -DatasetPath $DatasetPath -InstanceId $InstanceId
-if (-not $entries -or $entries.Count -eq 0) {
-    throw "Entry '$InstanceId' not found in $DatasetPath"
-}
-[string] $version = $entries[0].environment_setup_version
+[string] $version = Get-BCBenchEntryVersion -InstanceId $InstanceId -Category $Category -DatasetPath $DatasetPath
 Write-Log "Resolved BC version $version for InstanceId $InstanceId" -Level Info
 
 Import-Module BcContainerHelper -Force -DisableNameChecking


### PR DESCRIPTION
Caching the BC artifacts for the rest of categories, just like `NL2AL`.

This should speed up the evaluation for `Bug Fixing` and `Test Generation` and reduce the instability.