### PR TITLE
Map do.md severities (blocker/major/minor) in Severity.from_input

### DIFF
--- a/src/bcbench/dataset/codereview.py
+++ b/src/bcbench/dataset/codereview.py
@@ -41,6 +41,11 @@ _SEVERITY_ALIASES: dict[str, Severity] = {
     "warning": Severity.MEDIUM,
     "suggestion": Severity.LOW,
     "info": Severity.LOW,
+    # BCQuality skills/do.md emits blocker|major|minor|info; map them so engine
+    # findings score correctly instead of coercing to unspecified severity.
+    "blocker": Severity.CRITICAL,
+    "major": Severity.HIGH,
+    "minor": Severity.LOW,
 }
 
 

--- a/tests/test_codereview.py
+++ b/tests/test_codereview.py
@@ -29,6 +29,10 @@ class TestSeverity:
         assert Severity.from_input("warning") is Severity.MEDIUM
         assert Severity.from_input("suggestion") is Severity.LOW
         assert Severity.from_input("info") is Severity.LOW
+        # BCQuality do.md severities emitted by the production engine.
+        assert Severity.from_input("blocker") is Severity.CRITICAL
+        assert Severity.from_input("major") is Severity.HIGH
+        assert Severity.from_input("minor") is Severity.LOW
 
     def test_unknown_severity_raises(self):
         with pytest.raises(ValueError, match="Unknown severity"):


### PR DESCRIPTION
## What

Map the BCQuality `skills/do.md` severities `blocker`, `major`, and `minor` to the canonical BC-Bench severities in `Severity.from_input`:

- `blocker` -> `critical`
- `major` -> `high`
- `minor` -> `low`

## Why

The production AL review engine (via `Invoke-LocalReview.ps1` / do.md contract) emits findings with severities `blocker | major | minor | info`. BC-Bench's `_SEVERITY_ALIASES` only recognized `error | warning | suggestion | info`, so `blocker`, `major`, and `minor` raised `ValueError` and were silently coerced to unspecified severity. The finding still counted toward precision/recall, but its severity was dropped, so `severity_mae` was computed against the wrong (missing) value.

This closes the severity gap that surfaces when scoring engine output through the code-review pipeline. It is independent of the engine-adapter alignment work and can merge on its own.

## Tests

Extended `TestSeverity::test_aliases_map_to_canonical_severities` with the three new aliases. `pytest tests/test_codereview.py::TestSeverity` passes (7/7); `ruff check` clean.
