### PR TITLE
Key code-review per-task F1 by instance_id

### DIFF
--- a/src/bcbench/results/codereview.py
+++ b/src/bcbench/results/codereview.py
@@ -247,9 +247,9 @@ class CodeReviewResultSummary(EvaluationResultSummary):
     severity_mae: float = 0.0
     valid_review_output_rate: float = Field(default=0.0, ge=0.0, le=1.0)
 
-    # Per-task F1 scores, retained so the leaderboard can bootstrap a confidence interval over tasks
-    # (meaningful even for a single run) instead of only over runs.
-    per_task_f1: list[float] = Field(default_factory=list)
+    # Per-task F1 keyed by instance_id, retained so the leaderboard can bootstrap a confidence
+    # interval over tasks (meaningful even for a single run) instead of only over runs.
+    instance_results: dict[str, float] = Field(default_factory=dict)
 
     def render_github_metrics_markdown(self) -> str:
         micro_p = self.precision * 100
@@ -397,6 +397,6 @@ class CodeReviewResultSummary(EvaluationResultSummary):
                 "macro_f_beta_2": round(macro_f_beta_2, 3),
                 "severity_mae": round(severity_mae, 3),
                 "valid_review_output_rate": round(valid_output_rate, 3),
-                "per_task_f1": [round(r.f1, 6) for r in code_review_results],
+                "instance_results": {r.instance_id: round(r.f1, 6) for r in code_review_results},
             }
         )

--- a/src/bcbench/results/leaderboard.py
+++ b/src/bcbench/results/leaderboard.py
@@ -151,7 +151,7 @@ class CodeReviewLeaderboardAggregate(LeaderboardAggregate):
         # pooled per-task F1 scores across runs: the CI reflects task-level variance (resampling tasks),
         # which is the dominant sampling uncertainty for our small task set and is meaningful even for a
         # single run. This deliberately differs from the per-run micro CI above.
-        pooled_task_f1 = [score for r in cr_runs for score in r.per_task_f1]
+        pooled_task_f1 = [score for r in cr_runs for score in r.instance_results.values()]
         macro_f1_ci = bootstrap_ci(pooled_task_f1)
 
         return base.model_copy(

--- a/tests/test_codereview.py
+++ b/tests/test_codereview.py
@@ -546,8 +546,13 @@ class TestCodeReviewLeaderboardAggregate:
         ]
         run = CodeReviewResultSummary.from_results(results, run_id="run-1")
 
-        # Per-task F1 is retained so the CI can be bootstrapped over tasks.
-        assert run.per_task_f1 == [1.0, 0.0, 1.0, 0.0]
+        # Per-task F1 is retained (keyed by instance_id) so the CI can be bootstrapped over tasks.
+        assert run.instance_results == {
+            "test__t-1": 1.0,
+            "test__t-2": 0.0,
+            "test__t-3": 1.0,
+            "test__t-4": 0.0,
+        }
 
         agg = LeaderboardAggregate.from_runs([run])
 


### PR DESCRIPTION
## Problem
The code-review leaderboard stored per-task F1 as a bare `per_task_f1: list[float]`, so the JSON showed an anonymous array of scores with no indication of which task each value belonged to.

## Solution
Replace `per_task_f1: list[float]` with `instance_results: dict[str, float]` (`instance_id` -> F1), mirroring the existing execution-based `instance_results` schema. Each task's F1 is now labeled by its instance id.

## Changes
- `src/bcbench/results/codereview.py`: field + `from_results` serialization now build a dict keyed by `instance_id`.
- `src/bcbench/results/leaderboard.py`: bootstrap pooling reads `r.instance_results.values()` (CI behavior unchanged).
- `tests/test_codereview.py`: assertion updated to the dict form.

## Testing
- ruff check/format, `ty` (CI args), full suite: 548 passed, 1 skipped.

## Notes
First version of this leaderboard schema (not yet merged elsewhere), so no migration/back-compat needed.