### PR TITLE
Provision Copilot CLI for code-review judge in Claude workflow

### DIFF
--- a/.github/actions/install-eval-clis/action.yml
+++ b/.github/actions/install-eval-clis/action.yml
@@ -1,4 +1,4 @@
-name: Install evaluation CLIs
+name: Install Agent Harnesses
 description: Install the Claude Code and GitHub Copilot CLIs used by the evaluation workflows
 
 runs:

--- a/.github/actions/install-eval-clis/action.yml
+++ b/.github/actions/install-eval-clis/action.yml
@@ -1,0 +1,13 @@
+name: Install evaluation CLIs
+description: Install the Claude Code and GitHub Copilot CLIs used by the evaluation workflows
+
+runs:
+  using: composite
+  steps:
+    - name: Install Claude Code
+      run: npm install -g @anthropic-ai/claude-code@2.1.160
+      shell: pwsh
+
+    - name: Install GitHub Copilot CLI
+      run: npm install -g @github/copilot@1.0.57
+      shell: pwsh

--- a/.github/workflows/claude-evaluation.yml
+++ b/.github/workflows/claude-evaluation.yml
@@ -114,7 +114,7 @@ jobs:
           dotnet tool install -g Microsoft.Dynamics.BusinessCentral.Development.Tools --version 18.0.37.11445-beta
           echo "$HOME\.dotnet\tools" >> $env:GITHUB_PATH
 
-      - name: Install evaluation CLIs
+      - name: Install Agent Harnesses
         uses: ./.github/actions/install-eval-clis
 
       - name: Run Claude Code for entry ${{ matrix.entry }}

--- a/.github/workflows/claude-evaluation.yml
+++ b/.github/workflows/claude-evaluation.yml
@@ -114,14 +114,8 @@ jobs:
           dotnet tool install -g Microsoft.Dynamics.BusinessCentral.Development.Tools --version 18.0.37.11445-beta
           echo "$HOME\.dotnet\tools" >> $env:GITHUB_PATH
 
-      - name: Install Claude Code
-        run: npm install -g @anthropic-ai/claude-code@2.1.160
-
-      # The code-review category scores findings with a semantic judge that runs on Copilot CLI,
-      # regardless of the agent under test. Provision it only when judging is needed.
-      - name: Install GitHub Copilot CLI (code-review judge)
-        if: ${{ inputs.category == 'code-review' }}
-        run: npm install -g @github/copilot@1.0.57
+      - name: Install evaluation CLIs
+        uses: ./.github/actions/install-eval-clis
 
       - name: Run Claude Code for entry ${{ matrix.entry }}
         timeout-minutes: 120

--- a/.github/workflows/claude-evaluation.yml
+++ b/.github/workflows/claude-evaluation.yml
@@ -77,6 +77,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      copilot-requests: write  # code-review semantic judge runs via Copilot CLI
     name: ${{ matrix.entry }}
     strategy:
       fail-fast: false
@@ -116,13 +117,21 @@ jobs:
       - name: Install Claude Code
         run: npm install -g @anthropic-ai/claude-code@2.1.160
 
+      # The code-review category scores findings with a semantic judge that runs on Copilot CLI,
+      # regardless of the agent under test. Provision it only when judging is needed.
+      - name: Install GitHub Copilot CLI (code-review judge)
+        if: ${{ inputs.category == 'code-review' }}
+        run: npm install -g @github/copilot@1.0.57
+
       - name: Run Claude Code for entry ${{ matrix.entry }}
         timeout-minutes: 120
         shell: pwsh
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          COPILOT_GITHUB_TOKEN: ${{ github.token }}  # used by the code-review semantic judge
         run: |
           Write-Output "::add-mask::$env:ANTHROPIC_API_KEY"
+          Write-Output "::add-mask::$env:COPILOT_GITHUB_TOKEN"
 
           uv run bcbench evaluate claude "${{ matrix.entry }}" `
             --model "${{ inputs.model }}" `

--- a/.github/workflows/copilot-evaluation.yml
+++ b/.github/workflows/copilot-evaluation.yml
@@ -121,8 +121,8 @@ jobs:
           dotnet tool install -g Microsoft.Dynamics.BusinessCentral.Development.Tools --version 18.0.37.11445-beta
           echo "$HOME\.dotnet\tools" >> $env:GITHUB_PATH
 
-      - name: Install GitHub Copilot CLI
-        run: npm install -g @github/copilot@1.0.57
+      - name: Install evaluation CLIs
+        uses: ./.github/actions/install-eval-clis
 
       - name: Run GitHub Copilot CLI for entry ${{ matrix.entry }}
         timeout-minutes: 120


### PR DESCRIPTION
## Problem

Running the **code-review** category through the Claude evaluation workflow fails in the scoring step with:

```
LLMJudgeError: Copilot CLI not found; cannot run the semantic judge
```

The code-review semantic judge (`judge_verdicts` in `src/bcbench/evaluate/codereview_judge.py`) always runs on **Copilot CLI** as a fixed, agent-independent judge. But `claude-evaluation.yml` only installs Claude Code — it never provisions Copilot CLI, the `copilot-requests` permission, or `COPILOT_GITHUB_TOKEN` — so judging dies for any Claude code-review run.

This is a pre-existing gap in the Claude workflow, unrelated to the BCQuality work in #696.

## Fix

In `.github/workflows/claude-evaluation.yml`:
- Add `copilot-requests: write` to the evaluation job permissions.
- Install `@github/copilot@1.0.57`, gated on `category == 'code-review'` (skipped for bug-fix / test-generation to save time).
- Pass `COPILOT_GITHUB_TOKEN: ${{ github.token }}` to the run step and mask it.

This mirrors the judge environment already present in `copilot-evaluation.yml`.

## Testing

Workflow-only change. To validate: run the Claude evaluation workflow with `category: code-review` (test-run) and confirm the judge step no longer errors.
