### PR TITLE
Split commit fetching out of commit checkout

### DIFF
--- a/src/bcbench/evaluate/codereview.py
+++ b/src/bcbench/evaluate/codereview.py
@@ -8,7 +8,7 @@ from bcbench.evaluate.codereview_judge import judge_comment_matches
 from bcbench.evaluate.review_parsing import parse_review_output
 from bcbench.github_actions import github_log_group
 from bcbench.logger import get_logger
-from bcbench.operations import apply_patch, setup_repo_prebuild
+from bcbench.operations import apply_patch, fetch_commit_if_missing, setup_repo_prebuild
 from bcbench.results.codereview import CodeReviewResult, match_comments
 from bcbench.types import EvaluationContext
 
@@ -32,6 +32,8 @@ class CodeReviewPipeline(EvaluationPipeline[CodeReviewEntry]):
 
     def setup_workspace(self, entry: CodeReviewEntry, repo_path: Path) -> None:
         """Setup workspace for code review by applying the entry patch as local changes."""
+        # Code-review base commits are pre-squash PR commits, so they might be missing from local dev setups.
+        fetch_commit_if_missing(repo_path, entry.base_commit)
         setup_repo_prebuild(entry, repo_path)
         apply_patch(repo_path, entry.patch, f"{entry.instance_id} review patch")
         # Mark newly added files as intent-to-add so they appear in `git diff HEAD`;

--- a/src/bcbench/operations/__init__.py
+++ b/src/bcbench/operations/__init__.py
@@ -16,6 +16,7 @@ from bcbench.operations.git_operations import (
     clean_repo,
     clone_at_commit,
     commit_changes,
+    fetch_commit_if_missing,
     stage_and_get_diff,
 )
 from bcbench.operations.hooks_operations import setup_hooks
@@ -41,6 +42,7 @@ __all__ = [
     "copy_problem_statement_folder",
     "copy_symbol_apps",
     "extract_tests_from_patch",
+    "fetch_commit_if_missing",
     "resolve_artifact_version_root",
     "run_tests",
     "set_runtime_version",

--- a/src/bcbench/operations/git_operations.py
+++ b/src/bcbench/operations/git_operations.py
@@ -56,14 +56,26 @@ def clean_project_paths(repo_path: Path, project_paths: list[str]) -> None:
 
 def checkout_commit(repo_path: Path, commit: str) -> None:
     logger.info(f"Checking out commit: {commit}")
-    result = subprocess.run(["git", "checkout", commit], cwd=repo_path, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, check=False)
-    if result.returncode != 0:
-        # The commit may not be present locally (e.g. a real PR's base_commit that
-        # isn't in the shared clone). Fetch that SHA directly, then retry.
-        logger.info(f"Commit {commit} not present locally; fetching from origin")
-        subprocess.run(["git", "fetch", "--depth", "1", "origin", commit], cwd=repo_path, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, check=True)
-        subprocess.run(["git", "checkout", commit], cwd=repo_path, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, check=True)
+    subprocess.run(["git", "checkout", commit], cwd=repo_path, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, check=True)
     logger.info(f"Commit {commit} checked out")
+
+
+def _commit_present(repo_path: Path, commit: str) -> bool:
+    result = subprocess.run(["git", "cat-file", "-e", f"{commit}^{{commit}}"], cwd=repo_path, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False)
+    return result.returncode == 0
+
+
+def fetch_commit_if_missing(repo_path: Path, commit: str) -> None:
+    """Fetch `commit` from origin when it is not already present in `repo_path`.
+
+    Needed in local dev, might lack base commits that were squashed away on merge. No-op in CI, where the testbed is cloned at the exact commit already.
+    """
+    if _commit_present(repo_path, commit):
+        return
+
+    logger.info(f"Commit {commit} not present locally; fetching from origin")
+    subprocess.run(["git", "fetch", "origin", commit], cwd=repo_path, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, check=True)
+    logger.info(f"Commit {commit} fetched")
 
 
 def commit_changes(repo_path: Path, message: str) -> None:

--- a/tests/test_codereview.py
+++ b/tests/test_codereview.py
@@ -671,6 +671,7 @@ class TestCodeReviewPipeline:
         pipeline = CodeReviewPipeline()
 
         with (
+            patch("bcbench.evaluate.codereview.fetch_commit_if_missing"),
             patch("bcbench.evaluate.codereview.setup_repo_prebuild") as mock_setup,
             patch("bcbench.evaluate.codereview.apply_patch") as mock_apply,
         ):
@@ -702,7 +703,10 @@ class TestCodeReviewPipeline:
             check=True,
         )
 
-        with patch("bcbench.evaluate.codereview.setup_repo_prebuild") as mock_setup:
+        with (
+            patch("bcbench.evaluate.codereview.fetch_commit_if_missing"),
+            patch("bcbench.evaluate.codereview.setup_repo_prebuild") as mock_setup,
+        ):
             pipeline.setup_workspace(entry, Path(tmp_path))
 
         mock_setup.assert_called_once()

--- a/tests/test_git_operations.py
+++ b/tests/test_git_operations.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 import pytest
 
 from bcbench.exceptions import EmptyDiffError
-from bcbench.operations.git_operations import checkout_commit, clean_project_paths, clone_at_commit, commit_changes, stage_and_get_diff
+from bcbench.operations.git_operations import checkout_commit, clean_project_paths, clone_at_commit, commit_changes, fetch_commit_if_missing, stage_and_get_diff
 
 
 class TestCommitChanges:
@@ -244,31 +244,31 @@ def test_clone_at_commit_full_url_used_verbatim(mock_run, tmp_path):
 
 
 @patch("bcbench.operations.git_operations.subprocess.run")
-def test_checkout_commit_present_locally_does_not_fetch(mock_run, tmp_path):
+def test_checkout_commit_runs_plain_checkout(mock_run, tmp_path):
     mock_run.return_value = subprocess.CompletedProcess([], 0)
 
     checkout_commit(tmp_path, "a" * 40)
 
     commands = [c.args[0] for c in mock_run.call_args_list]
     assert commands == [["git", "checkout", "a" * 40]]
-    assert not any(cmd[:2] == ["git", "fetch"] for cmd in commands)
 
 
 @patch("bcbench.operations.git_operations.subprocess.run")
-def test_checkout_commit_missing_locally_fetches_then_retries(mock_run, tmp_path):
-    sha = "b" * 40
-    # First checkout fails (commit absent), fetch succeeds, retry checkout succeeds.
-    mock_run.side_effect = [
-        subprocess.CompletedProcess([], 1, stderr=b"error: pathspec"),
-        subprocess.CompletedProcess([], 0),
-        subprocess.CompletedProcess([], 0),
-    ]
+def test_fetch_commit_if_missing_skips_when_commit_present(mock_run, tmp_path):
+    mock_run.return_value = subprocess.CompletedProcess([], 0)
 
-    checkout_commit(tmp_path, sha)
+    fetch_commit_if_missing(tmp_path, "a" * 40)
 
     commands = [c.args[0] for c in mock_run.call_args_list]
-    assert commands == [
-        ["git", "checkout", sha],
-        ["git", "fetch", "--depth", "1", "origin", sha],
-        ["git", "checkout", sha],
-    ]
+    assert commands == [["git", "cat-file", "-e", f"{'a' * 40}^{{commit}}"]]
+
+
+@patch("bcbench.operations.git_operations.subprocess.run")
+def test_fetch_commit_if_missing_fetches_absent_commit(mock_run, tmp_path):
+    sha = "b" * 40
+    mock_run.side_effect = [subprocess.CompletedProcess([], 1), subprocess.CompletedProcess([], 0)]
+
+    fetch_commit_if_missing(tmp_path, sha)
+
+    commands = [c.args[0] for c in mock_run.call_args_list]
+    assert commands[-1] == ["git", "fetch", "origin", sha]


### PR DESCRIPTION
Split the commit fetching out of commit checkout, so each function is more self-contained.

The fetch is needed because some commits got squashed when the PRs got merged, not a problem in CI because that is handled during repo checkout, mostly a problem in local dev environment.