### PR TITLE
Fix secondary runs cleanup issue on windows

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,11 @@ env:
 
 jobs:
   lint-and-test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout repository

--- a/src/bcbench/evaluate/nl2al.py
+++ b/src/bcbench/evaluate/nl2al.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 import subprocess
 from collections.abc import Callable
 from pathlib import Path
@@ -9,7 +8,7 @@ from bcbench.evaluate.base import EvaluationPipeline
 from bcbench.exceptions import EmptyDiffError
 from bcbench.github_actions import github_log_group
 from bcbench.logger import get_logger
-from bcbench.operations import copy_symbol_apps, stage_and_get_diff
+from bcbench.operations import copy_symbol_apps, remove_tree, stage_and_get_diff
 from bcbench.results.base import JudgeBasedEvaluationResult
 from bcbench.types import EvaluationContext
 
@@ -24,14 +23,9 @@ _EMPTY_DIFF_MAX_ATTEMPTS = 3
 __all__ = ["NL2ALPipeline"]
 
 
-def _force_remove_readonly(func: Callable, path: str, _: object) -> None:
-    Path(path).chmod(0o666)
-    func(path)
-
-
 def _reset_repo_path(repo_path: Path) -> None:
     if repo_path.exists():
-        shutil.rmtree(repo_path, onexc=_force_remove_readonly)
+        remove_tree(repo_path)
     repo_path.mkdir(parents=True, exist_ok=True)
 
 

--- a/src/bcbench/operations/__init__.py
+++ b/src/bcbench/operations/__init__.py
@@ -9,6 +9,7 @@ from bcbench.operations.bc_operations import (
     resolve_artifact_version_root,
     run_tests,
 )
+from bcbench.operations.filesystem_operations import remove_tree
 from bcbench.operations.git_operations import (
     apply_patch,
     checkout_commit,
@@ -42,6 +43,7 @@ __all__ = [
     "copy_symbol_apps",
     "extract_tests_from_patch",
     "fetch_commit_if_missing",
+    "remove_tree",
     "resolve_artifact_version_root",
     "run_tests",
     "set_runtime_version",

--- a/src/bcbench/operations/filesystem_operations.py
+++ b/src/bcbench/operations/filesystem_operations.py
@@ -15,6 +15,6 @@ def remove_tree(path: Path) -> None:
     """
     Remove a directory tree, even if it contains read-only files on Windows.
 
-    Use when `shutil.rmtree` fails due to read-only files, usually occur in secondary runs on Windows.
+    Use when `shutil.rmtree` fails due to read-only files, which usually occur in secondary runs on Windows.
     """
     shutil.rmtree(path, onexc=_force_remove_readonly)

--- a/src/bcbench/operations/filesystem_operations.py
+++ b/src/bcbench/operations/filesystem_operations.py
@@ -1,0 +1,20 @@
+"""Filesystem operations."""
+
+import shutil
+import stat
+from collections.abc import Callable
+from pathlib import Path
+
+
+def _force_remove_readonly(func: Callable[[str], object], path: str, _: BaseException) -> None:
+    Path(path).chmod(stat.S_IWRITE)
+    func(path)
+
+
+def remove_tree(path: Path) -> None:
+    """
+    Remove a directory tree, even if it contains read-only files on Windows.
+
+    Use when `shutil.rmtree` fails due to read-only files, usually occur in secondary runs on Windows.
+    """
+    shutil.rmtree(path, onexc=_force_remove_readonly)

--- a/src/bcbench/operations/git_operations.py
+++ b/src/bcbench/operations/git_operations.py
@@ -1,6 +1,5 @@
 """Git repository operations."""
 
-import shutil
 import subprocess
 import tempfile
 from pathlib import Path
@@ -8,6 +7,7 @@ from pathlib import Path
 from bcbench.config import get_config
 from bcbench.exceptions import EmptyDiffError, PatchApplicationError
 from bcbench.logger import get_logger
+from bcbench.operations.filesystem_operations import remove_tree
 
 logger = get_logger(__name__)
 _config = get_config()
@@ -182,7 +182,7 @@ def clone_repo_at_revision(repo: str, revision: str, destination: Path) -> None:
     """
     logger.info(f"Cloning {repo} @ {revision} into {destination}")
     if destination.exists():
-        shutil.rmtree(destination)
+        remove_tree(destination)
     destination.parent.mkdir(parents=True, exist_ok=True)
 
     try:

--- a/tests/test_git_operations.py
+++ b/tests/test_git_operations.py
@@ -234,7 +234,10 @@ def test_clone_repo_at_revision_shallow_clones_via_gh(mock_run, tmp_path):
 @patch("bcbench.operations.git_operations.subprocess.run")
 def test_clone_repo_at_revision_replaces_existing_destination(mock_run, tmp_path):
     destination = tmp_path / "clone"
-    (destination / "stale").mkdir(parents=True)
+    stale_file = destination / "stale" / "pack.idx"
+    stale_file.parent.mkdir(parents=True)
+    stale_file.write_text("stale")
+    stale_file.chmod(0o444)
 
     clone_repo_at_revision("o/r", "b" * 40, destination)
 


### PR DESCRIPTION
We clone plugin repos during runtime, the secondary run will have to delete the previously cloned git repo.

On windows this fails due to permission issues: https://stackoverflow.com/questions/1213706/what-user-do-python-scripts-run-as-in-windows.

We had similar problems before in nl2al, move the cleanup logic into operations utilities.

---

In order to catch similar issues in tests, `lint and test` job now run on both ubuntu and windows