### PR TITLE
Upload branch name and experimentation details in Kusto

### DIFF
--- a/.github/workflows/claude-evaluation.yml
+++ b/.github/workflows/claude-evaluation.yml
@@ -50,6 +50,11 @@ on:
           - "3"
           - "4"
           - "5"
+      git-ref:
+        description: "Branch to record for experiment tracking (auto-filled on requeue; leave blank for manual runs)"
+        required: false
+        default: ""
+        type: string
 
 concurrency:
   group: claude-evaluation-${{ inputs.test-run && 'test' || 'full' }}
@@ -155,6 +160,7 @@ jobs:
       agent: "Claude Code"
       mock: ${{ inputs.test-run }}
       category: ${{ inputs.category }}
+      git-ref: ${{ inputs.git-ref || github.ref_name }}
     secrets: inherit
 
   requeue:
@@ -168,4 +174,4 @@ jobs:
       workflow-file: claude-evaluation.yml
       repeat: ${{ inputs.repeat }}
       workflow-inputs: |
-        {"model": "${{ inputs.model }}", "category": "${{ inputs.category }}", "test-run": "${{ inputs.test-run }}", "al-mcp": "${{ inputs.al-mcp }}", "al-lsp": "${{ inputs.al-lsp }}"}
+        {"model": "${{ inputs.model }}", "category": "${{ inputs.category }}", "test-run": "${{ inputs.test-run }}", "al-mcp": "${{ inputs.al-mcp }}", "al-lsp": "${{ inputs.al-lsp }}", "git-ref": "${{ inputs.git-ref || github.ref_name }}"}

--- a/.github/workflows/copilot-evaluation.yml
+++ b/.github/workflows/copilot-evaluation.yml
@@ -57,6 +57,11 @@ on:
           - "3"
           - "4"
           - "5"
+      git-ref:
+        description: "Branch to record for experiment tracking (auto-filled on requeue; leave blank for manual runs)"
+        required: false
+        default: ""
+        type: string
 
 concurrency:
   group: copilot-evaluation-${{ inputs.test-run && 'test' || 'full' }}-${{ inputs.category }}
@@ -160,6 +165,7 @@ jobs:
       agent: "GitHub Copilot CLI"
       mock: ${{ inputs.test-run }}
       category: ${{ inputs.category }}
+      git-ref: ${{ inputs.git-ref || github.ref_name }}
     secrets: inherit
 
   requeue:
@@ -173,4 +179,4 @@ jobs:
       workflow-file: copilot-evaluation.yml
       repeat: ${{ inputs.repeat }}
       workflow-inputs: |
-        {"model": "${{ inputs.model }}", "category": "${{ inputs.category }}", "test-run": "${{ inputs.test-run }}", "al-mcp": "${{ inputs.al-mcp }}", "al-lsp": "${{ inputs.al-lsp }}"}
+        {"model": "${{ inputs.model }}", "category": "${{ inputs.category }}", "test-run": "${{ inputs.test-run }}", "al-mcp": "${{ inputs.al-mcp }}", "al-lsp": "${{ inputs.al-lsp }}", "git-ref": "${{ inputs.git-ref || github.ref_name }}"}

--- a/.github/workflows/summarize-results.yml
+++ b/.github/workflows/summarize-results.yml
@@ -29,6 +29,11 @@ on:
         required: false
         type: boolean
         default: false
+      git-ref:
+        description: "Git ref (branch) the evaluation was dispatched from; preserved across requeue for experiment tracking"
+        required: false
+        type: string
+        default: ""
 
 env:
   BCEVAL_RESULT_FILE: bceval_results.jsonl
@@ -58,7 +63,7 @@ jobs:
           merge-multiple: true
 
       - name: Summarize evaluation results
-        run: uv run bcbench result summarize --category "${{ inputs.category }}" --result-dir "${{ inputs.results-dir }}" --bceval-output "${{ env.BCEVAL_RESULT_FILE }}" --summary-output "${{ env.SUMMARY_OUTPUT_FILE }}"
+        run: uv run bcbench result summarize --category "${{ inputs.category }}" --result-dir "${{ inputs.results-dir }}" --bceval-output "${{ env.BCEVAL_RESULT_FILE }}" --summary-output "${{ env.SUMMARY_OUTPUT_FILE }}" --git-ref "${{ inputs.git-ref || github.ref_name }}"
 
       - name: Upload evaluation summary to artifacts
         uses: actions/upload-artifact@v6
@@ -93,11 +98,13 @@ jobs:
           # Upload summary using bc-eval
           MODEL_TAG="${{ inputs.model }}"
           MODEL_TAG="${MODEL_TAG//./-}"
+          BRANCH_TAG="${{ inputs.git-ref || github.ref_name }}"
+          BRANCH_TAG="${BRANCH_TAG//./-}"
           bceval metrics calculate \
             --feature-name "BC-Bench" \
             --eval-suite-name "${{ inputs.category }}" \
             --eval-run-name "${{ inputs.agent }} (${{ inputs.model }}) - #${{ github.run_id }}" \
-            --tags "${{ inputs.agent }},${MODEL_TAG}" \
+            --tags "${{ inputs.agent }},${MODEL_TAG},${BRANCH_TAG}" \
             --source "${{ github.sha }}" \
             --input-file "${{ inputs.results-dir }}/${{ github.run_id }}/${{ env.BCEVAL_RESULT_FILE }}" \
             --evaluator-definitions "${{ github.workspace }}/evaluator/scores.py" \

--- a/.github/workflows/summarize-results.yml
+++ b/.github/workflows/summarize-results.yml
@@ -93,7 +93,7 @@ jobs:
           ADO_TOKEN=$(az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv)
           echo "::add-mask::$ADO_TOKEN"
 
-          uv tool install bc-eval[capi]==0.3.6 --python 3.12 --index "https://anything:${ADO_TOKEN}@dynamicssmb2.pkgs.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_packaging/BC_PythonFeed/pypi/simple/"
+          uv tool install bc-eval[capi]==0.3.8 --python 3.12 --index "https://anything:${ADO_TOKEN}@dynamicssmb2.pkgs.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_packaging/BC_PythonFeed/pypi/simple/"
 
           # Upload summary using bc-eval
           MODEL_TAG="${{ inputs.model }}"

--- a/src/bcbench/agent/shared/config.yaml
+++ b/src/bcbench/agent/shared/config.yaml
@@ -109,9 +109,9 @@ mcp:
           "{{package_cache_path}}",
         ]
 
-    - name: "mslearn"
-      type: "http"
-      url: "https://learn.microsoft.com/api/mcp"
+    # - name: "mslearn"
+    #   type: "http"
+    #   url: "https://learn.microsoft.com/api/mcp"
 
     # - name: "filesystem"
     #   type: "stdio"

--- a/src/bcbench/agent/shared/config.yaml
+++ b/src/bcbench/agent/shared/config.yaml
@@ -109,9 +109,9 @@ mcp:
           "{{package_cache_path}}",
         ]
 
-    # - name: "mslearn"
-    #   type: "http"
-    #   url: "https://learn.microsoft.com/api/mcp"
+    - name: "mslearn"
+      type: "http"
+      url: "https://learn.microsoft.com/api/mcp"
 
     # - name: "filesystem"
     #   type: "stdio"

--- a/src/bcbench/commands/result.py
+++ b/src/bcbench/commands/result.py
@@ -35,6 +35,7 @@ def result_summarize(
     result_pattern: Annotated[str, typer.Option(help="Pattern for the per instances result files")] = f"*{_config.file_patterns.result_pattern}",
     summary_output: Annotated[str, typer.Option(help="Output filename for summary JSON")] = "evaluation_summary.json",
     bceval_output: Annotated[str, typer.Option(help="Output filename for bceval results")] = "bceval_results.jsonl",
+    git_ref: Annotated[str | None, typer.Option("--git-ref", help="Git ref (branch/tag) the run was dispatched from; recorded in bceval metadata as git_branch")] = None,
 ) -> None:
     """
     Summarize evaluation results from a completed run.
@@ -70,7 +71,7 @@ def result_summarize(
         logger.error("No results found in the result files")
         raise typer.Exit(code=1)
 
-    write_bceval_results(results, run_dir, run_id, bceval_output, category)
+    write_bceval_results(results, run_dir, run_id, bceval_output, category, git_ref=git_ref)
 
     summary = EvaluationResultSummary.from_results(results, run_id=run_id)
 

--- a/src/bcbench/results/bceval_export.py
+++ b/src/bcbench/results/bceval_export.py
@@ -9,15 +9,39 @@ from typing import Any
 from bcbench.dataset import BaseDatasetEntry
 from bcbench.logger import get_logger
 from bcbench.results.base import BaseEvaluationResult
-from bcbench.types import EvaluationCategory, ExpectedOutput
+from bcbench.results.summary import get_benchmark_version
+from bcbench.types import EvaluationCategory, ExpectedOutput, ExperimentConfiguration
 
 logger = get_logger(__name__)
 
 
-def write_bceval_results(results: list[BaseEvaluationResult], out_dir: Path, run_id: str, output_filename: str, category: EvaluationCategory) -> None:
+def _experiment_metadata(experiment: ExperimentConfiguration | None, git_ref: str | None, benchmark_version: str) -> dict[str, Any]:
+    """Metadata identifying whether a run is a baseline or an experiment, and its configuration.
+
+    bc-eval promotes the ``EvalRunType`` key to the Kusto ``EvalRunType``/``testJobType`` fields
+    when ``--eval-run-type`` is left at its default, so no extra CLI flag is needed.
+    """
+    is_experiment: bool = experiment is not None and not experiment.is_empty()
+    return {
+        "EvalRunType": "experiment" if is_experiment else "baseline",
+        "experiment": experiment.model_dump(mode="json") if (is_experiment and experiment) else None,
+        "git_branch": git_ref,
+        "benchmark_version": benchmark_version,
+    }
+
+
+def write_bceval_results(
+    results: list[BaseEvaluationResult],
+    out_dir: Path,
+    run_id: str,
+    output_filename: str,
+    category: EvaluationCategory,
+    git_ref: str | None = None,
+) -> None:
     """Write results into a JSONL file for bceval consumption."""
     entry_cls = category.entry_class
     dataset_entries: list[BaseDatasetEntry] = entry_cls.load(category.dataset_path)
+    benchmark_version = get_benchmark_version()
 
     output_file = out_dir / output_filename
     with open(output_file, "w") as f:
@@ -44,6 +68,7 @@ def write_bceval_results(results: list[BaseEvaluationResult], out_dir: Path, run
                 "project": result.project,
                 "error_message": result.error_message,
                 "tool_usage": (result.metrics.tool_usage if result.metrics and result.metrics.tool_usage else None) or 0,
+                **_experiment_metadata(result.experiment, git_ref, benchmark_version),
             }
 
             bceval_result = {

--- a/src/bcbench/results/summary.py
+++ b/src/bcbench/results/summary.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
-def _get_benchmark_version() -> str:
+def get_benchmark_version() -> str:
     pyproject_path = Path(__file__).parent.parent.parent.parent / "pyproject.toml"
     if not pyproject_path.exists():
         try:
@@ -105,7 +105,7 @@ class EvaluationResultSummary(BaseModel, ABC):
             average_tool_usage=calculate_average_tool_usage(tool_usages) if tool_usages else None,
             github_run_id=run_id,
             experiment=experiment,
-            benchmark_version=_get_benchmark_version(),
+            benchmark_version=get_benchmark_version(),
         )
 
     @classmethod

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ from bcbench.evaluate.review_parsing import parse_review_output
 from bcbench.results.bugfix import BugFixResult
 from bcbench.results.codereview import CodeReviewResult
 from bcbench.results.testgeneration import TestGenerationResult
-from bcbench.types import AgentMetrics, ChecklistAssertion, ContainerConfig, EvaluationCategory, EvaluationContext
+from bcbench.types import AgentMetrics, ChecklistAssertion, ContainerConfig, EvaluationCategory, EvaluationContext, ExperimentConfiguration
 
 # Valid test data that passes all BugFixEntry validation rules
 VALID_INSTANCE_ID = "microsoftInternal__NAV-123456"
@@ -109,6 +109,7 @@ def create_bugfix_result(
     output: str = "diff --git a/test.al b/test.al\n+fixed",
     error_message: str | None = None,
     metrics: AgentMetrics | None = None,
+    experiment: ExperimentConfiguration | None = None,
 ) -> BugFixResult:
     return BugFixResult(
         instance_id=instance_id,
@@ -121,6 +122,7 @@ def create_bugfix_result(
         output=output,
         error_message=error_message,
         metrics=metrics,
+        experiment=experiment,
     )
 
 

--- a/tests/test_result_writer.py
+++ b/tests/test_result_writer.py
@@ -3,7 +3,7 @@ from unittest.mock import PropertyMock, patch
 
 from bcbench.dataset.dataset_entry import BugFixEntry, _BugFixTestGenBase
 from bcbench.results.bceval_export import write_bceval_results
-from bcbench.types import AgentMetrics, EvaluationCategory
+from bcbench.types import AgentMetrics, EvaluationCategory, ExperimentConfiguration
 from tests.conftest import VALID_INSTANCE_ID, create_bugfix_result
 
 
@@ -210,3 +210,83 @@ class TestWriteBcevalResults:
             data = json.loads(f.readline())
 
         assert data["expected"] == checklist_payload
+
+    def test_marks_run_as_baseline_when_no_experiment(self, tmp_path, sample_dataset_file, problem_statement_dir):
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+
+        result = create_bugfix_result(metrics=AgentMetrics(execution_time=1.0), experiment=None)
+
+        with (
+            patch.object(_BugFixTestGenBase, "problem_statement_dir", property(lambda self: problem_statement_dir)),
+            patch.object(EvaluationCategory, "dataset_path", new_callable=PropertyMock, return_value=sample_dataset_file),
+        ):
+            write_bceval_results(
+                results=[result],
+                out_dir=output_dir,
+                run_id="run_baseline",
+                output_filename="results.jsonl",
+                category=EvaluationCategory.BUG_FIX,
+                git_ref="main",
+            )
+
+        with open(output_dir / "results.jsonl") as f:
+            data = json.loads(f.readline())
+
+        assert data["metadata"]["EvalRunType"] == "baseline"
+        assert data["metadata"]["experiment"] is None
+        assert data["metadata"]["git_branch"] == "main"
+        assert data["metadata"]["benchmark_version"]
+
+    def test_marks_run_as_baseline_when_experiment_is_empty(self, tmp_path, sample_dataset_file, problem_statement_dir):
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+
+        result = create_bugfix_result(metrics=AgentMetrics(execution_time=1.0), experiment=ExperimentConfiguration())
+
+        with (
+            patch.object(_BugFixTestGenBase, "problem_statement_dir", property(lambda self: problem_statement_dir)),
+            patch.object(EvaluationCategory, "dataset_path", new_callable=PropertyMock, return_value=sample_dataset_file),
+        ):
+            write_bceval_results(
+                results=[result],
+                out_dir=output_dir,
+                run_id="run_empty_experiment",
+                output_filename="results.jsonl",
+                category=EvaluationCategory.BUG_FIX,
+            )
+
+        with open(output_dir / "results.jsonl") as f:
+            data = json.loads(f.readline())
+
+        assert data["metadata"]["EvalRunType"] == "baseline"
+        assert data["metadata"]["experiment"] is None
+
+    def test_marks_run_as_experiment_with_config(self, tmp_path, sample_dataset_file, problem_statement_dir):
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+
+        experiment = ExperimentConfiguration(mcp_servers=["al-mcp"], al_lsp_enabled=True, custom_instructions=True)
+        result = create_bugfix_result(metrics=AgentMetrics(execution_time=1.0), experiment=experiment)
+
+        with (
+            patch.object(_BugFixTestGenBase, "problem_statement_dir", property(lambda self: problem_statement_dir)),
+            patch.object(EvaluationCategory, "dataset_path", new_callable=PropertyMock, return_value=sample_dataset_file),
+        ):
+            write_bceval_results(
+                results=[result],
+                out_dir=output_dir,
+                run_id="run_experiment",
+                output_filename="results.jsonl",
+                category=EvaluationCategory.BUG_FIX,
+                git_ref="feat/al-mcp",
+            )
+
+        with open(output_dir / "results.jsonl") as f:
+            data = json.loads(f.readline())
+
+        assert data["metadata"]["EvalRunType"] == "experiment"
+        assert data["metadata"]["experiment"]["mcp_servers"] == ["al-mcp"]
+        assert data["metadata"]["experiment"]["al_lsp_enabled"] is True
+        assert data["metadata"]["experiment"]["custom_instructions"] is True
+        assert data["metadata"]["git_branch"] == "feat/al-mcp"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,16 +1,16 @@
 """Tests for version utility."""
 
-from bcbench.results.summary import _get_benchmark_version
+from bcbench.results.summary import get_benchmark_version
 
 
 def test_get_benchmark_version_returns_string():
-    version = _get_benchmark_version()
+    version = get_benchmark_version()
     assert isinstance(version, str)
     assert version != "unknown"
 
 
 def test_get_benchmark_version_follows_semver_format():
-    version = _get_benchmark_version()
+    version = get_benchmark_version()
     # Should match semver pattern like "0.1.0" or "1.0.0"
     parts = version.split(".")
     assert len(parts) >= 2, f"Version should have at least 2 parts: {version}"


### PR DESCRIPTION
It's hard to tell which ones are experiments and which are baseline for the results uploaded to Kusto

Keep track of the branch names and upload the experiment configuration when upload results

Triggered some test run to see if things work:
* Baseline: https://github.com/microsoft/BC-Bench/actions/runs/28594948237
* Experiment: https://github.com/microsoft/BC-Bench/actions/runs/28597342534
* Experiment after bumping bc-eval: https://github.com/microsoft/BC-Bench/actions/runs/28602150237