### PR TITLE
Update Copilot CLI to 1.0.80 and MAI Code 1.1 Flash

### DIFF
--- a/.github/actions/install-eval-clis/action.yml
+++ b/.github/actions/install-eval-clis/action.yml
@@ -9,36 +9,5 @@ runs:
       shell: pwsh
 
     - name: Install GitHub Copilot CLI
-      run: |
-        $version = "1.0.80"
-        $platform = node --print "process.platform"
-        $architecture = node --print "process.arch"
-        if ($platform -eq "linux" -and (node --print "process.report.getReport().header.glibcVersionRuntime ? 'glibc' : 'musl'") -eq "musl") {
-          $platform = "linuxmusl"
-        }
-
-        $extension = if ($platform -eq "win32") { "zip" } else { "tar.gz" }
-        $asset = "copilot-$platform-$architecture.$extension"
-        $archive = Join-Path $env:RUNNER_TEMP $asset
-        $installDir = Join-Path $env:RUNNER_TEMP "copilot-cli-$version"
-        Invoke-WebRequest "https://github.com/github/copilot-cli/releases/download/v$version/$asset" -OutFile $archive
-        New-Item -ItemType Directory -Force -Path $installDir | Out-Null
-
-        if ($extension -eq "zip") {
-          Expand-Archive -Path $archive -DestinationPath $installDir -Force
-        } else {
-          tar -xzf $archive -C $installDir
-        }
-
-        $executableName = if ($platform -eq "win32") { "copilot.exe" } else { "copilot" }
-        $executable = Get-ChildItem -Path $installDir -Recurse -File -Filter $executableName | Select-Object -First 1
-        if (-not $executable) {
-          throw "GitHub Copilot CLI executable not found in $asset"
-        }
-        $versionOutput = (& $executable.FullName --version 2>&1) -join [Environment]::NewLine
-        if ($LASTEXITCODE -ne 0 -or $versionOutput -notmatch [regex]::Escape($version)) {
-          throw "Expected GitHub Copilot CLI $version, got: $versionOutput"
-        }
-        Write-Output $versionOutput
-        $executable.DirectoryName | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      run: npm install -g @github/copilot@1.0.80
       shell: pwsh

--- a/.github/actions/install-eval-clis/action.yml
+++ b/.github/actions/install-eval-clis/action.yml
@@ -9,5 +9,36 @@ runs:
       shell: pwsh
 
     - name: Install GitHub Copilot CLI
-      run: npm install -g @github/copilot@1.0.75
+      run: |
+        $version = "1.0.80"
+        $platform = node --print "process.platform"
+        $architecture = node --print "process.arch"
+        if ($platform -eq "linux" -and (node --print "process.report.getReport().header.glibcVersionRuntime ? 'glibc' : 'musl'") -eq "musl") {
+          $platform = "linuxmusl"
+        }
+
+        $extension = if ($platform -eq "win32") { "zip" } else { "tar.gz" }
+        $asset = "copilot-$platform-$architecture.$extension"
+        $archive = Join-Path $env:RUNNER_TEMP $asset
+        $installDir = Join-Path $env:RUNNER_TEMP "copilot-cli-$version"
+        Invoke-WebRequest "https://github.com/github/copilot-cli/releases/download/v$version/$asset" -OutFile $archive
+        New-Item -ItemType Directory -Force -Path $installDir | Out-Null
+
+        if ($extension -eq "zip") {
+          Expand-Archive -Path $archive -DestinationPath $installDir -Force
+        } else {
+          tar -xzf $archive -C $installDir
+        }
+
+        $executableName = if ($platform -eq "win32") { "copilot.exe" } else { "copilot" }
+        $executable = Get-ChildItem -Path $installDir -Recurse -File -Filter $executableName | Select-Object -First 1
+        if (-not $executable) {
+          throw "GitHub Copilot CLI executable not found in $asset"
+        }
+        $versionOutput = (& $executable.FullName --version 2>&1) -join [Environment]::NewLine
+        if ($LASTEXITCODE -ne 0 -or $versionOutput -notmatch [regex]::Escape($version)) {
+          throw "Expected GitHub Copilot CLI $version, got: $versionOutput"
+        }
+        Write-Output $versionOutput
+        $executable.DirectoryName | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       shell: pwsh

--- a/.github/workflows/contamination-file-path-identification.yml
+++ b/.github/workflows/contamination-file-path-identification.yml
@@ -25,7 +25,7 @@ on:
           - "gpt-5.6-terra"
           - "gpt-5.6-luna"
           - "gpt-5.3-codex"
-          - "mai-code-1-flash-picker"
+          - "mai-code-1.1-flash"
           - "gemini-3.6-flash"
       category:
         description: "Dataset category (must be patch-based)"

--- a/.github/workflows/copilot-evaluation.yml
+++ b/.github/workflows/copilot-evaluation.yml
@@ -18,7 +18,7 @@ on:
           - "gpt-5.6-terra"
           - "gpt-5.6-luna"
           - "gpt-5.3-codex"
-          - "mai-code-1-flash-picker"
+          - "mai-code-1.1-flash"
           - "gemini-3.6-flash"
       category:
         description: "Evaluation category to run"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bcbench"
-version = "0.9.0"
+version = "0.8.1"
 description = "Benchmarking tool for Business Central (AL) ecosystem, inspired by SWE-Bench"
 readme = "README.md"
 requires-python = ">=3.13,<3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bcbench"
-version = "0.8.0"
+version = "0.9.0"
 description = "Benchmarking tool for Business Central (AL) ecosystem, inspired by SWE-Bench"
 readme = "README.md"
 requires-python = ">=3.13,<3.14"

--- a/src/bcbench/cli_options.py
+++ b/src/bcbench/cli_options.py
@@ -42,7 +42,7 @@ CopilotModel = Annotated[
         "gpt-5.6-terra",
         "gpt-5.6-luna",
         "gpt-5.3-codex",
-        "mai-code-1-flash-picker",
+        "mai-code-1.1-flash",
         "gemini-3.6-flash",
     ],
     typer.Option(help="Copilot model to use"),

--- a/uv.lock
+++ b/uv.lock
@@ -245,7 +245,7 @@ wheels = [
 
 [[package]]
 name = "bcbench"
-version = "0.9.0"
+version = "0.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },

--- a/uv.lock
+++ b/uv.lock
@@ -245,7 +245,7 @@ wheels = [
 
 [[package]]
 name = "bcbench"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## Summary

- Update GitHub Copilot CLI from 1.0.75 to 1.0.80 using the existing pinned npm install command.
- Replace `mai-code-1-flash-picker` with `mai-code-1.1-flash` across the Python and workflow model choices.
- Bump BC-Bench from 0.8.0 to 0.8.1.

## Model decisions

| Model | Availability evidence | Benchmark role | Decision | Rationale |
| --- | --- | --- | --- | --- |
| `mai-code-1.1-flash` | Copilot CLI 1.0.80 accepted the exact model ID in a live prompt as `haoranpb`; evaluation-identity availability is unverified. | Fast Microsoft coding-model baseline | Add | Stable successor requested by the maintainer. |
| `mai-code-1-flash-picker` | The maintainer expects it to be removed soon. | Previous fast Microsoft coding-model baseline | Remove | Superseded by MAI Code 1.1 Flash; retaining both would be redundant. |

## Release-note impact

Reviewed every GitHub Copilot CLI release note from 1.0.76 through 1.0.80, including intervening prereleases. Existing non-interactive prompt, permissions, MCP/LSP/plugin, hook, logging, and metrics-parsing interfaces remain compatible. The 1.0.79 sandbox-setting rename does not affect BC-Bench configuration.

## Checks

- Copilot CLI 1.0.80 successfully completed a live prompt with `--model=mai-code-1.1-flash`.
- Copilot model choices are synchronized across both workflows and the Python `Literal`.
- Focused Copilot and version tests: 29 passed.
- Full suite from the initial update: 744 passed, 1 skipped.
- `uv run pre-commit run --all-files`: passed.

## Remaining validation

A test evaluation with the evaluation identity is still required before merge/full benchmark execution; its credentials and infrastructure are not available in this local session.