### PR TITLE
Accept root plugin.json manifest and grant plugin dir access

### DIFF
--- a/src/bcbench/agent/claude/agent.py
+++ b/src/bcbench/agent/claude/agent.py
@@ -83,10 +83,9 @@ def run_claude_code(
         # --add-dir grants read+write (unlike --plugin-dir, which only registers a plugin), so hand it
         # only to plugins that opt in via grant_dir_access - currently a temporary accommodation for
         # BCQuality, whose skill reads its own knowledge files at runtime. Enabling a plugin must not
-        # silently widen the agent's sandbox access.
-        cmd_args.extend(
-            f"--add-dir={plugins[PluginConfig(**plugin_entry).record]}" for plugin_entry in claude_config["plugins"] if plugin_entry.get("enabled") and plugin_entry.get("grant_dir_access")
-        )
+        # silently widen the agent's sandbox access. Read the opt-in from the validated PluginConfig, not
+        # the raw YAML, so a non-boolean like `grant_dir_access: "false"` is not treated as truthy.
+        cmd_args.extend(f"--add-dir={plugins[plugin.record]}" for plugin in (PluginConfig(**entry) for entry in claude_config["plugins"]) if plugin.enabled and plugin.grant_dir_access)
         if custom_agent:
             cmd_args.append(f"--agent={custom_agent}")
         cmd_args.extend(

--- a/src/bcbench/agent/claude/agent.py
+++ b/src/bcbench/agent/claude/agent.py
@@ -49,7 +49,7 @@ def run_claude_code(
     skills_enabled: bool = setup_agent_skills(claude_config, entry, repo_path, agent_type=AgentType.CLAUDE)
     custom_agent: str | None = setup_custom_agent(claude_config, entry, repo_path, agent_type=AgentType.CLAUDE)
     tool_log_path: Path = setup_hooks(repo_path, AgentType.CLAUDE, output_dir)
-    plugins: list[PluginConfig] = resolve_config_plugins(claude_config, allow_copilot_manifest=False)
+    plugins: list[tuple[PluginConfig, Path]] = resolve_config_plugins(claude_config, allow_copilot_manifest=False)
 
     config = ExperimentConfiguration(
         mcp_servers=mcp_server_names,
@@ -57,7 +57,7 @@ def run_claude_code(
         custom_instructions=instructions_enabled,
         skills_enabled=skills_enabled,
         custom_agent=custom_agent,
-        plugins=[plugin.record for plugin in plugins] or None,
+        plugins=[plugin.record for plugin, _ in plugins] or None,
     )
 
     logger.info(f"Executing Claude Code in directory: {repo_path}")
@@ -79,12 +79,12 @@ def run_claude_code(
             cmd_args.append(f"--mcp-config={mcp_config_json}")
         if lsp_plugin_dir is not None:
             cmd_args.append(f"--plugin-dir={lsp_plugin_dir}")
-        cmd_args.extend(f"--plugin-dir={plugin.plugin_dir}" for plugin in plugins)
+        cmd_args.extend(f"--plugin-dir={plugin_dir}" for _, plugin_dir in plugins)
         # --add-dir grants read+write (unlike --plugin-dir, which only registers a plugin), so hand it
         # only to plugins that opt in via grant_dir_access - currently a temporary accommodation for
         # BCQuality, whose skill reads its own knowledge files at runtime. Enabling a plugin must not
         # silently widen the agent's sandbox access.
-        cmd_args.extend(f"--add-dir={plugin.plugin_dir}" for plugin in plugins if plugin.grant_dir_access)
+        cmd_args.extend(f"--add-dir={plugin_dir}" for plugin, plugin_dir in plugins if plugin.grant_dir_access)
         if custom_agent:
             cmd_args.append(f"--agent={custom_agent}")
         cmd_args.extend(

--- a/src/bcbench/agent/claude/agent.py
+++ b/src/bcbench/agent/claude/agent.py
@@ -49,7 +49,7 @@ def run_claude_code(
     skills_enabled: bool = setup_agent_skills(claude_config, entry, repo_path, agent_type=AgentType.CLAUDE)
     custom_agent: str | None = setup_custom_agent(claude_config, entry, repo_path, agent_type=AgentType.CLAUDE)
     tool_log_path: Path = setup_hooks(repo_path, AgentType.CLAUDE, output_dir)
-    plugins: dict[str, Path] = resolve_config_plugins(claude_config)
+    plugins: dict[str, Path] = resolve_config_plugins(claude_config, allow_copilot_manifest=False)
 
     config = ExperimentConfiguration(
         mcp_servers=mcp_server_names,

--- a/src/bcbench/agent/claude/agent.py
+++ b/src/bcbench/agent/claude/agent.py
@@ -83,9 +83,11 @@ def run_claude_code(
         # --add-dir grants read+write (unlike --plugin-dir, which only registers a plugin), so hand it
         # only to plugins that opt in via grant_dir_access - currently a temporary accommodation for
         # BCQuality, whose skill reads its own knowledge files at runtime. Enabling a plugin must not
-        # silently widen the agent's sandbox access. Read the opt-in from the validated PluginConfig, not
-        # the raw YAML, so a non-boolean like `grant_dir_access: "false"` is not treated as truthy.
-        cmd_args.extend(f"--add-dir={plugins[plugin.record]}" for plugin in (PluginConfig(**entry) for entry in claude_config["plugins"]) if plugin.enabled and plugin.grant_dir_access)
+        # silently widen the agent's sandbox access. Mirror resolve_config_plugins: filter on the raw
+        # `enabled` flag before constructing PluginConfig (a disabled, possibly platform-specific entry
+        # must never be validated), then gate on the validated grant_dir_access so a non-boolean like
+        # `grant_dir_access: "false"` is not treated as truthy.
+        cmd_args.extend(f"--add-dir={plugins[plugin.record]}" for plugin in (PluginConfig(**entry) for entry in claude_config["plugins"] if entry.get("enabled", False)) if plugin.grant_dir_access)
         if custom_agent:
             cmd_args.append(f"--agent={custom_agent}")
         cmd_args.extend(

--- a/src/bcbench/agent/claude/agent.py
+++ b/src/bcbench/agent/claude/agent.py
@@ -49,7 +49,7 @@ def run_claude_code(
     skills_enabled: bool = setup_agent_skills(claude_config, entry, repo_path, agent_type=AgentType.CLAUDE)
     custom_agent: str | None = setup_custom_agent(claude_config, entry, repo_path, agent_type=AgentType.CLAUDE)
     tool_log_path: Path = setup_hooks(repo_path, AgentType.CLAUDE, output_dir)
-    plugins: dict[str, Path] = resolve_config_plugins(claude_config, allow_copilot_manifest=False)
+    plugins: list[PluginConfig] = resolve_config_plugins(claude_config, allow_copilot_manifest=False)
 
     config = ExperimentConfiguration(
         mcp_servers=mcp_server_names,
@@ -57,7 +57,7 @@ def run_claude_code(
         custom_instructions=instructions_enabled,
         skills_enabled=skills_enabled,
         custom_agent=custom_agent,
-        plugins=list(plugins.keys()) or None,
+        plugins=[plugin.record for plugin in plugins] or None,
     )
 
     logger.info(f"Executing Claude Code in directory: {repo_path}")
@@ -79,15 +79,12 @@ def run_claude_code(
             cmd_args.append(f"--mcp-config={mcp_config_json}")
         if lsp_plugin_dir is not None:
             cmd_args.append(f"--plugin-dir={lsp_plugin_dir}")
-        cmd_args.extend(f"--plugin-dir={plugin_dir}" for plugin_dir in plugins.values())
+        cmd_args.extend(f"--plugin-dir={plugin.plugin_dir}" for plugin in plugins)
         # --add-dir grants read+write (unlike --plugin-dir, which only registers a plugin), so hand it
         # only to plugins that opt in via grant_dir_access - currently a temporary accommodation for
         # BCQuality, whose skill reads its own knowledge files at runtime. Enabling a plugin must not
-        # silently widen the agent's sandbox access. Mirror resolve_config_plugins: filter on the raw
-        # `enabled` flag before constructing PluginConfig (a disabled, possibly platform-specific entry
-        # must never be validated), then gate on the validated grant_dir_access so a non-boolean like
-        # `grant_dir_access: "false"` is not treated as truthy.
-        cmd_args.extend(f"--add-dir={plugins[plugin.record]}" for plugin in (PluginConfig(**entry) for entry in claude_config["plugins"] if entry.get("enabled", False)) if plugin.grant_dir_access)
+        # silently widen the agent's sandbox access.
+        cmd_args.extend(f"--add-dir={plugin.plugin_dir}" for plugin in plugins if plugin.grant_dir_access)
         if custom_agent:
             cmd_args.append(f"--agent={custom_agent}")
         cmd_args.extend(

--- a/src/bcbench/agent/claude/agent.py
+++ b/src/bcbench/agent/claude/agent.py
@@ -12,7 +12,7 @@ from bcbench.dataset import BaseDatasetEntry
 from bcbench.exceptions import AgentError, AgentTimeoutError
 from bcbench.logger import get_logger
 from bcbench.operations import setup_agent_skills, setup_custom_agent, setup_hooks, setup_instructions_from_config
-from bcbench.types import AgentMetrics, AgentType, EvaluationCategory, ExperimentConfiguration
+from bcbench.types import AgentMetrics, AgentType, EvaluationCategory, ExperimentConfiguration, PluginConfig
 
 logger = get_logger(__name__)
 _config = get_config()
@@ -80,6 +80,13 @@ def run_claude_code(
         if lsp_plugin_dir is not None:
             cmd_args.append(f"--plugin-dir={lsp_plugin_dir}")
         cmd_args.extend(f"--plugin-dir={plugin_dir}" for plugin_dir in plugins.values())
+        # --add-dir grants read+write (unlike --plugin-dir, which only registers a plugin), so hand it
+        # only to plugins that opt in via grant_dir_access - currently a temporary accommodation for
+        # BCQuality, whose skill reads its own knowledge files at runtime. Enabling a plugin must not
+        # silently widen the agent's sandbox access.
+        cmd_args.extend(
+            f"--add-dir={plugins[PluginConfig(**plugin_entry).record]}" for plugin_entry in claude_config["plugins"] if plugin_entry.get("enabled") and plugin_entry.get("grant_dir_access")
+        )
         if custom_agent:
             cmd_args.append(f"--agent={custom_agent}")
         cmd_args.extend(

--- a/src/bcbench/agent/copilot/agent.py
+++ b/src/bcbench/agent/copilot/agent.py
@@ -85,6 +85,9 @@ def run_copilot_agent(
         if lsp_plugin_dir is not None:
             cmd_args.append(f"--plugin-dir={lsp_plugin_dir}")
         cmd_args.extend(f"--plugin-dir={plugin_dir}" for plugin_dir in plugins.values())
+        # Plugins are cloned outside the review workspace, so grant the agent read access to each
+        # plugin's tree (e.g. a skill reading its own knowledge files); --plugin-dir only registers it.
+        cmd_args.extend(f"--add-dir={plugin_dir}" for plugin_dir in plugins.values())
         if custom_agent:
             cmd_args.append(f"--agent={custom_agent}")
 

--- a/src/bcbench/agent/copilot/agent.py
+++ b/src/bcbench/agent/copilot/agent.py
@@ -8,14 +8,14 @@ from pathlib import Path
 import yaml
 
 from bcbench.agent.copilot.metrics import parse_metrics
-from bcbench.agent.shared import build_al_lsp_plugin, build_mcp_config, build_prompt, parse_tool_usage_from_hooks, plugins_needing_dir_access, resolve_config_plugins
+from bcbench.agent.shared import build_al_lsp_plugin, build_mcp_config, build_prompt, parse_tool_usage_from_hooks, resolve_config_plugins
 from bcbench.config import get_config
 from bcbench.copilot_cli import find_copilot
 from bcbench.dataset import BaseDatasetEntry
 from bcbench.exceptions import AgentError, AgentTimeoutError
 from bcbench.logger import get_logger
 from bcbench.operations import setup_agent_skills, setup_custom_agent, setup_hooks, setup_instructions_from_config
-from bcbench.types import AgentMetrics, AgentType, EvaluationCategory, ExperimentConfiguration
+from bcbench.types import AgentMetrics, AgentType, EvaluationCategory, ExperimentConfiguration, PluginConfig
 
 logger = get_logger(__name__)
 _config = get_config()
@@ -54,7 +54,7 @@ def run_copilot_agent(
     skills_enabled: bool = setup_agent_skills(copilot_config, entry, repo_path, agent_type=AgentType.COPILOT)
     custom_agent: str | None = setup_custom_agent(copilot_config, entry, repo_path, agent_type=AgentType.COPILOT)
     tool_log_path: Path = setup_hooks(repo_path, AgentType.COPILOT, output_dir)
-    plugins: dict[str, Path] = resolve_config_plugins(copilot_config, allow_root_manifest=True)
+    plugins: dict[str, Path] = resolve_config_plugins(copilot_config, allow_copilot_manifest=True)
 
     config = ExperimentConfiguration(
         mcp_servers=mcp_server_names,
@@ -85,12 +85,13 @@ def run_copilot_agent(
         if lsp_plugin_dir is not None:
             cmd_args.append(f"--plugin-dir={lsp_plugin_dir}")
         cmd_args.extend(f"--plugin-dir={plugin_dir}" for plugin_dir in plugins.values())
-        # A plugin that reads its own tree at runtime (e.g. a skill loading its knowledge files)
-        # needs filesystem access beyond --plugin-dir, which only registers it. --add-dir grants
-        # read+write, so it is limited to plugins that opt in via grant_dir_access rather than
-        # handed to every plugin - keeping "plugin enabled" and "dir access granted" separate.
-        granted = plugins_needing_dir_access(copilot_config)
-        cmd_args.extend(f"--add-dir={plugins[record]}" for record in plugins if record in granted)
+        # --add-dir grants read+write (unlike --plugin-dir, which only registers a plugin), so hand it
+        # only to plugins that opt in via grant_dir_access - currently a temporary accommodation for
+        # BCQuality, whose skill reads its own knowledge files at runtime. Enabling a plugin must not
+        # silently widen the agent's sandbox access.
+        cmd_args.extend(
+            f"--add-dir={plugins[PluginConfig(**plugin_entry).record]}" for plugin_entry in copilot_config["plugins"] if plugin_entry.get("enabled") and plugin_entry.get("grant_dir_access")
+        )
         if custom_agent:
             cmd_args.append(f"--agent={custom_agent}")
 

--- a/src/bcbench/agent/copilot/agent.py
+++ b/src/bcbench/agent/copilot/agent.py
@@ -54,7 +54,7 @@ def run_copilot_agent(
     skills_enabled: bool = setup_agent_skills(copilot_config, entry, repo_path, agent_type=AgentType.COPILOT)
     custom_agent: str | None = setup_custom_agent(copilot_config, entry, repo_path, agent_type=AgentType.COPILOT)
     tool_log_path: Path = setup_hooks(repo_path, AgentType.COPILOT, output_dir)
-    plugins: dict[str, Path] = resolve_config_plugins(copilot_config, allow_copilot_manifest=True)
+    plugins: list[PluginConfig] = resolve_config_plugins(copilot_config, allow_copilot_manifest=True)
 
     config = ExperimentConfiguration(
         mcp_servers=mcp_server_names,
@@ -62,7 +62,7 @@ def run_copilot_agent(
         custom_instructions=instructions_enabled,
         skills_enabled=skills_enabled,
         custom_agent=custom_agent,
-        plugins=list(plugins.keys()) or None,
+        plugins=[plugin.record for plugin in plugins] or None,
     )
 
     logger.info(f"Executing Copilot CLI in directory: {repo_path}")
@@ -84,15 +84,12 @@ def run_copilot_agent(
             cmd_args.append(f"--additional-mcp-config={mcp_config_json}")
         if lsp_plugin_dir is not None:
             cmd_args.append(f"--plugin-dir={lsp_plugin_dir}")
-        cmd_args.extend(f"--plugin-dir={plugin_dir}" for plugin_dir in plugins.values())
+        cmd_args.extend(f"--plugin-dir={plugin.plugin_dir}" for plugin in plugins)
         # --add-dir grants read+write (unlike --plugin-dir, which only registers a plugin), so hand it
         # only to plugins that opt in via grant_dir_access - currently a temporary accommodation for
         # BCQuality, whose skill reads its own knowledge files at runtime. Enabling a plugin must not
-        # silently widen the agent's sandbox access. Mirror resolve_config_plugins: filter on the raw
-        # `enabled` flag before constructing PluginConfig (a disabled, possibly platform-specific entry
-        # must never be validated), then gate on the validated grant_dir_access so a non-boolean like
-        # `grant_dir_access: "false"` is not treated as truthy.
-        cmd_args.extend(f"--add-dir={plugins[plugin.record]}" for plugin in (PluginConfig(**entry) for entry in copilot_config["plugins"] if entry.get("enabled", False)) if plugin.grant_dir_access)
+        # silently widen the agent's sandbox access.
+        cmd_args.extend(f"--add-dir={plugin.plugin_dir}" for plugin in plugins if plugin.grant_dir_access)
         if custom_agent:
             cmd_args.append(f"--agent={custom_agent}")
 

--- a/src/bcbench/agent/copilot/agent.py
+++ b/src/bcbench/agent/copilot/agent.py
@@ -88,10 +88,9 @@ def run_copilot_agent(
         # --add-dir grants read+write (unlike --plugin-dir, which only registers a plugin), so hand it
         # only to plugins that opt in via grant_dir_access - currently a temporary accommodation for
         # BCQuality, whose skill reads its own knowledge files at runtime. Enabling a plugin must not
-        # silently widen the agent's sandbox access.
-        cmd_args.extend(
-            f"--add-dir={plugins[PluginConfig(**plugin_entry).record]}" for plugin_entry in copilot_config["plugins"] if plugin_entry.get("enabled") and plugin_entry.get("grant_dir_access")
-        )
+        # silently widen the agent's sandbox access. Read the opt-in from the validated PluginConfig, not
+        # the raw YAML, so a non-boolean like `grant_dir_access: "false"` is not treated as truthy.
+        cmd_args.extend(f"--add-dir={plugins[plugin.record]}" for plugin in (PluginConfig(**entry) for entry in copilot_config["plugins"]) if plugin.enabled and plugin.grant_dir_access)
         if custom_agent:
             cmd_args.append(f"--agent={custom_agent}")
 

--- a/src/bcbench/agent/copilot/agent.py
+++ b/src/bcbench/agent/copilot/agent.py
@@ -88,9 +88,11 @@ def run_copilot_agent(
         # --add-dir grants read+write (unlike --plugin-dir, which only registers a plugin), so hand it
         # only to plugins that opt in via grant_dir_access - currently a temporary accommodation for
         # BCQuality, whose skill reads its own knowledge files at runtime. Enabling a plugin must not
-        # silently widen the agent's sandbox access. Read the opt-in from the validated PluginConfig, not
-        # the raw YAML, so a non-boolean like `grant_dir_access: "false"` is not treated as truthy.
-        cmd_args.extend(f"--add-dir={plugins[plugin.record]}" for plugin in (PluginConfig(**entry) for entry in copilot_config["plugins"]) if plugin.enabled and plugin.grant_dir_access)
+        # silently widen the agent's sandbox access. Mirror resolve_config_plugins: filter on the raw
+        # `enabled` flag before constructing PluginConfig (a disabled, possibly platform-specific entry
+        # must never be validated), then gate on the validated grant_dir_access so a non-boolean like
+        # `grant_dir_access: "false"` is not treated as truthy.
+        cmd_args.extend(f"--add-dir={plugins[plugin.record]}" for plugin in (PluginConfig(**entry) for entry in copilot_config["plugins"] if entry.get("enabled", False)) if plugin.grant_dir_access)
         if custom_agent:
             cmd_args.append(f"--agent={custom_agent}")
 

--- a/src/bcbench/agent/copilot/agent.py
+++ b/src/bcbench/agent/copilot/agent.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import yaml
 
 from bcbench.agent.copilot.metrics import parse_metrics
-from bcbench.agent.shared import build_al_lsp_plugin, build_mcp_config, build_prompt, parse_tool_usage_from_hooks, resolve_config_plugins
+from bcbench.agent.shared import build_al_lsp_plugin, build_mcp_config, build_prompt, parse_tool_usage_from_hooks, plugins_needing_dir_access, resolve_config_plugins
 from bcbench.config import get_config
 from bcbench.copilot_cli import find_copilot
 from bcbench.dataset import BaseDatasetEntry
@@ -54,7 +54,7 @@ def run_copilot_agent(
     skills_enabled: bool = setup_agent_skills(copilot_config, entry, repo_path, agent_type=AgentType.COPILOT)
     custom_agent: str | None = setup_custom_agent(copilot_config, entry, repo_path, agent_type=AgentType.COPILOT)
     tool_log_path: Path = setup_hooks(repo_path, AgentType.COPILOT, output_dir)
-    plugins: dict[str, Path] = resolve_config_plugins(copilot_config)
+    plugins: dict[str, Path] = resolve_config_plugins(copilot_config, allow_root_manifest=True)
 
     config = ExperimentConfiguration(
         mcp_servers=mcp_server_names,
@@ -85,9 +85,12 @@ def run_copilot_agent(
         if lsp_plugin_dir is not None:
             cmd_args.append(f"--plugin-dir={lsp_plugin_dir}")
         cmd_args.extend(f"--plugin-dir={plugin_dir}" for plugin_dir in plugins.values())
-        # Plugins are cloned outside the review workspace, so grant the agent read access to each
-        # plugin's tree (e.g. a skill reading its own knowledge files); --plugin-dir only registers it.
-        cmd_args.extend(f"--add-dir={plugin_dir}" for plugin_dir in plugins.values())
+        # A plugin that reads its own tree at runtime (e.g. a skill loading its knowledge files)
+        # needs filesystem access beyond --plugin-dir, which only registers it. --add-dir grants
+        # read+write, so it is limited to plugins that opt in via grant_dir_access rather than
+        # handed to every plugin - keeping "plugin enabled" and "dir access granted" separate.
+        granted = plugins_needing_dir_access(copilot_config)
+        cmd_args.extend(f"--add-dir={plugins[record]}" for record in plugins if record in granted)
         if custom_agent:
             cmd_args.append(f"--agent={custom_agent}")
 

--- a/src/bcbench/agent/copilot/agent.py
+++ b/src/bcbench/agent/copilot/agent.py
@@ -54,7 +54,7 @@ def run_copilot_agent(
     skills_enabled: bool = setup_agent_skills(copilot_config, entry, repo_path, agent_type=AgentType.COPILOT)
     custom_agent: str | None = setup_custom_agent(copilot_config, entry, repo_path, agent_type=AgentType.COPILOT)
     tool_log_path: Path = setup_hooks(repo_path, AgentType.COPILOT, output_dir)
-    plugins: list[PluginConfig] = resolve_config_plugins(copilot_config, allow_copilot_manifest=True)
+    plugins: list[tuple[PluginConfig, Path]] = resolve_config_plugins(copilot_config, allow_copilot_manifest=True)
 
     config = ExperimentConfiguration(
         mcp_servers=mcp_server_names,
@@ -62,7 +62,7 @@ def run_copilot_agent(
         custom_instructions=instructions_enabled,
         skills_enabled=skills_enabled,
         custom_agent=custom_agent,
-        plugins=[plugin.record for plugin in plugins] or None,
+        plugins=[plugin.record for plugin, _ in plugins] or None,
     )
 
     logger.info(f"Executing Copilot CLI in directory: {repo_path}")
@@ -84,12 +84,12 @@ def run_copilot_agent(
             cmd_args.append(f"--additional-mcp-config={mcp_config_json}")
         if lsp_plugin_dir is not None:
             cmd_args.append(f"--plugin-dir={lsp_plugin_dir}")
-        cmd_args.extend(f"--plugin-dir={plugin.plugin_dir}" for plugin in plugins)
+        cmd_args.extend(f"--plugin-dir={plugin_dir}" for _, plugin_dir in plugins)
         # --add-dir grants read+write (unlike --plugin-dir, which only registers a plugin), so hand it
         # only to plugins that opt in via grant_dir_access - currently a temporary accommodation for
         # BCQuality, whose skill reads its own knowledge files at runtime. Enabling a plugin must not
         # silently widen the agent's sandbox access.
-        cmd_args.extend(f"--add-dir={plugin.plugin_dir}" for plugin in plugins if plugin.grant_dir_access)
+        cmd_args.extend(f"--add-dir={plugin_dir}" for plugin, plugin_dir in plugins if plugin.grant_dir_access)
         if custom_agent:
             cmd_args.append(f"--agent={custom_agent}")
 

--- a/src/bcbench/agent/shared/__init__.py
+++ b/src/bcbench/agent/shared/__init__.py
@@ -3,7 +3,7 @@
 from bcbench.agent.shared.hooks_parser import parse_tool_usage_from_hooks
 from bcbench.agent.shared.lsp import build_al_lsp_plugin
 from bcbench.agent.shared.mcp import build_mcp_config
-from bcbench.agent.shared.plugin import plugins_needing_dir_access, resolve_config_plugins
+from bcbench.agent.shared.plugin import resolve_config_plugins
 from bcbench.agent.shared.prompt import build_prompt
 
-__all__ = ["build_al_lsp_plugin", "build_mcp_config", "build_prompt", "parse_tool_usage_from_hooks", "plugins_needing_dir_access", "resolve_config_plugins"]
+__all__ = ["build_al_lsp_plugin", "build_mcp_config", "build_prompt", "parse_tool_usage_from_hooks", "resolve_config_plugins"]

--- a/src/bcbench/agent/shared/__init__.py
+++ b/src/bcbench/agent/shared/__init__.py
@@ -3,7 +3,7 @@
 from bcbench.agent.shared.hooks_parser import parse_tool_usage_from_hooks
 from bcbench.agent.shared.lsp import build_al_lsp_plugin
 from bcbench.agent.shared.mcp import build_mcp_config
-from bcbench.agent.shared.plugin import resolve_config_plugins
+from bcbench.agent.shared.plugin import plugins_needing_dir_access, resolve_config_plugins
 from bcbench.agent.shared.prompt import build_prompt
 
-__all__ = ["build_al_lsp_plugin", "build_mcp_config", "build_prompt", "parse_tool_usage_from_hooks", "resolve_config_plugins"]
+__all__ = ["build_al_lsp_plugin", "build_mcp_config", "build_prompt", "parse_tool_usage_from_hooks", "plugins_needing_dir_access", "resolve_config_plugins"]

--- a/src/bcbench/agent/shared/config.yaml
+++ b/src/bcbench/agent/shared/config.yaml
@@ -97,6 +97,7 @@ agents:
 # Each plugin gets its own entry, and is passed to the CLI via `--plugin-dir` (session-scoped).
 #   name:     plugin name; also how it is recorded on the result as "<name>@<revision|local>"
 #   enabled:  per-entry toggle (defaults to false)
+#   grant_dir_access: grant the agent read+write access to this plugin's tree via --add-dir (defaults to false)
 #   source:   "local" (a folder on this machine) or "github" (cloned at runtime)
 #   path:     plugin root - for local an absolute path ; for github relative to the clone ("." for its root, or a subfolder when the repo hosts several plugins)
 #   repo:     github only, "owner/repo"
@@ -114,6 +115,10 @@ plugins:
     path: "."
   - name: "BCQuality"
     enabled: false
+    # grant_dir_access gives BCQuality's skill --add-dir access to read its own knowledge files at
+    # runtime. This is a (hopefully temporary) design that may change once that content is served
+    # via skills / an MCP server instead.
+    grant_dir_access: false
     source: github
     repo: "microsoft/BCQuality"
     revision: "ad8ccde5953fd6ce072e3b59049406783066ed60"

--- a/src/bcbench/agent/shared/plugin.py
+++ b/src/bcbench/agent/shared/plugin.py
@@ -44,7 +44,7 @@ def remove_agent_plugin(folder: str) -> None:
         logger.info(f"Removed stale agent plugin '{folder}': {plugin_dir}")
 
 
-def resolve_config_plugins(agent_config: dict, *, allow_copilot_manifest: bool = False) -> dict[str, Path]:
+def resolve_config_plugins(agent_config: dict, *, allow_copilot_manifest: bool = False) -> list[PluginConfig]:
     """Resolve the config's enabled plugin entries to loadable plugin folders.
 
     A plugin is either `local` (an absolute path on this machine) or `github` (cloned from its repo
@@ -57,7 +57,7 @@ def resolve_config_plugins(agent_config: dict, *, allow_copilot_manifest: bool =
         allow_copilot_manifest: Also accept a root ``plugin.json`` - a layout only Copilot CLI loads.
 
     Returns:
-        Plugin folders keyed by the record they get on the result, in config order.
+        The enabled plugins, in config order, each with its resolved ``plugin_dir`` set.
 
     Raises:
         AgentError: If two enabled plugins share a name, or a plugin does not resolve to a folder
@@ -74,7 +74,7 @@ def resolve_config_plugins(agent_config: dict, *, allow_copilot_manifest: bool =
     if duplicates:
         raise AgentError(f"Duplicate plugin name(s) among enabled plugins: {', '.join(duplicates)}")
 
-    return {plugin.record: _resolve_plugin(plugin, allow_copilot_manifest) for plugin in plugins}
+    return [plugin.model_copy(update={"plugin_dir": _resolve_plugin(plugin, allow_copilot_manifest)}) for plugin in plugins]
 
 
 def _has_plugin_manifest(plugin_dir: Path, allow_copilot_manifest: bool) -> bool:

--- a/src/bcbench/agent/shared/plugin.py
+++ b/src/bcbench/agent/shared/plugin.py
@@ -65,6 +65,16 @@ def resolve_config_plugins(agent_config: dict) -> dict[str, Path]:
     return {plugin.record: _resolve_plugin(plugin) for plugin in plugins}
 
 
+def _has_plugin_manifest(plugin_dir: Path) -> bool:
+    """True if the folder holds a plugin manifest in either supported location.
+
+    Claude Code expects ``.claude-plugin/plugin.json``; GitHub Copilot CLI also loads a
+    ``plugin.json`` at the plugin root. A plugin published in either layout is loadable.
+    """
+    root_manifest: Path = plugin_dir / _config.file_patterns.plugin_manifest.name
+    return (plugin_dir / _config.file_patterns.plugin_manifest).is_file() or root_manifest.is_file()
+
+
 def _resolve_plugin(plugin: PluginConfig) -> Path:
     match plugin.source:
         case "local":
@@ -74,8 +84,8 @@ def _resolve_plugin(plugin: PluginConfig) -> Path:
             clone_repo_at_revision(str(plugin.repo), str(plugin.revision), clone_dir)
             plugin_dir = _plugin_dir_in_clone(clone_dir, plugin)
 
-    if not (plugin_dir / _config.file_patterns.plugin_manifest).is_file():
-        raise AgentError(f"Plugin '{plugin.name}' has no manifest at {plugin_dir / _config.file_patterns.plugin_manifest}")
+    if not _has_plugin_manifest(plugin_dir):
+        raise AgentError(f"Plugin '{plugin.name}' has no manifest at {plugin_dir / _config.file_patterns.plugin_manifest} or {plugin_dir / _config.file_patterns.plugin_manifest.name}")
 
     logger.info(f"Loading plugin {plugin.record} from {plugin_dir}")
     return plugin_dir

--- a/src/bcbench/agent/shared/plugin.py
+++ b/src/bcbench/agent/shared/plugin.py
@@ -44,7 +44,7 @@ def remove_agent_plugin(folder: str) -> None:
         logger.info(f"Removed stale agent plugin '{folder}': {plugin_dir}")
 
 
-def resolve_config_plugins(agent_config: dict, *, allow_copilot_manifest: bool = False) -> list[PluginConfig]:
+def resolve_config_plugins(agent_config: dict, *, allow_copilot_manifest: bool = False) -> list[tuple[PluginConfig, Path]]:
     """Resolve the config's enabled plugin entries to loadable plugin folders.
 
     A plugin is either `local` (an absolute path on this machine) or `github` (cloned from its repo
@@ -57,7 +57,7 @@ def resolve_config_plugins(agent_config: dict, *, allow_copilot_manifest: bool =
         allow_copilot_manifest: Also accept a root ``plugin.json`` - a layout only Copilot CLI loads.
 
     Returns:
-        The enabled plugins, in config order, each with its resolved ``plugin_dir`` set.
+        Each enabled plugin, in config order, paired with the folder it resolved to.
 
     Raises:
         AgentError: If two enabled plugins share a name, or a plugin does not resolve to a folder
@@ -74,7 +74,7 @@ def resolve_config_plugins(agent_config: dict, *, allow_copilot_manifest: bool =
     if duplicates:
         raise AgentError(f"Duplicate plugin name(s) among enabled plugins: {', '.join(duplicates)}")
 
-    return [plugin.model_copy(update={"plugin_dir": _resolve_plugin(plugin, allow_copilot_manifest)}) for plugin in plugins]
+    return [(plugin, _resolve_plugin(plugin, allow_copilot_manifest)) for plugin in plugins]
 
 
 def _has_plugin_manifest(plugin_dir: Path, allow_copilot_manifest: bool) -> bool:

--- a/src/bcbench/agent/shared/plugin.py
+++ b/src/bcbench/agent/shared/plugin.py
@@ -60,29 +60,21 @@ def resolve_config_plugins(agent_config: dict, *, allow_copilot_manifest: bool =
         Plugin folders keyed by the record they get on the result, in config order.
 
     Raises:
-        AgentError: If two enabled plugins share a record or resolve to the same folder, or a plugin
-            does not resolve to a folder holding a plugin manifest.
+        AgentError: If two enabled plugins share a name, or a plugin does not resolve to a folder
+            holding a plugin manifest.
     """
     plugins = [PluginConfig(**entry) for entry in agent_config["plugins"] if entry.get("enabled", False)]
 
-    # A record (``name@revision-or-source``) keys both the resolved folder and the plugin's entry on a
-    # result, so a collision would silently drop a plugin - and, with grant_dir_access in play, let one
-    # entry's opt-in leak onto another's path. Reject duplicate records up front.
-    records = [plugin.record for plugin in plugins]
-    duplicate_records = sorted({record for record in records if records.count(record) > 1})
-    if duplicate_records:
-        raise AgentError(f"Duplicate plugin record(s) among enabled plugins: {', '.join(duplicate_records)}")
+    # A GitHub plugin clones into ``<plugin_root>/<name>`` and every plugin is recorded as
+    # ``<name>@<revision|source>``, so two enabled plugins sharing a name would clobber each other's
+    # clone and collide on their record. There is no reason to enable the same-named plugin twice, so
+    # reject duplicate names up front.
+    names = [plugin.name for plugin in plugins]
+    duplicates = sorted({name for name in names if names.count(name) > 1})
+    if duplicates:
+        raise AgentError(f"Duplicate plugin name(s) among enabled plugins: {', '.join(duplicates)}")
 
-    resolved = {plugin.record: _resolve_plugin(plugin, allow_copilot_manifest) for plugin in plugins}
-
-    # Distinct records can still resolve to one folder (e.g. two GitHub entries sharing a name clone
-    # into ``<plugin_root>/<name>``, the second clobbering the first), which would grant a non-opted-in
-    # plugin the other's ``--add-dir``. Reject shared destinations too.
-    folders = [str(path) for path in resolved.values()]
-    shared_folders = sorted({folder for folder in folders if folders.count(folder) > 1})
-    if shared_folders:
-        raise AgentError(f"Distinct plugins resolve to the same folder: {', '.join(shared_folders)}")
-    return resolved
+    return {plugin.record: _resolve_plugin(plugin, allow_copilot_manifest) for plugin in plugins}
 
 
 def _has_plugin_manifest(plugin_dir: Path, allow_copilot_manifest: bool) -> bool:

--- a/src/bcbench/agent/shared/plugin.py
+++ b/src/bcbench/agent/shared/plugin.py
@@ -44,7 +44,7 @@ def remove_agent_plugin(folder: str) -> None:
         logger.info(f"Removed stale agent plugin '{folder}': {plugin_dir}")
 
 
-def resolve_config_plugins(agent_config: dict) -> dict[str, Path]:
+def resolve_config_plugins(agent_config: dict, *, allow_root_manifest: bool = False) -> dict[str, Path]:
     """Resolve the config's enabled plugin entries to loadable plugin folders.
 
     A plugin is either `local` (an absolute path on this machine) or `github` (cloned from its repo
@@ -54,6 +54,9 @@ def resolve_config_plugins(agent_config: dict) -> dict[str, Path]:
 
     Args:
         agent_config: Parsed `config.yaml`.
+        allow_root_manifest: Accept a root ``plugin.json`` in addition to ``.claude-plugin/plugin.json``.
+            Only Copilot CLI loads a root manifest, so Copilot runs pass ``True`` while Claude runs keep
+            the default ``False`` and reject a root-only plugin they could not load anyway.
 
     Returns:
         Plugin folders keyed by the record they get on the result, in config order.
@@ -62,20 +65,34 @@ def resolve_config_plugins(agent_config: dict) -> dict[str, Path]:
         AgentError: If a plugin does not resolve to a folder holding a plugin manifest.
     """
     plugins = [PluginConfig(**entry) for entry in agent_config["plugins"] if entry.get("enabled", False)]
-    return {plugin.record: _resolve_plugin(plugin) for plugin in plugins}
+    return {plugin.record: _resolve_plugin(plugin, allow_root_manifest) for plugin in plugins}
 
 
-def _has_plugin_manifest(plugin_dir: Path) -> bool:
-    """True if the folder holds a plugin manifest in either supported location.
+def plugins_needing_dir_access(agent_config: dict) -> set[str]:
+    """Records of enabled plugins that opt into filesystem access via Copilot ``--add-dir``.
 
-    Claude Code expects ``.claude-plugin/plugin.json``; GitHub Copilot CLI also loads a
-    ``plugin.json`` at the plugin root. A plugin published in either layout is loadable.
+    ``--add-dir`` grants read+write access, so a plugin receives it only when it sets
+    ``grant_dir_access`` in its config entry. Enabling a plugin therefore never widens the agent's
+    sandbox access on its own, keeping "plugin enabled" and "directory access granted" separate.
     """
-    root_manifest: Path = plugin_dir / _config.file_patterns.plugin_manifest.name
-    return (plugin_dir / _config.file_patterns.plugin_manifest).is_file() or root_manifest.is_file()
+    enabled = (PluginConfig(**entry) for entry in agent_config["plugins"] if entry.get("enabled", False))
+    return {plugin.record for plugin in enabled if plugin.grant_dir_access}
 
 
-def _resolve_plugin(plugin: PluginConfig) -> Path:
+def _has_plugin_manifest(plugin_dir: Path, allow_root_manifest: bool) -> bool:
+    """True if the folder holds a plugin manifest in a location the target agent can load.
+
+    Claude Code loads only ``.claude-plugin/plugin.json``. GitHub Copilot CLI loads that layout too
+    but also accepts a ``plugin.json`` at the plugin root, so a root-only manifest is honored only
+    when ``allow_root_manifest`` is set (Copilot runs) - never for a Claude run, which would otherwise
+    forward the plugin via ``--plugin-dir`` only for Claude to ignore it.
+    """
+    if (plugin_dir / _config.file_patterns.plugin_manifest).is_file():
+        return True
+    return allow_root_manifest and (plugin_dir / _config.file_patterns.plugin_manifest.name).is_file()
+
+
+def _resolve_plugin(plugin: PluginConfig, allow_root_manifest: bool) -> Path:
     match plugin.source:
         case "local":
             plugin_dir = Path(plugin.path).expanduser().resolve()
@@ -84,8 +101,10 @@ def _resolve_plugin(plugin: PluginConfig) -> Path:
             clone_repo_at_revision(str(plugin.repo), str(plugin.revision), clone_dir)
             plugin_dir = _plugin_dir_in_clone(clone_dir, plugin)
 
-    if not _has_plugin_manifest(plugin_dir):
-        raise AgentError(f"Plugin '{plugin.name}' has no manifest at {plugin_dir / _config.file_patterns.plugin_manifest} or {plugin_dir / _config.file_patterns.plugin_manifest.name}")
+    if not _has_plugin_manifest(plugin_dir, allow_root_manifest):
+        nested: Path = plugin_dir / _config.file_patterns.plugin_manifest
+        locations: str = f"{nested} or {plugin_dir / _config.file_patterns.plugin_manifest.name}" if allow_root_manifest else str(nested)
+        raise AgentError(f"Plugin '{plugin.name}' has no manifest at {locations}")
 
     logger.info(f"Loading plugin {plugin.record} from {plugin_dir}")
     return plugin_dir

--- a/src/bcbench/agent/shared/plugin.py
+++ b/src/bcbench/agent/shared/plugin.py
@@ -62,9 +62,10 @@ def resolve_config_plugins(agent_config: dict, *, allow_root_manifest: bool = Fa
         Plugin folders keyed by the record they get on the result, in config order.
 
     Raises:
-        AgentError: If a plugin does not resolve to a folder holding a plugin manifest.
+        AgentError: If two enabled plugins share a record, or a plugin does not resolve to a folder
+            holding a plugin manifest.
     """
-    plugins = [PluginConfig(**entry) for entry in agent_config["plugins"] if entry.get("enabled", False)]
+    plugins = _enabled_plugins(agent_config)
     return {plugin.record: _resolve_plugin(plugin, allow_root_manifest) for plugin in plugins}
 
 
@@ -75,8 +76,22 @@ def plugins_needing_dir_access(agent_config: dict) -> set[str]:
     ``grant_dir_access`` in its config entry. Enabling a plugin therefore never widens the agent's
     sandbox access on its own, keeping "plugin enabled" and "directory access granted" separate.
     """
-    enabled = (PluginConfig(**entry) for entry in agent_config["plugins"] if entry.get("enabled", False))
-    return {plugin.record for plugin in enabled if plugin.grant_dir_access}
+    return {plugin.record for plugin in _enabled_plugins(agent_config) if plugin.grant_dir_access}
+
+
+def _enabled_plugins(agent_config: dict) -> list[PluginConfig]:
+    """Parse the enabled plugin entries, enforcing that their records are unique.
+
+    A record (``name@revision-or-source``) keys both the resolved plugin folder and the plugin's
+    entry on a result. A collision would silently drop a plugin and, once ``grant_dir_access`` is in
+    play, let one entry's opt-in leak onto another entry's resolved path - so reject duplicates up front.
+    """
+    plugins = [PluginConfig(**entry) for entry in agent_config["plugins"] if entry.get("enabled", False)]
+    records = [plugin.record for plugin in plugins]
+    duplicates = sorted({record for record in records if records.count(record) > 1})
+    if duplicates:
+        raise AgentError(f"Duplicate plugin record(s) among enabled plugins: {', '.join(duplicates)}")
+    return plugins
 
 
 def _has_plugin_manifest(plugin_dir: Path, allow_root_manifest: bool) -> bool:

--- a/src/bcbench/agent/shared/plugin.py
+++ b/src/bcbench/agent/shared/plugin.py
@@ -44,7 +44,7 @@ def remove_agent_plugin(folder: str) -> None:
         logger.info(f"Removed stale agent plugin '{folder}': {plugin_dir}")
 
 
-def resolve_config_plugins(agent_config: dict, *, allow_root_manifest: bool = False) -> dict[str, Path]:
+def resolve_config_plugins(agent_config: dict, *, allow_copilot_manifest: bool = False) -> dict[str, Path]:
     """Resolve the config's enabled plugin entries to loadable plugin folders.
 
     A plugin is either `local` (an absolute path on this machine) or `github` (cloned from its repo
@@ -54,60 +54,51 @@ def resolve_config_plugins(agent_config: dict, *, allow_root_manifest: bool = Fa
 
     Args:
         agent_config: Parsed `config.yaml`.
-        allow_root_manifest: Accept a root ``plugin.json`` in addition to ``.claude-plugin/plugin.json``.
-            Only Copilot CLI loads a root manifest, so Copilot runs pass ``True`` while Claude runs keep
-            the default ``False`` and reject a root-only plugin they could not load anyway.
+        allow_copilot_manifest: Also accept a root ``plugin.json`` - a layout only Copilot CLI loads.
 
     Returns:
         Plugin folders keyed by the record they get on the result, in config order.
 
     Raises:
-        AgentError: If two enabled plugins share a record, or a plugin does not resolve to a folder
-            holding a plugin manifest.
-    """
-    plugins = _enabled_plugins(agent_config)
-    return {plugin.record: _resolve_plugin(plugin, allow_root_manifest) for plugin in plugins}
-
-
-def plugins_needing_dir_access(agent_config: dict) -> set[str]:
-    """Records of enabled plugins that opt into filesystem access via Copilot ``--add-dir``.
-
-    ``--add-dir`` grants read+write access, so a plugin receives it only when it sets
-    ``grant_dir_access`` in its config entry. Enabling a plugin therefore never widens the agent's
-    sandbox access on its own, keeping "plugin enabled" and "directory access granted" separate.
-    """
-    return {plugin.record for plugin in _enabled_plugins(agent_config) if plugin.grant_dir_access}
-
-
-def _enabled_plugins(agent_config: dict) -> list[PluginConfig]:
-    """Parse the enabled plugin entries, enforcing that their records are unique.
-
-    A record (``name@revision-or-source``) keys both the resolved plugin folder and the plugin's
-    entry on a result. A collision would silently drop a plugin and, once ``grant_dir_access`` is in
-    play, let one entry's opt-in leak onto another entry's resolved path - so reject duplicates up front.
+        AgentError: If two enabled plugins share a record or resolve to the same folder, or a plugin
+            does not resolve to a folder holding a plugin manifest.
     """
     plugins = [PluginConfig(**entry) for entry in agent_config["plugins"] if entry.get("enabled", False)]
+
+    # A record (``name@revision-or-source``) keys both the resolved folder and the plugin's entry on a
+    # result, so a collision would silently drop a plugin - and, with grant_dir_access in play, let one
+    # entry's opt-in leak onto another's path. Reject duplicate records up front.
     records = [plugin.record for plugin in plugins]
-    duplicates = sorted({record for record in records if records.count(record) > 1})
-    if duplicates:
-        raise AgentError(f"Duplicate plugin record(s) among enabled plugins: {', '.join(duplicates)}")
-    return plugins
+    duplicate_records = sorted({record for record in records if records.count(record) > 1})
+    if duplicate_records:
+        raise AgentError(f"Duplicate plugin record(s) among enabled plugins: {', '.join(duplicate_records)}")
+
+    resolved = {plugin.record: _resolve_plugin(plugin, allow_copilot_manifest) for plugin in plugins}
+
+    # Distinct records can still resolve to one folder (e.g. two GitHub entries sharing a name clone
+    # into ``<plugin_root>/<name>``, the second clobbering the first), which would grant a non-opted-in
+    # plugin the other's ``--add-dir``. Reject shared destinations too.
+    folders = [str(path) for path in resolved.values()]
+    shared_folders = sorted({folder for folder in folders if folders.count(folder) > 1})
+    if shared_folders:
+        raise AgentError(f"Distinct plugins resolve to the same folder: {', '.join(shared_folders)}")
+    return resolved
 
 
-def _has_plugin_manifest(plugin_dir: Path, allow_root_manifest: bool) -> bool:
+def _has_plugin_manifest(plugin_dir: Path, allow_copilot_manifest: bool) -> bool:
     """True if the folder holds a plugin manifest in a location the target agent can load.
 
     Claude Code loads only ``.claude-plugin/plugin.json``. GitHub Copilot CLI loads that layout too
     but also accepts a ``plugin.json`` at the plugin root, so a root-only manifest is honored only
-    when ``allow_root_manifest`` is set (Copilot runs) - never for a Claude run, which would otherwise
+    when ``allow_copilot_manifest`` is set (Copilot runs) - never for a Claude run, which would otherwise
     forward the plugin via ``--plugin-dir`` only for Claude to ignore it.
     """
     if (plugin_dir / _config.file_patterns.plugin_manifest).is_file():
         return True
-    return allow_root_manifest and (plugin_dir / _config.file_patterns.plugin_manifest.name).is_file()
+    return allow_copilot_manifest and (plugin_dir / _config.file_patterns.plugin_manifest.name).is_file()
 
 
-def _resolve_plugin(plugin: PluginConfig, allow_root_manifest: bool) -> Path:
+def _resolve_plugin(plugin: PluginConfig, allow_copilot_manifest: bool) -> Path:
     match plugin.source:
         case "local":
             plugin_dir = Path(plugin.path).expanduser().resolve()
@@ -116,9 +107,9 @@ def _resolve_plugin(plugin: PluginConfig, allow_root_manifest: bool) -> Path:
             clone_repo_at_revision(str(plugin.repo), str(plugin.revision), clone_dir)
             plugin_dir = _plugin_dir_in_clone(clone_dir, plugin)
 
-    if not _has_plugin_manifest(plugin_dir, allow_root_manifest):
+    if not _has_plugin_manifest(plugin_dir, allow_copilot_manifest):
         nested: Path = plugin_dir / _config.file_patterns.plugin_manifest
-        locations: str = f"{nested} or {plugin_dir / _config.file_patterns.plugin_manifest.name}" if allow_root_manifest else str(nested)
+        locations: str = f"{nested} or {plugin_dir / _config.file_patterns.plugin_manifest.name}" if allow_copilot_manifest else str(nested)
         raise AgentError(f"Plugin '{plugin.name}' has no manifest at {locations}")
 
     logger.info(f"Loading plugin {plugin.record} from {plugin_dir}")

--- a/src/bcbench/types.py
+++ b/src/bcbench/types.py
@@ -137,9 +137,6 @@ class PluginConfig(BaseModel):
     # github only
     repo: RepoSlug | None = None
     revision: CommitSha | None = None
-    # Filesystem folder this entry resolved to, set by ``resolve_config_plugins``. None on an entry
-    # parsed straight from ``config.yaml``, which has no such key.
-    plugin_dir: Path | None = None
 
     @property
     def record(self) -> str:

--- a/src/bcbench/types.py
+++ b/src/bcbench/types.py
@@ -131,6 +131,8 @@ class PluginConfig(BaseModel):
     enabled: bool = False
     # Grant the agent filesystem access to this plugin's tree via Copilot `--add-dir`.
     # Off by default so enabling a plugin does not also widen the agent's sandbox access.
+    # This is a (hopefully temporary) accommodation for BCQuality, whose skill reads its own
+    # knowledge files at runtime; the long-term fix is to serve that content via skills / an MCP server.
     grant_dir_access: bool = False
     # github only
     repo: RepoSlug | None = None

--- a/src/bcbench/types.py
+++ b/src/bcbench/types.py
@@ -137,6 +137,9 @@ class PluginConfig(BaseModel):
     # github only
     repo: RepoSlug | None = None
     revision: CommitSha | None = None
+    # Filesystem folder this entry resolved to, set by ``resolve_config_plugins``. None on an entry
+    # parsed straight from ``config.yaml``, which has no such key.
+    plugin_dir: Path | None = None
 
     @property
     def record(self) -> str:

--- a/src/bcbench/types.py
+++ b/src/bcbench/types.py
@@ -129,6 +129,9 @@ class PluginConfig(BaseModel):
     source: PluginSource
     path: str
     enabled: bool = False
+    # Grant the agent filesystem access to this plugin's tree via Copilot `--add-dir`.
+    # Off by default so enabling a plugin does not also widen the agent's sandbox access.
+    grant_dir_access: bool = False
     # github only
     repo: RepoSlug | None = None
     revision: CommitSha | None = None

--- a/tests/test_agent_plugins.py
+++ b/tests/test_agent_plugins.py
@@ -35,6 +35,11 @@ def _shipped_plugins() -> list[dict]:
     return config["plugins"]
 
 
+def _dirs_by_record(resolved: list[PluginConfig]) -> dict[str, Path | None]:
+    """Map resolved plugins back to a record -> plugin_dir dict for assertions."""
+    return {plugin.record: plugin.plugin_dir for plugin in resolved}
+
+
 class TestPluginConfigValidation:
     """Enabled entries are validated before a run starts, so a typo fails fast rather than mid-agent."""
 
@@ -70,7 +75,7 @@ class TestPluginConfigValidation:
 
     def test_disabled_entry_is_inert(self):
         # A disabled entry must never break a run - it may hold a path that is only valid on another OS
-        assert resolve_config_plugins({"plugins": [{"name": "x", "source": "local", "enabled": False, "path": "C:/only/valid/on/windows"}]}) == {}
+        assert resolve_config_plugins({"plugins": [{"name": "x", "source": "local", "enabled": False, "path": "C:/only/valid/on/windows"}]}) == []
 
     @pytest.mark.parametrize("revision", ["refs/heads/main", "main", "v1.2.3", "HEAD", "a" * 7, "a" * 41, "z" * 40])
     def test_revision_that_is_not_a_commit_sha_is_rejected(self, revision):
@@ -93,19 +98,19 @@ class TestPluginConfigValidation:
 @pytest.mark.usefixtures("plugin_root")
 class TestResolveConfigPlugins:
     def test_no_enabled_entries_resolves_to_nothing(self, tmp_path):
-        assert resolve_config_plugins({"plugins": [_local_entry(tmp_path, enabled=False)]}) == {}
+        assert resolve_config_plugins({"plugins": [_local_entry(tmp_path, enabled=False)]}) == []
 
     def test_local_plugin_resolves_to_its_absolute_path(self, tmp_path):
         plugin = _make_plugin(tmp_path / "my-plugin")
 
-        assert resolve_config_plugins({"plugins": [_local_entry(plugin)]}) == {"probe@local": plugin}
+        assert _dirs_by_record(resolve_config_plugins({"plugins": [_local_entry(plugin)]})) == {"probe@local": plugin}
 
     def test_local_plugin_with_root_manifest_resolves_for_copilot(self, tmp_path):
         plugin = tmp_path / "root-manifest-plugin"
         plugin.mkdir()
         (plugin / _MANIFEST.name).write_text(json.dumps({"name": "probe", "version": "0.0.1"}), encoding="utf-8")
 
-        assert resolve_config_plugins({"plugins": [_local_entry(plugin)]}, allow_copilot_manifest=True) == {"probe@local": plugin}
+        assert _dirs_by_record(resolve_config_plugins({"plugins": [_local_entry(plugin)]}, allow_copilot_manifest=True)) == {"probe@local": plugin}
 
     def test_root_manifest_is_rejected_without_opt_in(self, tmp_path):
         # Claude Code cannot load a root-only manifest, so the default (allow_copilot_manifest=False) must
@@ -120,7 +125,7 @@ class TestResolveConfigPlugins:
     def test_local_plugin_expands_user_home(self, tmp_path):
         plugin = _make_plugin(tmp_path / "my-plugin")
         with patch.object(Path, "expanduser", return_value=plugin):
-            assert resolve_config_plugins({"plugins": [_local_entry(Path("~/my-plugin"))]}) == {"probe@local": plugin}
+            assert _dirs_by_record(resolve_config_plugins({"plugins": [_local_entry(Path("~/my-plugin"))]})) == {"probe@local": plugin}
 
     def test_missing_manifest_raises_pointing_at_the_expected_location(self, tmp_path):
         (tmp_path / "not-a-plugin").mkdir()
@@ -133,21 +138,22 @@ class TestResolveConfigPlugins:
             resolved = resolve_config_plugins({"plugins": [_github_entry()]})
 
         clone.assert_called_once_with("obra/superpowers", "a" * 40, plugin_root / "superpowers")
-        assert resolved == {f"superpowers@{'a' * 40}": plugin_root / "superpowers"}
+        assert _dirs_by_record(resolved) == {f"superpowers@{'a' * 40}": plugin_root / "superpowers"}
 
     def test_github_plugin_never_lands_in_the_repo_under_evaluation(self, tmp_path, plugin_root):
         with patch("bcbench.agent.shared.plugin.clone_repo_at_revision", side_effect=lambda repo, revision, destination: _make_plugin(destination)):
             resolved = resolve_config_plugins({"plugins": [_github_entry()]})
 
         testbed = tmp_path / "repo"
-        assert not any(directory.is_relative_to(testbed) for directory in resolved.values())
-        assert list(resolved.values()) == [plugin_root / "superpowers"]
+        resolved_dirs = [plugin.plugin_dir for plugin in resolved]
+        assert not any(directory is not None and directory.is_relative_to(testbed) for directory in resolved_dirs)
+        assert resolved_dirs == [plugin_root / "superpowers"]
 
     def test_github_path_selects_a_subfolder_of_the_clone(self, plugin_root):
         with patch("bcbench.agent.shared.plugin.clone_repo_at_revision", side_effect=lambda repo, revision, destination: _make_plugin(destination / "plugins" / "inner")):
             resolved = resolve_config_plugins({"plugins": [_github_entry(path="plugins/inner")]})
 
-        assert resolved == {f"superpowers@{'a' * 40}": plugin_root / "superpowers" / "plugins" / "inner"}
+        assert _dirs_by_record(resolved) == {f"superpowers@{'a' * 40}": plugin_root / "superpowers" / "plugins" / "inner"}
 
     def test_preserves_config_order_across_sources(self, tmp_path):
         local = _make_plugin(tmp_path / "local-plugin")
@@ -155,7 +161,7 @@ class TestResolveConfigPlugins:
         with patch("bcbench.agent.shared.plugin.clone_repo_at_revision", side_effect=lambda repo, revision, destination: _make_plugin(destination)):
             resolved = resolve_config_plugins({"plugins": [_github_entry(), _local_entry(local)]})
 
-        assert list(resolved) == [f"superpowers@{'a' * 40}", "probe@local"]
+        assert [plugin.record for plugin in resolved] == [f"superpowers@{'a' * 40}", "probe@local"]
 
     def test_duplicate_names_are_rejected(self, tmp_path):
         # Two enabled plugins sharing a name would clobber each other's clone and collide on their
@@ -201,7 +207,7 @@ class TestShippedConfig:
     def test_shipped_config_resolves_on_any_os(self):
         # Entries are disabled, so this must hold even though the `local` example carries a Windows path
         with patch.object(Path, "is_absolute", return_value=False):  # simulate posix path semantics
-            assert resolve_config_plugins({"plugins": _shipped_plugins()}) == {}
+            assert resolve_config_plugins({"plugins": _shipped_plugins()}) == []
 
     def test_shipped_entries_are_disabled_by_default(self):
         assert not [entry for entry in _shipped_plugins() if entry.get("enabled")]

--- a/tests/test_agent_plugins.py
+++ b/tests/test_agent_plugins.py
@@ -35,9 +35,9 @@ def _shipped_plugins() -> list[dict]:
     return config["plugins"]
 
 
-def _dirs_by_record(resolved: list[PluginConfig]) -> dict[str, Path | None]:
+def _dirs_by_record(resolved: list[tuple[PluginConfig, Path]]) -> dict[str, Path]:
     """Map resolved plugins back to a record -> plugin_dir dict for assertions."""
-    return {plugin.record: plugin.plugin_dir for plugin in resolved}
+    return {plugin.record: plugin_dir for plugin, plugin_dir in resolved}
 
 
 class TestPluginConfigValidation:
@@ -145,8 +145,8 @@ class TestResolveConfigPlugins:
             resolved = resolve_config_plugins({"plugins": [_github_entry()]})
 
         testbed = tmp_path / "repo"
-        resolved_dirs = [plugin.plugin_dir for plugin in resolved]
-        assert not any(directory is not None and directory.is_relative_to(testbed) for directory in resolved_dirs)
+        resolved_dirs = [plugin_dir for _, plugin_dir in resolved]
+        assert not any(directory.is_relative_to(testbed) for directory in resolved_dirs)
         assert resolved_dirs == [plugin_root / "superpowers"]
 
     def test_github_path_selects_a_subfolder_of_the_clone(self, plugin_root):
@@ -161,7 +161,7 @@ class TestResolveConfigPlugins:
         with patch("bcbench.agent.shared.plugin.clone_repo_at_revision", side_effect=lambda repo, revision, destination: _make_plugin(destination)):
             resolved = resolve_config_plugins({"plugins": [_github_entry(), _local_entry(local)]})
 
-        assert [plugin.record for plugin in resolved] == [f"superpowers@{'a' * 40}", "probe@local"]
+        assert [plugin.record for plugin, _ in resolved] == [f"superpowers@{'a' * 40}", "probe@local"]
 
     def test_duplicate_names_are_rejected(self, tmp_path):
         # Two enabled plugins sharing a name would clobber each other's clone and collide on their

--- a/tests/test_agent_plugins.py
+++ b/tests/test_agent_plugins.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 import pytest
 import yaml
 
-from bcbench.agent.shared.plugin import plugins_needing_dir_access, resolve_config_plugins
+from bcbench.agent.shared.plugin import resolve_config_plugins
 from bcbench.config import get_config
 from bcbench.exceptions import AgentError
 from bcbench.types import PluginConfig
@@ -105,10 +105,10 @@ class TestResolveConfigPlugins:
         plugin.mkdir()
         (plugin / _MANIFEST.name).write_text(json.dumps({"name": "probe", "version": "0.0.1"}), encoding="utf-8")
 
-        assert resolve_config_plugins({"plugins": [_local_entry(plugin)]}, allow_root_manifest=True) == {"probe@local": plugin}
+        assert resolve_config_plugins({"plugins": [_local_entry(plugin)]}, allow_copilot_manifest=True) == {"probe@local": plugin}
 
     def test_root_manifest_is_rejected_without_opt_in(self, tmp_path):
-        # Claude Code cannot load a root-only manifest, so the default (allow_root_manifest=False) must
+        # Claude Code cannot load a root-only manifest, so the default (allow_copilot_manifest=False) must
         # reject it rather than forward a plugin that Claude would silently ignore.
         plugin = tmp_path / "root-manifest-plugin"
         plugin.mkdir()
@@ -159,7 +159,7 @@ class TestResolveConfigPlugins:
 
     def test_duplicate_records_are_rejected(self, tmp_path):
         # Same name + source => same record; the resolved dict would silently drop one and, worse,
-        # leak the other's grant_dir_access onto the survivor's path. Fail fast at both entry points.
+        # leak the other's grant_dir_access onto the survivor's path. Fail fast.
         entries = {
             "plugins": [
                 _local_entry(tmp_path / "a", name="dup", grant_dir_access=True),
@@ -168,28 +168,16 @@ class TestResolveConfigPlugins:
         }
         with pytest.raises(AgentError, match="Duplicate plugin record"):
             resolve_config_plugins(entries)
-        with pytest.raises(AgentError, match="Duplicate plugin record"):
-            plugins_needing_dir_access(entries)
 
-
-class TestPluginsNeedingDirAccess:
-    """--add-dir grants read+write, so it is limited to plugins that opt in - enabling a plugin never widens access."""
-
-    def test_returns_only_enabled_opted_in_records(self, tmp_path):
-        result = plugins_needing_dir_access(
-            {
-                "plugins": [
-                    _local_entry(tmp_path / "a", name="granted", grant_dir_access=True),
-                    _local_entry(tmp_path / "b", name="plain"),  # no grant_dir_access -> default off
-                    _local_entry(tmp_path / "c", name="off", enabled=False, grant_dir_access=True),  # disabled -> excluded
-                ]
-            }
-        )
-
-        assert result == {"granted@local"}
-
-    def test_no_plugin_opts_in_by_default(self, tmp_path):
-        assert plugins_needing_dir_access({"plugins": [_local_entry(tmp_path / "a", name="plain")]}) == set()
+    def test_distinct_records_resolving_to_one_folder_are_rejected(self, plugin_root):
+        # Two GitHub entries sharing a name clone into <plugin_root>/<name>, so distinct records resolve
+        # to the same folder - which would grant a non-opted-in plugin the other's --add-dir.
+        entries = {"plugins": [_github_entry(name="dup", revision="a" * 40), _github_entry(name="dup", revision="b" * 40)]}
+        with (
+            patch("bcbench.agent.shared.plugin.clone_repo_at_revision", side_effect=lambda repo, revision, destination: _make_plugin(destination)),
+            pytest.raises(AgentError, match="resolve to the same folder"),
+        ):
+            resolve_config_plugins(entries)
 
 
 @pytest.mark.usefixtures("plugin_root")

--- a/tests/test_agent_plugins.py
+++ b/tests/test_agent_plugins.py
@@ -157,26 +157,23 @@ class TestResolveConfigPlugins:
 
         assert list(resolved) == [f"superpowers@{'a' * 40}", "probe@local"]
 
-    def test_duplicate_records_are_rejected(self, tmp_path):
-        # Same name + source => same record; the resolved dict would silently drop one and, worse,
-        # leak the other's grant_dir_access onto the survivor's path. Fail fast.
+    def test_duplicate_names_are_rejected(self, tmp_path):
+        # Two enabled plugins sharing a name would clobber each other's clone and collide on their
+        # record, so the loader rejects duplicate names before resolving anything.
         entries = {
             "plugins": [
                 _local_entry(tmp_path / "a", name="dup", grant_dir_access=True),
                 _local_entry(tmp_path / "b", name="dup"),
             ]
         }
-        with pytest.raises(AgentError, match="Duplicate plugin record"):
+        with pytest.raises(AgentError, match="Duplicate plugin name"):
             resolve_config_plugins(entries)
 
-    def test_distinct_records_resolving_to_one_folder_are_rejected(self, plugin_root):
-        # Two GitHub entries sharing a name clone into <plugin_root>/<name>, so distinct records resolve
-        # to the same folder - which would grant a non-opted-in plugin the other's --add-dir.
+    def test_duplicate_github_names_are_rejected(self):
+        # Same name with different revisions still clones into <plugin_root>/<name>; the name check
+        # fails fast before any clone, so no plugin_root or clone mock is needed here.
         entries = {"plugins": [_github_entry(name="dup", revision="a" * 40), _github_entry(name="dup", revision="b" * 40)]}
-        with (
-            patch("bcbench.agent.shared.plugin.clone_repo_at_revision", side_effect=lambda repo, revision, destination: _make_plugin(destination)),
-            pytest.raises(AgentError, match="resolve to the same folder"),
-        ):
+        with pytest.raises(AgentError, match="Duplicate plugin name"):
             resolve_config_plugins(entries)
 
 

--- a/tests/test_agent_plugins.py
+++ b/tests/test_agent_plugins.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 import pytest
 import yaml
 
-from bcbench.agent.shared.plugin import resolve_config_plugins
+from bcbench.agent.shared.plugin import plugins_needing_dir_access, resolve_config_plugins
 from bcbench.config import get_config
 from bcbench.exceptions import AgentError
 from bcbench.types import PluginConfig
@@ -100,12 +100,22 @@ class TestResolveConfigPlugins:
 
         assert resolve_config_plugins({"plugins": [_local_entry(plugin)]}) == {"probe@local": plugin}
 
-    def test_local_plugin_with_root_manifest_resolves(self, tmp_path):
+    def test_local_plugin_with_root_manifest_resolves_for_copilot(self, tmp_path):
         plugin = tmp_path / "root-manifest-plugin"
         plugin.mkdir()
         (plugin / _MANIFEST.name).write_text(json.dumps({"name": "probe", "version": "0.0.1"}), encoding="utf-8")
 
-        assert resolve_config_plugins({"plugins": [_local_entry(plugin)]}) == {"probe@local": plugin}
+        assert resolve_config_plugins({"plugins": [_local_entry(plugin)]}, allow_root_manifest=True) == {"probe@local": plugin}
+
+    def test_root_manifest_is_rejected_without_opt_in(self, tmp_path):
+        # Claude Code cannot load a root-only manifest, so the default (allow_root_manifest=False) must
+        # reject it rather than forward a plugin that Claude would silently ignore.
+        plugin = tmp_path / "root-manifest-plugin"
+        plugin.mkdir()
+        (plugin / _MANIFEST.name).write_text(json.dumps({"name": "probe", "version": "0.0.1"}), encoding="utf-8")
+
+        with pytest.raises(AgentError, match="has no manifest at"):
+            resolve_config_plugins({"plugins": [_local_entry(plugin)]})
 
     def test_local_plugin_expands_user_home(self, tmp_path):
         plugin = _make_plugin(tmp_path / "my-plugin")
@@ -146,6 +156,26 @@ class TestResolveConfigPlugins:
             resolved = resolve_config_plugins({"plugins": [_github_entry(), _local_entry(local)]})
 
         assert list(resolved) == [f"superpowers@{'a' * 40}", "probe@local"]
+
+
+class TestPluginsNeedingDirAccess:
+    """--add-dir grants read+write, so it is limited to plugins that opt in - enabling a plugin never widens access."""
+
+    def test_returns_only_enabled_opted_in_records(self, tmp_path):
+        result = plugins_needing_dir_access(
+            {
+                "plugins": [
+                    _local_entry(tmp_path / "a", name="granted", grant_dir_access=True),
+                    _local_entry(tmp_path / "b", name="plain"),  # no grant_dir_access -> default off
+                    _local_entry(tmp_path / "c", name="off", enabled=False, grant_dir_access=True),  # disabled -> excluded
+                ]
+            }
+        )
+
+        assert result == {"granted@local"}
+
+    def test_no_plugin_opts_in_by_default(self, tmp_path):
+        assert plugins_needing_dir_access({"plugins": [_local_entry(tmp_path / "a", name="plain")]}) == set()
 
 
 @pytest.mark.usefixtures("plugin_root")

--- a/tests/test_agent_plugins.py
+++ b/tests/test_agent_plugins.py
@@ -100,6 +100,13 @@ class TestResolveConfigPlugins:
 
         assert resolve_config_plugins({"plugins": [_local_entry(plugin)]}) == {"probe@local": plugin}
 
+    def test_local_plugin_with_root_manifest_resolves(self, tmp_path):
+        plugin = tmp_path / "root-manifest-plugin"
+        plugin.mkdir()
+        (plugin / _MANIFEST.name).write_text(json.dumps({"name": "probe", "version": "0.0.1"}), encoding="utf-8")
+
+        assert resolve_config_plugins({"plugins": [_local_entry(plugin)]}) == {"probe@local": plugin}
+
     def test_local_plugin_expands_user_home(self, tmp_path):
         plugin = _make_plugin(tmp_path / "my-plugin")
         with patch.object(Path, "expanduser", return_value=plugin):

--- a/tests/test_agent_plugins.py
+++ b/tests/test_agent_plugins.py
@@ -157,6 +157,20 @@ class TestResolveConfigPlugins:
 
         assert list(resolved) == [f"superpowers@{'a' * 40}", "probe@local"]
 
+    def test_duplicate_records_are_rejected(self, tmp_path):
+        # Same name + source => same record; the resolved dict would silently drop one and, worse,
+        # leak the other's grant_dir_access onto the survivor's path. Fail fast at both entry points.
+        entries = {
+            "plugins": [
+                _local_entry(tmp_path / "a", name="dup", grant_dir_access=True),
+                _local_entry(tmp_path / "b", name="dup"),
+            ]
+        }
+        with pytest.raises(AgentError, match="Duplicate plugin record"):
+            resolve_config_plugins(entries)
+        with pytest.raises(AgentError, match="Duplicate plugin record"):
+            plugins_needing_dir_access(entries)
+
 
 class TestPluginsNeedingDirAccess:
     """--add-dir grants read+write, so it is limited to plugins that opt in - enabling a plugin never widens access."""


### PR DESCRIPTION
## What

Small fixes to the shared plugin loader so a read-heavy config plugin can be consumed during an evaluation, scoped so they do not broaden the loader's contract for agents or plugins that don't need it:

1. **Accept a root `plugin.json` manifest - for Copilot only.** `_resolve_plugin` previously required the manifest at `.claude-plugin/plugin.json`. Copilot CLI also loads a `plugin.json` at the plugin root (BCQuality keeps its manifest there), while Claude Code loads only the nested layout. `resolve_config_plugins` now takes `allow_root_manifest`: the Copilot agent passes `True` (root or nested accepted); the Claude agent keeps the strict default (`False`), so a root-only plugin is **not** forwarded to a Claude run that would silently ignore it. The `AgentError` message lists the location(s) actually accepted for that run.
2. **Grant directory access only to plugins that opt in.** `run_agent` passes `--plugin-dir <dir>` for every enabled plugin, which registers/auto-discovers its skills, but Copilot CLI keeps *directory access* as a sandbox separate from `--allow-all-tools`, so a knowledge-heavy plugin registers its skill yet cannot read its own files. `--add-dir` closes that gap - but it grants **read+write**, so applying it to every plugin would over-grant and couple "plugin enabled" with "directory access granted." A new per-plugin `grant_dir_access` flag (default `false`) gates it: the Copilot agent passes `--add-dir` only for plugins that set it, mirroring how the production engine grants `--add-dir` for its knowledge root.
3. **Docstring** clarifies which manifest layout each CLI loads.

## Why

BC-Bench already loads config plugins via `resolve_config_plugins` -> `--plugin-dir` (the existing plugin mechanism). These gaps are what stop that mechanism working for a read-heavy plugin end-to-end, and the fixes are scoped so they change behavior for no other agent or plugin.

## Scope / safety

- **No shipped-config changes.** All plugins remain `enabled: false` and no plugin sets `grant_dir_access`; the `TestShippedConfig` invariants (`test_shipped_entries_are_disabled_by_default`, `test_shipped_config_resolves_on_any_os`) stay green. Enabling a plugin (and granting it dir access) for a specific run is a separate, experiment-only change.
- **Claude path stays strict.** The shared resolver keeps the nested-only contract for Claude, so this PR cannot make a root-only plugin pass validation for a Claude run.

## Tests

- `test_local_plugin_with_root_manifest_resolves_for_copilot` (root manifest resolves under `allow_root_manifest=True`) and `test_root_manifest_is_rejected_without_opt_in` (the default rejects it).
- `TestPluginsNeedingDirAccess`: only enabled, opted-in plugins receive dir access; none by default.
- Plugin suite green; `ruff check` clean.
