### PR TITLE
docs(code-review): drop bcquality variant, show only inline-knowledge arm

### DIFF
--- a/docs/code-review.md
+++ b/docs/code-review.md
@@ -66,7 +66,6 @@ Unlike the pass/fail categories, code review is scored with **Precision / Recall
 Compares review-knowledge configurations for the same model (see the Baseline Leaderboard above for the plain agent):
 
 - **Inline knowledge (pre-#8700)** — the review checklists BCApps shipped inline before adopting BCQuality, injected as custom instructions.
-- **BCQuality (live skills)** — the agent dynamically consumes the live BCQuality skill tree.
 
 {% assign experiment_rows = site.data.code-review.aggregate | where_exp: "agg", "agg.experiment" %}
 {% if experiment_rows and experiment_rows.size > 0 %}
@@ -89,8 +88,7 @@ Compares review-knowledge configurations for the same model (see the Baseline Le
     {% for agg in experiment_results %}
     <tr>
       <td>
-        {%- if agg.experiment.bcquality -%}BCQuality (live skills)
-        {%- elsif agg.experiment.custom_instructions -%}Inline knowledge (pre-#8700)
+        {%- if agg.experiment.custom_instructions -%}Inline knowledge (pre-#8700)
         {%- else -%}Other{%- endif -%}
       </td>
       <td>{{ agg.agent_name }}</td>

--- a/src/bcbench/types.py
+++ b/src/bcbench/types.py
@@ -95,18 +95,13 @@ class ExperimentConfiguration(BaseModel):
     # Custom agent name used in experiment (if any)
     custom_agent: str | None = None
 
-    # Live BCQuality consumption enabled (code-review category only)
-    bcquality: bool = False
-
     def is_empty(self) -> bool:
         """Check if this configuration has all default/empty values.
 
         An empty configuration means no special experiment settings were used.
         This is useful for comparing with None (no experiment) vs default experiment.
         """
-        return (
-            self.mcp_servers is None and self.al_lsp_enabled is False and self.custom_instructions is False and self.skills_enabled is False and self.custom_agent is None and self.bcquality is False
-        )
+        return self.mcp_servers is None and self.al_lsp_enabled is False and self.custom_instructions is False and self.skills_enabled is False and self.custom_agent is None
 
 
 class AgentType(StrEnum):

--- a/src/bcbench/types.py
+++ b/src/bcbench/types.py
@@ -95,13 +95,18 @@ class ExperimentConfiguration(BaseModel):
     # Custom agent name used in experiment (if any)
     custom_agent: str | None = None
 
+    # Live BCQuality consumption enabled (code-review category only)
+    bcquality: bool = False
+
     def is_empty(self) -> bool:
         """Check if this configuration has all default/empty values.
 
         An empty configuration means no special experiment settings were used.
         This is useful for comparing with None (no experiment) vs default experiment.
         """
-        return self.mcp_servers is None and self.al_lsp_enabled is False and self.custom_instructions is False and self.skills_enabled is False and self.custom_agent is None
+        return (
+            self.mcp_servers is None and self.al_lsp_enabled is False and self.custom_instructions is False and self.skills_enabled is False and self.custom_agent is None and self.bcquality is False
+        )
 
 
 class AgentType(StrEnum):


### PR DESCRIPTION
## What

Hide the **BCQuality (live skills)** variant from the code-review experiment leaderboard, leaving only the **Inline knowledge (pre-#8700)** arm. The live BCQuality run is still in progress, so only the finished inline-skills variant is displayed.

## Changes

- `docs/code-review.md`: drop the BCQuality bullet and its `{%- if agg.experiment.bcquality -%}` branch; the experiment table now labels rows as Inline knowledge or Other.

## Notes

- bcquality is no longer a first-class experiment config (removed in #709), so labeling the live arm there would be dead code.
- Once the BCQuality run lands we can re-introduce its column.
