### PR TITLE
Remove bcquality as first-class experiment config

### DIFF
--- a/src/bcbench/types.py
+++ b/src/bcbench/types.py
@@ -95,18 +95,13 @@ class ExperimentConfiguration(BaseModel):
     # Custom agent name used in experiment (if any)
     custom_agent: str | None = None
 
-    # Live BCQuality consumption enabled (code-review category only)
-    bcquality: bool = False
-
     def is_empty(self) -> bool:
         """Check if this configuration has all default/empty values.
 
         An empty configuration means no special experiment settings were used.
         This is useful for comparing with None (no experiment) vs default experiment.
         """
-        return (
-            self.mcp_servers is None and self.al_lsp_enabled is False and self.custom_instructions is False and self.skills_enabled is False and self.custom_agent is None and self.bcquality is False
-        )
+        return self.mcp_servers is None and self.al_lsp_enabled is False and self.custom_instructions is False and self.skills_enabled is False and self.custom_agent is None
 
 
 class AgentType(StrEnum):


### PR DESCRIPTION
BCQuality is a collection of skills and instructions, it shouldn't be a first-class experimentation configuration, leverage existing config instead.

We will brainstorm a way to best enable configuration of https://github.com/microsoft/BCQuality to experiment here