### PR TITLE
Add lsp.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -276,3 +276,5 @@ docs/Gemfile
 docs/Gemfile.lock
 
 *.orig
+
+lsp.json


### PR DESCRIPTION
## Summary
Adds `lsp.json` to `.gitignore` so generated AL language-server config files (e.g. `.github/lsp.json`) are no longer tracked or shown in `git status`.

## Changes
- Append `lsp.json` to `.gitignore`

## Verification
- `git status` no longer lists `.github/lsp.json` as untracked