### PR TITLE
Drop never-emitted comment key spellings from review parsing

### DIFF
--- a/src/bcbench/evaluate/review_parsing.py
+++ b/src/bcbench/evaluate/review_parsing.py
@@ -44,11 +44,14 @@ def _to_int(value: object) -> int | None:
 
 
 def _normalize_comment(item: dict[Any, Any]) -> ReviewComment | None:
-    file_path = item.get("file") or item.get("filePath") or item.get("path")
+    # Two producers are in play: the pr_review agent emits file/line_start/line_end/body,
+    # while the BCApps review instructions ask for filePath/lineNumber/issue. BCQuality
+    # reports name the line "line", so that spelling is kept for a flattened report.
+    file_path = item.get("file") or item.get("filePath")
     line_start = _to_int(item.get("line_start") or item.get("lineNumber") or item.get("line"))
-    line_end = _to_int(item.get("line_end") or item.get("lineEnd") or item.get("endLine"))
+    line_end = _to_int(item.get("line_end"))
     domain = item.get("domain")
-    body = item.get("body") or item.get("issue") or item.get("comment")
+    body = item.get("body") or item.get("issue")
 
     if not isinstance(file_path, str) or not file_path.strip():
         return None
@@ -107,7 +110,7 @@ def parse_review_output(raw_output: str) -> list[ReviewComment] | None:
         raw_items = raw
     elif isinstance(raw, dict) and isinstance(raw.get("findings"), list):
         raw_items = raw["findings"]
-    elif isinstance(raw, dict) and any(key in raw for key in ("file", "filePath", "path")):
+    elif isinstance(raw, dict) and any(key in raw for key in ("file", "filePath")):
         raw_items = [raw]
     else:
         logger.warning(f"Expected JSON array or object with findings[], got {type(raw).__name__}")


### PR DESCRIPTION
## What

`_normalize_comment` in `evaluate/review_parsing.py` accepted four key spellings that no producer emits:

| Removed | Kept, and why |
| --- | --- |
| `path` | `file` (pr_review agent), `filePath` (BCApps review instructions) |
| `lineEnd`, `endLine` | `line_end` (pr_review agent) |
| `comment` | `body` (pr_review agent), `issue` (BCApps review instructions) |

`parse_review_output`'s bare-single-object check drops `path` for the same reason.

## Why

The parser has exactly three known producers, and each was checked:

- **pr_review agent** (`agent/copilot/pr_review/review_output.py`) emits `file` / `line_start` / `line_end` / `body`.
- **BCApps review instructions** (`agent/shared/instructions/microsoft-BCApps/instructions/*.md`) ask for `filePath` / `lineNumber` / `issue`.
- **BCQuality** review reports name the line field `line`, so that spelling is kept for a flattened report. Its `path` key belongs to `references[]`, not to a finding's location, so it is not a file-key producer.

Across **488 finding objects** in recorded agent outputs on disk, `path`, `lineEnd`, `endLine` and `comment` occur **zero** times. `git log -S` shows all four arrived in the original "Introducing Code Review category" commit, so they were speculative from the start rather than a fix for an observed parse failure. No test pinned them.

Severity aliases were audited in the same pass and **deliberately left alone** — `blocker`/`major`/`minor`/`info` come from BCQuality's report schema and `error`/`warning`/`suggestion` are parsed out of real reviewer-bot comment headers in `collection/collect_codereview.py`.

## Validation

- `ruff format` / `ruff check` clean; `ty check` shows only the pre-existing `redteam.py` diagnostic.
- `pytest` 738 passed, 2 skipped.
- Spot-checked the parser directly: pr_review, BCApps-instruction, flat-`line` and bare-single-object payloads all still parse to one comment each.
- Existing tests already pin the surviving alternate spellings (`test_codereview.py` covers `filePath` / `lineNumber` / `issue`).
