### PR TITLE
Fetch base_commit on demand in checkout_commit

### DIFF
--- a/src/bcbench/operations/git_operations.py
+++ b/src/bcbench/operations/git_operations.py
@@ -56,7 +56,13 @@ def clean_project_paths(repo_path: Path, project_paths: list[str]) -> None:
 
 def checkout_commit(repo_path: Path, commit: str) -> None:
     logger.info(f"Checking out commit: {commit}")
-    subprocess.run(["git", "checkout", commit], cwd=repo_path, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, check=True)
+    result = subprocess.run(["git", "checkout", commit], cwd=repo_path, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+    if result.returncode != 0:
+        # The commit may not be present locally (e.g. a real PR's base_commit that
+        # isn't in the shared clone). Fetch that SHA directly, then retry.
+        logger.info(f"Commit {commit} not present locally; fetching from origin")
+        subprocess.run(["git", "fetch", "--depth", "1", "origin", commit], cwd=repo_path, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, check=True)
+        subprocess.run(["git", "checkout", commit], cwd=repo_path, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, check=True)
     logger.info(f"Commit {commit} checked out")
 
 

--- a/src/bcbench/operations/git_operations.py
+++ b/src/bcbench/operations/git_operations.py
@@ -56,7 +56,7 @@ def clean_project_paths(repo_path: Path, project_paths: list[str]) -> None:
 
 def checkout_commit(repo_path: Path, commit: str) -> None:
     logger.info(f"Checking out commit: {commit}")
-    result = subprocess.run(["git", "checkout", commit], cwd=repo_path, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+    result = subprocess.run(["git", "checkout", commit], cwd=repo_path, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, check=False)
     if result.returncode != 0:
         # The commit may not be present locally (e.g. a real PR's base_commit that
         # isn't in the shared clone). Fetch that SHA directly, then retry.

--- a/tests/test_git_operations.py
+++ b/tests/test_git_operations.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 import pytest
 
 from bcbench.exceptions import EmptyDiffError
-from bcbench.operations.git_operations import clean_project_paths, clone_at_commit, commit_changes, stage_and_get_diff
+from bcbench.operations.git_operations import checkout_commit, clean_project_paths, clone_at_commit, commit_changes, stage_and_get_diff
 
 
 class TestCommitChanges:
@@ -241,3 +241,34 @@ def test_clone_at_commit_full_url_used_verbatim(mock_run, tmp_path):
 
     remote_calls = [c.args[0] for c in mock_run.call_args_list if c.args[0][:3] == ["git", "remote", "add"]]
     assert remote_calls == [["git", "remote", "add", "origin", "https://gitlab.com/o/r.git"]]
+
+
+@patch("bcbench.operations.git_operations.subprocess.run")
+def test_checkout_commit_present_locally_does_not_fetch(mock_run, tmp_path):
+    mock_run.return_value = subprocess.CompletedProcess([], 0)
+
+    checkout_commit(tmp_path, "a" * 40)
+
+    commands = [c.args[0] for c in mock_run.call_args_list]
+    assert commands == [["git", "checkout", "a" * 40]]
+    assert not any(cmd[:2] == ["git", "fetch"] for cmd in commands)
+
+
+@patch("bcbench.operations.git_operations.subprocess.run")
+def test_checkout_commit_missing_locally_fetches_then_retries(mock_run, tmp_path):
+    sha = "b" * 40
+    # First checkout fails (commit absent), fetch succeeds, retry checkout succeeds.
+    mock_run.side_effect = [
+        subprocess.CompletedProcess([], 1, stderr=b"error: pathspec"),
+        subprocess.CompletedProcess([], 0),
+        subprocess.CompletedProcess([], 0),
+    ]
+
+    checkout_commit(tmp_path, sha)
+
+    commands = [c.args[0] for c in mock_run.call_args_list]
+    assert commands == [
+        ["git", "checkout", sha],
+        ["git", "fetch", "--depth", "1", "origin", sha],
+        ["git", "checkout", sha],
+    ]


### PR DESCRIPTION
## What

`checkout_commit` now fetches the target commit from `origin` when it isn't already present locally, instead of failing outright.

## Why

The code-review category checks out `base_commit` via a bare `git checkout <sha>` (no fetch). That only works because every synthetic entry shares a `base_commit` that's already in the shared BCApps clone. To let a **real PR** be added as a dataset entry, the entry's `base_commit` (the PR merge-base) must be resolvable even when it isn't in the local clone.

This reuses the exact `git fetch --depth 1 origin <sha>` pattern already proven in `clone_at_commit`. As a side effect it also unblocks modification-type patches (real PRs, not new-files-only), because the base blobs are fetched so `git apply` can patch them.

First step of *Accept real PRs as BC Bench code-review dataset entries* (ADO 643360). The ingestion helper (PR pointer → entry) lands in a follow-up PR.

## How

- Run the initial `git checkout` without `check=True`; on non-zero exit, `git fetch --depth 1 origin <sha>` then retry the checkout.
- Commit-present path is unchanged (single checkout, no network).

## Tests

`tests/test_git_operations.py`:
- `test_checkout_commit_present_locally_does_not_fetch` — happy path issues only `git checkout`, never fetches.
- `test_checkout_commit_missing_locally_fetches_then_retries` — failed checkout triggers fetch + retry in order.

`uv run python -m pytest tests/test_git_operations.py` → 17 passed.
