### PR TITLE
Fix bcal CAPI evals: send M365 LLM API taxonomy headers; default to gpt-55-chat

### DIFF
--- a/.github/workflows/bcal-evaluation.yml
+++ b/.github/workflows/bcal-evaluation.yml
@@ -215,7 +215,8 @@ jobs:
           # M365 LLM API taxonomy/CoS headers (aka.ms/llmapi/waves-timeline). CAPI rejects calls
           # that omit them. Set here (not secret) so the values are visible and easy to adjust; the
           # bridge falls back to the same defaults when these are unset (e.g. local runs).
-          CAPI_TAXONOMY_EXPERIENCE: DynamicsBusinessCentral
+          # Experience must be an LLM API allowed value (BizChat/WXPOAgents/AppCopilots/Cowork/Scout/WorkIQ).
+          CAPI_TAXONOMY_EXPERIENCE: AppCopilots
           CAPI_TAXONOMY_AGENT: bcal
           CAPI_TAXONOMY_INFERENCE_STEP: ChatCompletion
           CAPI_TAXONOMY_TRAFFIC_TYPE: Test

--- a/.github/workflows/bcal-evaluation.yml
+++ b/.github/workflows/bcal-evaluation.yml
@@ -24,10 +24,11 @@ on:
       external-model:
         description: "Model alias passed to the external-command bridge when llm-backend=external-command"
         required: false
-        default: "gpt-53-chat-2026-03-03"
+        default: "gpt-55-chat-2026-04-29"
         type: choice
         options:
           - "claude-opus-4-8"
+          - "gpt-55-chat-2026-04-29"
           - "gpt-55-2026-04-24"
           - "gpt-52-2025-12-11"
           - "gpt-5-codex-2025-09-15"
@@ -199,7 +200,7 @@ jobs:
         timeout-minutes: 28
         env:
           BCAL_LLM_BACKEND: ${{ inputs.llm-backend || 'external-command' }}
-          BCAL_LLM_MODEL: ${{ (inputs.llm-backend || 'external-command') == 'external-command' && (inputs.external-model || 'gpt-53-chat-2026-03-03') || (inputs.model || 'gpt-5.2') }}
+          BCAL_LLM_MODEL: ${{ (inputs.llm-backend || 'external-command') == 'external-command' && (inputs.external-model || 'gpt-55-chat-2026-04-29') || (inputs.model || 'gpt-5.2') }}
           AZURE_OPENAI_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
           AZURE_OPENAI_DEPLOYMENT: ${{ inputs.model || 'gpt-5.2' }}
           CAPI_ENDPOINT: ${{ secrets.CAPI_ENDPOINT }}
@@ -211,6 +212,13 @@ jobs:
           CAPI_CLIENT_ID: ${{ secrets.CAPI_CLIENT_ID }}
           CAPI_CERTIFICATE_KEY_VAULT_NAME: ${{ secrets.CAPI_CERTIFICATE_KEY_VAULT_NAME }}
           CAPI_CERTIFICATE_NAME: ${{ secrets.CAPI_CERTIFICATE_NAME }}
+          # M365 LLM API taxonomy/CoS headers (aka.ms/llmapi/waves-timeline). CAPI rejects calls
+          # that omit them. Set here (not secret) so the values are visible and easy to adjust; the
+          # bridge falls back to the same defaults when these are unset (e.g. local runs).
+          CAPI_TAXONOMY_EXPERIENCE: DynamicsBusinessCentral
+          CAPI_TAXONOMY_AGENT: bcal
+          CAPI_TAXONOMY_INFERENCE_STEP: ChatCompletion
+          CAPI_TAXONOMY_TRAFFIC_TYPE: Test
         shell: pwsh
         run: |
           if ("${{ inputs.llm-backend || 'external-command' }}" -eq "external-command") {
@@ -239,7 +247,7 @@ jobs:
       id-token: write
     with:
       results-dir: ${{ needs.evaluate-with-bcal.outputs.results-dir }}
-      model: ${{ (inputs.llm-backend || 'external-command') == 'external-command' && (inputs.external-model || 'gpt-53-chat-2026-03-03') || (inputs.model || 'gpt-5.2') }}
+      model: ${{ (inputs.llm-backend || 'external-command') == 'external-command' && (inputs.external-model || 'gpt-55-chat-2026-04-29') || (inputs.model || 'gpt-5.2') }}
       agent: ${{ (inputs.llm-backend || 'external-command') == 'external-command' && 'BCal-external-command' || 'BCal' }}
       mock: ${{ inputs.test-run || false }}
       category: nl2al

--- a/evaluator/_capi_taxonomy.py
+++ b/evaluator/_capi_taxonomy.py
@@ -1,0 +1,63 @@
+"""Inject the M365 LLM API taxonomy/CoS headers into bc-eval's CAPI judge calls.
+
+The nl2al ``lm_checklist`` judge runs inside the ``bceval metrics calculate`` step through
+``bc_eval``'s ``CapiModel``, which (like the bcal bridge) does not send the now-required
+``X-Taxonomy-*`` headers, so CAPI rejects the calls with ``InvalidInferenceInput``. bc-eval
+``exec_module``s the ``--evaluator-definitions`` / ``--metric-definitions`` files (this package's
+``scores.py`` and ``metrics.py``) while resolving evaluators, before any judge runs, so installing
+the patch at their import time covers the judge path.
+
+Self-contained on purpose: the ``uv tool`` env that runs ``bceval`` has ``bc_eval`` but not
+``bcbench`` (which hosts the equivalent bridge-side shim), so this must not import ``bcbench``.
+"""
+
+from __future__ import annotations
+
+import os
+
+# (header name, env var, default value) -- kept in sync with
+# src/bcbench/agent/bcal/bc_eval_capi_bridge.py::_TAXONOMY_HEADERS.
+_TAXONOMY_HEADERS: tuple[tuple[str, str, str], ...] = (
+    ("X-Taxonomy-Experience", "CAPI_TAXONOMY_EXPERIENCE", "DynamicsBusinessCentral"),
+    ("X-Taxonomy-Agent", "CAPI_TAXONOMY_AGENT", "bcal"),
+    ("X-Taxonomy-InferenceStep", "CAPI_TAXONOMY_INFERENCE_STEP", "ChatCompletion"),
+    ("X-Taxonomy-TrafficType", "CAPI_TAXONOMY_TRAFFIC_TYPE", "Test"),
+)
+
+_PATCH_FLAG = "_bcbench_taxonomy_patched"
+
+
+def _resolve_headers() -> dict[str, str]:
+    resolved: dict[str, str] = {}
+    for header, env_var, default in _TAXONOMY_HEADERS:
+        value = os.environ.get(env_var, default).strip()
+        if value:
+            resolved[header] = value
+    return resolved
+
+
+def install() -> None:
+    headers = _resolve_headers()
+    if not headers:
+        return
+
+    try:
+        from bc_eval.capi.capi_model import CapiModel
+    except ImportError:
+        return  # No CAPI judge in this context; nothing to patch.
+
+    get_common = getattr(CapiModel, "_get_common_capi_parameters", None)
+    if get_common is None or getattr(get_common.__func__, _PATCH_FLAG, False):
+        return  # Missing internal (revisit on bc-eval bump) or already patched.
+
+    original = get_common.__func__
+
+    def _with_taxonomy_headers(cls: type) -> dict[str, object]:
+        params = original(cls)
+        merged = dict(params.get("headers") or {})
+        merged.update(headers)
+        params["headers"] = merged
+        return params
+
+    setattr(_with_taxonomy_headers, _PATCH_FLAG, True)
+    CapiModel._get_common_capi_parameters = classmethod(_with_taxonomy_headers)

--- a/evaluator/_capi_taxonomy.py
+++ b/evaluator/_capi_taxonomy.py
@@ -18,7 +18,7 @@ import os
 # (header name, env var, default value) -- kept in sync with
 # src/bcbench/agent/bcal/bc_eval_capi_bridge.py::_TAXONOMY_HEADERS.
 _TAXONOMY_HEADERS: tuple[tuple[str, str, str], ...] = (
-    ("X-Taxonomy-Experience", "CAPI_TAXONOMY_EXPERIENCE", "DynamicsBusinessCentral"),
+    ("X-Taxonomy-Experience", "CAPI_TAXONOMY_EXPERIENCE", "AppCopilots"),
     ("X-Taxonomy-Agent", "CAPI_TAXONOMY_AGENT", "bcal"),
     ("X-Taxonomy-InferenceStep", "CAPI_TAXONOMY_INFERENCE_STEP", "ChatCompletion"),
     ("X-Taxonomy-TrafficType", "CAPI_TAXONOMY_TRAFFIC_TYPE", "Test"),

--- a/evaluator/scores.py
+++ b/evaluator/scores.py
@@ -1,5 +1,18 @@
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
+# bc-eval loads this file via importlib.exec_module (not a package import) while resolving
+# evaluators -- before running the nl2al lm_checklist judge -- so make the sibling taxonomy shim
+# importable and install it here. This threads the M365 LLM API taxonomy/CoS headers onto the
+# judge's CAPI calls (aka.ms/llmapi/waves-timeline); without them CAPI returns InvalidInferenceInput.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _capi_taxonomy import install as _install_capi_taxonomy
+
+_install_capi_taxonomy()
+
 
 class ResolutionRate:
     def __call__(self, *, metadata: dict, **kwargs: object) -> bool:

--- a/src/bcbench/agent/bcal/bc_eval_capi_bridge.py
+++ b/src/bcbench/agent/bcal/bc_eval_capi_bridge.py
@@ -16,6 +16,18 @@ _CERT_FILE_ENV = "CAPI_CERT_FILE"
 _CERT_TENANT_ENV = "CAPI_TENANT_ID"
 _CERT_CLIENT_ENV = "CAPI_CLIENT_ID"
 
+# The M365 LLM API now enforces taxonomy/CoS headers (aka.ms/llmapi/waves-timeline). Neither
+# bc-eval's CapiModel nor the generated CAPI client sends them, so CAPI rejects every call with
+# InvalidInferenceInput ("Required taxonomy data X-Taxonomy-* not provided"). We thread them onto
+# each request below. Each value is env-overridable so it can be corrected without a code change.
+# (header name, env var, default value)
+_TAXONOMY_HEADERS: tuple[tuple[str, str, str], ...] = (
+    ("X-Taxonomy-Experience", "CAPI_TAXONOMY_EXPERIENCE", "DynamicsBusinessCentral"),
+    ("X-Taxonomy-Agent", "CAPI_TAXONOMY_AGENT", "bcal"),
+    ("X-Taxonomy-InferenceStep", "CAPI_TAXONOMY_INFERENCE_STEP", "ChatCompletion"),
+    ("X-Taxonomy-TrafficType", "CAPI_TAXONOMY_TRAFFIC_TYPE", "Test"),
+)
+
 # Reasoning effort (not all models support this parameter), different models might have different available values:
 # Set to None to omit the parameter entirely (lets the model/service use its own default).
 _DEFAULT_REASONING_EFFORT: str | None = None
@@ -126,6 +138,47 @@ def _maybe_install_local_cert_credential() -> None:
     _patch_credential_from_local_file(cert_file)
 
 
+def _resolve_taxonomy_headers() -> dict[str, str]:
+    resolved: dict[str, str] = {}
+    for header, env_var, default in _TAXONOMY_HEADERS:
+        value = os.environ.get(env_var, default).strip()
+        if value:
+            resolved[header] = value
+    return resolved
+
+
+def _install_taxonomy_headers() -> None:
+    """Thread the M365 LLM API taxonomy/CoS headers onto every CAPI request.
+
+    `CapiModel._get_common_capi_parameters()` builds the kwargs splatted into the generated
+    `chat_completions` / `anthropic_messages` / `predict_with_embeddings` operations, each of which
+    forwards an otherwise-unknown `headers` kwarg onto the outgoing HTTP request. Merging our
+    headers into that single dict is the one clean injection point that covers every model family.
+    """
+    headers = _resolve_taxonomy_headers()
+    if not headers:
+        return
+
+    from bc_eval.capi.capi_model import CapiModel
+
+    get_common = getattr(CapiModel, "_get_common_capi_parameters", None)
+    if get_common is None:
+        # Fail loud rather than silently omit the now-required headers: a bc-eval upgrade that
+        # renames/removes this internal (or adds native taxonomy support) must be revisited here.
+        raise RuntimeError("bc_eval CapiModel._get_common_capi_parameters is missing; the taxonomy-header shim in bc_eval_capi_bridge.py needs updating for this bc-eval version.")
+
+    original = get_common.__func__
+
+    def _with_taxonomy_headers(cls: type) -> dict[str, object]:
+        params = original(cls)
+        merged = dict(params.get("headers") or {})
+        merged.update(headers)
+        params["headers"] = merged
+        return params
+
+    CapiModel._get_common_capi_parameters = classmethod(_with_taxonomy_headers)
+
+
 def main() -> int:
     request = _load_request(sys.stdin.buffer)
     model = request.get("model")
@@ -142,6 +195,7 @@ def main() -> int:
         raise RuntimeError("bc-eval[capi] is required for the bcal CAPI bridge.") from exc
 
     _maybe_install_local_cert_credential()
+    _install_taxonomy_headers()
 
     client = CapiModel()
     kwargs: dict[str, object] = {

--- a/src/bcbench/agent/bcal/bc_eval_capi_bridge.py
+++ b/src/bcbench/agent/bcal/bc_eval_capi_bridge.py
@@ -20,9 +20,11 @@ _CERT_CLIENT_ENV = "CAPI_CLIENT_ID"
 # bc-eval's CapiModel nor the generated CAPI client sends them, so CAPI rejects every call with
 # InvalidInferenceInput ("Required taxonomy data X-Taxonomy-* not provided"). We thread them onto
 # each request below. Each value is env-overridable so it can be corrected without a code change.
+# X-Taxonomy-Experience must be one of the LLM API's allowed values (BizChat, WXPOAgents,
+# AppCopilots, Cowork, Scout, WorkIQ); BC is an app copilot -> AppCopilots.
 # (header name, env var, default value)
 _TAXONOMY_HEADERS: tuple[tuple[str, str, str], ...] = (
-    ("X-Taxonomy-Experience", "CAPI_TAXONOMY_EXPERIENCE", "DynamicsBusinessCentral"),
+    ("X-Taxonomy-Experience", "CAPI_TAXONOMY_EXPERIENCE", "AppCopilots"),
     ("X-Taxonomy-Agent", "CAPI_TAXONOMY_AGENT", "bcal"),
     ("X-Taxonomy-InferenceStep", "CAPI_TAXONOMY_INFERENCE_STEP", "ChatCompletion"),
     ("X-Taxonomy-TrafficType", "CAPI_TAXONOMY_TRAFFIC_TYPE", "Test"),

--- a/tests/test_bcal_capi_bridge.py
+++ b/tests/test_bcal_capi_bridge.py
@@ -193,7 +193,7 @@ def test_resolve_taxonomy_headers_uses_defaults(monkeypatch):
     _clear_taxonomy_env(monkeypatch)
 
     assert bc_eval_capi_bridge._resolve_taxonomy_headers() == {
-        "X-Taxonomy-Experience": "DynamicsBusinessCentral",
+        "X-Taxonomy-Experience": "AppCopilots",
         "X-Taxonomy-Agent": "bcal",
         "X-Taxonomy-InferenceStep": "ChatCompletion",
         "X-Taxonomy-TrafficType": "Test",
@@ -221,7 +221,7 @@ def test_install_taxonomy_headers_merges_into_common_params(monkeypatch, stub_ca
 
     params = stub_capi_model._get_common_capi_parameters()
     assert params["headers"] == {
-        "X-Taxonomy-Experience": "DynamicsBusinessCentral",
+        "X-Taxonomy-Experience": "AppCopilots",
         "X-Taxonomy-Agent": "bcal",
         "X-Taxonomy-InferenceStep": "ChatCompletion",
         "X-Taxonomy-TrafficType": "Test",

--- a/tests/test_bcal_capi_bridge.py
+++ b/tests/test_bcal_capi_bridge.py
@@ -5,6 +5,7 @@ import sys
 import types
 from io import BytesIO
 from types import SimpleNamespace
+from typing import ClassVar
 from unittest.mock import MagicMock
 
 import pytest
@@ -158,3 +159,101 @@ def test_maybe_install_local_cert_credential_patches_factory(monkeypatch, fake_c
         # SNI (x5c) auth is required by the CAPI app registration; without it
         # AAD rejects the client assertion with AADSTS700027.
         assert cred.send_certificate_chain is True
+
+
+@pytest.fixture
+def stub_capi_model(monkeypatch):
+    """Stub bc_eval.capi.capi_model.CapiModel with the internal the taxonomy shim patches."""
+
+    class _StubCapiModel:
+        base_params: ClassVar[dict[str, object]] = {"customer_id": "c", "x_ms_correlation_id": "corr"}
+
+        @classmethod
+        def _get_common_capi_parameters(cls) -> dict[str, object]:
+            return dict(cls.base_params)
+
+    bc_eval_pkg = types.ModuleType("bc_eval")
+    bc_eval_pkg.__path__ = []
+    capi_pkg = types.ModuleType("bc_eval.capi")
+    capi_pkg.__path__ = []
+    capi_model_mod = types.ModuleType("bc_eval.capi.capi_model")
+    capi_model_mod.CapiModel = _StubCapiModel  # ty: ignore[unresolved-attribute]
+    monkeypatch.setitem(sys.modules, "bc_eval", bc_eval_pkg)
+    monkeypatch.setitem(sys.modules, "bc_eval.capi", capi_pkg)
+    monkeypatch.setitem(sys.modules, "bc_eval.capi.capi_model", capi_model_mod)
+    return _StubCapiModel
+
+
+def _clear_taxonomy_env(monkeypatch):
+    for _, env_var, _ in bc_eval_capi_bridge._TAXONOMY_HEADERS:
+        monkeypatch.delenv(env_var, raising=False)
+
+
+def test_resolve_taxonomy_headers_uses_defaults(monkeypatch):
+    _clear_taxonomy_env(monkeypatch)
+
+    assert bc_eval_capi_bridge._resolve_taxonomy_headers() == {
+        "X-Taxonomy-Experience": "DynamicsBusinessCentral",
+        "X-Taxonomy-Agent": "bcal",
+        "X-Taxonomy-InferenceStep": "ChatCompletion",
+        "X-Taxonomy-TrafficType": "Test",
+    }
+
+
+def test_resolve_taxonomy_headers_env_override_and_blank_dropped(monkeypatch):
+    _clear_taxonomy_env(monkeypatch)
+    monkeypatch.setenv("CAPI_TAXONOMY_EXPERIENCE", "MyExperience")
+    monkeypatch.setenv("CAPI_TAXONOMY_TRAFFIC_TYPE", "Prod")
+    monkeypatch.setenv("CAPI_TAXONOMY_AGENT", "   ")  # blank -> dropped
+
+    headers = bc_eval_capi_bridge._resolve_taxonomy_headers()
+
+    assert headers["X-Taxonomy-Experience"] == "MyExperience"
+    assert headers["X-Taxonomy-TrafficType"] == "Prod"
+    assert headers["X-Taxonomy-InferenceStep"] == "ChatCompletion"  # still the default
+    assert "X-Taxonomy-Agent" not in headers
+
+
+def test_install_taxonomy_headers_merges_into_common_params(monkeypatch, stub_capi_model):
+    _clear_taxonomy_env(monkeypatch)
+
+    bc_eval_capi_bridge._install_taxonomy_headers()
+
+    params = stub_capi_model._get_common_capi_parameters()
+    assert params["headers"] == {
+        "X-Taxonomy-Experience": "DynamicsBusinessCentral",
+        "X-Taxonomy-Agent": "bcal",
+        "X-Taxonomy-InferenceStep": "ChatCompletion",
+        "X-Taxonomy-TrafficType": "Test",
+    }
+    assert params["customer_id"] == "c"  # existing params preserved
+
+
+def test_install_taxonomy_headers_preserves_existing_headers(monkeypatch, stub_capi_model):
+    _clear_taxonomy_env(monkeypatch)
+    monkeypatch.setattr(stub_capi_model, "base_params", {"customer_id": "c", "headers": {"X-Existing": "1"}})
+
+    bc_eval_capi_bridge._install_taxonomy_headers()
+
+    params = stub_capi_model._get_common_capi_parameters()
+    assert params["headers"]["X-Existing"] == "1"
+    assert params["headers"]["X-Taxonomy-TrafficType"] == "Test"
+
+
+def test_install_taxonomy_headers_noop_when_all_blank(monkeypatch, stub_capi_model):
+    for _, env_var, _ in bc_eval_capi_bridge._TAXONOMY_HEADERS:
+        monkeypatch.setenv(env_var, "")
+    original = stub_capi_model.__dict__["_get_common_capi_parameters"]
+
+    bc_eval_capi_bridge._install_taxonomy_headers()
+
+    assert stub_capi_model.__dict__["_get_common_capi_parameters"] is original
+    assert "headers" not in stub_capi_model._get_common_capi_parameters()
+
+
+def test_install_taxonomy_headers_raises_when_internal_missing(monkeypatch, stub_capi_model):
+    _clear_taxonomy_env(monkeypatch)
+    delattr(stub_capi_model, "_get_common_capi_parameters")
+
+    with pytest.raises(RuntimeError, match="_get_common_capi_parameters is missing"):
+        bc_eval_capi_bridge._install_taxonomy_headers()

--- a/tests/test_capi_taxonomy_evaluator.py
+++ b/tests/test_capi_taxonomy_evaluator.py
@@ -60,7 +60,7 @@ def test_install_merges_headers_into_common_params(monkeypatch, taxonomy, stub_c
 
     params = stub_capi_model._get_common_capi_parameters()
     assert params["headers"]["X-Taxonomy-TrafficType"] == "Test"
-    assert params["headers"]["X-Taxonomy-Experience"] == "DynamicsBusinessCentral"
+    assert params["headers"]["X-Taxonomy-Experience"] == "AppCopilots"
     assert params["customer_id"] == "c"  # existing params preserved
 
 

--- a/tests/test_capi_taxonomy_evaluator.py
+++ b/tests/test_capi_taxonomy_evaluator.py
@@ -1,0 +1,81 @@
+"""Tests for evaluator/_capi_taxonomy.py, the taxonomy-header shim bc-eval loads for the judge path.
+
+The module lives under evaluator/ (loaded by the isolated bceval tool env, not importable as a
+bcbench package), so it is loaded here the same way bc-eval does: via importlib.exec_module.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from typing import ClassVar
+
+import pytest
+
+_MODULE_PATH = Path(__file__).resolve().parent.parent / "evaluator" / "_capi_taxonomy.py"
+
+
+@pytest.fixture
+def taxonomy():
+    spec = importlib.util.spec_from_file_location("_capi_taxonomy_under_test", _MODULE_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def stub_capi_model(monkeypatch):
+    class _StubCapiModel:
+        base_params: ClassVar[dict[str, object]] = {"customer_id": "c"}
+
+        @classmethod
+        def _get_common_capi_parameters(cls) -> dict[str, object]:
+            return dict(cls.base_params)
+
+    bc_eval_pkg = types.ModuleType("bc_eval")
+    bc_eval_pkg.__path__ = []
+    capi_pkg = types.ModuleType("bc_eval.capi")
+    capi_pkg.__path__ = []
+    capi_model_mod = types.ModuleType("bc_eval.capi.capi_model")
+    capi_model_mod.CapiModel = _StubCapiModel  # ty: ignore[unresolved-attribute]
+    monkeypatch.setitem(sys.modules, "bc_eval", bc_eval_pkg)
+    monkeypatch.setitem(sys.modules, "bc_eval.capi", capi_pkg)
+    monkeypatch.setitem(sys.modules, "bc_eval.capi.capi_model", capi_model_mod)
+    return _StubCapiModel
+
+
+def _clear_env(monkeypatch, taxonomy):
+    for _, env_var, _ in taxonomy._TAXONOMY_HEADERS:
+        monkeypatch.delenv(env_var, raising=False)
+
+
+def test_install_merges_headers_into_common_params(monkeypatch, taxonomy, stub_capi_model):
+    _clear_env(monkeypatch, taxonomy)
+
+    taxonomy.install()
+
+    params = stub_capi_model._get_common_capi_parameters()
+    assert params["headers"]["X-Taxonomy-TrafficType"] == "Test"
+    assert params["headers"]["X-Taxonomy-Experience"] == "DynamicsBusinessCentral"
+    assert params["customer_id"] == "c"  # existing params preserved
+
+
+def test_install_is_idempotent(monkeypatch, taxonomy, stub_capi_model):
+    _clear_env(monkeypatch, taxonomy)
+
+    taxonomy.install()
+    patched = stub_capi_model.__dict__["_get_common_capi_parameters"]
+    taxonomy.install()
+
+    assert stub_capi_model.__dict__["_get_common_capi_parameters"] is patched
+
+
+def test_install_noop_when_bc_eval_absent(monkeypatch, taxonomy):
+    _clear_env(monkeypatch, taxonomy)
+    monkeypatch.setitem(sys.modules, "bc_eval", None)  # force ImportError on `import bc_eval...`
+
+    taxonomy.install()  # must not raise


### PR DESCRIPTION
## Problem
All bcal CAPI evaluations have failed since ~Jul 19 (runs 29672964336, 30187493565, 30349142281).

## Root cause
The M365 LLM API taxonomy/CoS rollout (aka.ms/llmapi/waves-timeline) began enforcing the
`X-Taxonomy-Experience/Agent/InferenceStep/TrafficType` headers between the last green run (Jul 12)
and Jul 19. Neither bc-eval's `CapiModel` nor the generated CAPI client sends them, so CAPI rejects
every call with `InvalidInferenceInput`. BC production is unaffected because it calls Azure OpenAI
directly (`BC-Platform .../CopilotApi/AL/AzureOpenAIClient.cs`), bypassing the enforcing gateway —
only BC-Bench's CAPI eval path hits it, so this was new and unfixed anywhere in BC.

## Fix
Inject the four headers (env-overridable via `CAPI_TAXONOMY_*`, defaults baked in) at the one point
both code paths flow through — `CapiModel._get_common_capi_parameters`, whose dict is splatted onto
the generated operations that forward an unknown `headers` kwarg:
- **bcal eval path**: `bc_eval_capi_bridge.py` patches it in the bridge subprocess.
- **nl2al judge/scoring path**: `evaluator/_capi_taxonomy.py`, installed at import time from
  `scores.py`, which `bceval` `exec_module`s while resolving evaluators before the judge runs
  (the judge runs in an isolated `uv tool` env that has bc-eval but not bcbench, hence a second,
  self-contained shim).

Values validated directly against CAPI (for both `gpt-55-chat-2026-04-29` and the `gpt-41` judge):
`Experience=AppCopilots` (BC is an app copilot; the LLM API's allowed set is BizChat, WXPOAgents,
AppCopilots, Cowork, Scout, WorkIQ), `Agent=bcal`, `InferenceStep=ChatCompletion`, `TrafficType=Test`.

Also sets `gpt-55-chat-2026-04-29` as the new default external-model (added to the choices and the
scheduled-run fallback).

## Validation
- +9 unit tests; full suite 634 pass; ruff + ty + pre-commit clean.
- 4-entry test run: all green.
- Full run on gpt-55-chat-2026-04-29: 122/122 eval jobs + summarize/judge succeeded.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
