### PR TITLE
Add PR review performance telemetry and dashboards

### DIFF
--- a/.github/actions/install-agent-harnesses/action.yml
+++ b/.github/actions/install-agent-harnesses/action.yml
@@ -1,5 +1,10 @@
 name: Install Agent Harnesses
-description: Install the Claude Code and GitHub Copilot CLIs used by the evaluation workflows
+description: Install the agent harnesses used by the evaluation workflows
+
+outputs:
+  bc-alagents-path:
+    description: Path to the pinned BC-ALAgents checkout
+    value: ${{ steps.bc-alagents-path.outputs.path }}
 
 runs:
   using: composite
@@ -10,4 +15,17 @@ runs:
 
     - name: Install GitHub Copilot CLI
       run: npm install -g @github/copilot@1.0.80
+      shell: pwsh
+
+    - name: Checkout BC-ALAgents
+      uses: actions/checkout@v5
+      with:
+        repository: microsoft/BC-ALAgents
+        ref: 533dd39dfe29218c09e5e31c39c78bb72fa20aa2
+        path: .agent-harnesses/bc-alagents
+        persist-credentials: false
+
+    - name: Export BC-ALAgents path
+      id: bc-alagents-path
+      run: '"path=$(Join-Path $env:GITHUB_WORKSPACE ''.agent-harnesses/bc-alagents'')" >> $env:GITHUB_OUTPUT'
       shell: pwsh

--- a/.github/workflows/pr-review-evaluation.yml
+++ b/.github/workflows/pr-review-evaluation.yml
@@ -109,6 +109,7 @@ jobs:
           node-version: 24
 
       - name: Install evaluation CLIs
+        id: install-harnesses
         uses: $/.github/actions/install-agent-harnesses
 
       - name: Run BC PR Review for entry ${{ matrix.entry }}
@@ -122,6 +123,7 @@ jobs:
 
           uv run bcbench evaluate pr-review "${{ matrix.entry }}" `
             --model "${{ inputs.model }}" `
+            --engine-path "${{ steps.install-harnesses.outputs.bc-alagents-path }}" `
             --repo-path "${{ steps.setup-env.outputs.repo_path }}" `
             --output-dir "${{ env.EVALUATION_RESULTS_DIR }}"
 

--- a/.github/workflows/pr-review-evaluation.yml
+++ b/.github/workflows/pr-review-evaluation.yml
@@ -111,25 +111,17 @@ jobs:
       - name: Install evaluation CLIs
         uses: $/.github/actions/install-agent-harnesses
 
-      - name: Checkout BC-ALAgents review engine
-        uses: actions/checkout@v5
-        with:
-          repository: microsoft/BC-ALAgents
-          ref: 533dd39dfe29218c09e5e31c39c78bb72fa20aa2
-          path: bc-alagents-engine
-          token: ${{ github.token }}
-
       - name: Run BC PR Review for entry ${{ matrix.entry }}
         timeout-minutes: 120
         shell: pwsh
         env:
           COPILOT_GITHUB_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           Write-Output "::add-mask::$env:COPILOT_GITHUB_TOKEN"
 
           uv run bcbench evaluate pr-review "${{ matrix.entry }}" `
             --model "${{ inputs.model }}" `
-            --engine-path "${{ github.workspace }}/bc-alagents-engine" `
             --repo-path "${{ steps.setup-env.outputs.repo_path }}" `
             --output-dir "${{ env.EVALUATION_RESULTS_DIR }}"
 

--- a/.github/workflows/pr-review-evaluation.yml
+++ b/.github/workflows/pr-review-evaluation.yml
@@ -115,7 +115,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           repository: microsoft/BC-ALAgents
-          ref: f2ac8704bf8d39000f8002bcf2d287f1f5b5e9ba
+          ref: 533dd39dfe29218c09e5e31c39c78bb72fa20aa2
           path: bc-alagents-engine
           token: ${{ github.token }}
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,7 +135,7 @@ Keep evaluation tools pinned so benchmark runs remain reproducible. For example,
 
 ### Bump the BC PR Review engine
 
-1. Update the pinned `microsoft/BC-ALAgents` commit in `.github/workflows/pr-review-evaluation.yml`
+1. Update the pinned `microsoft/BC-ALAgents` commit in `src/bcbench/agent/shared/config.yaml`
 2. Run a test evaluation through the `pr-review` workflow
 3. Bump the BC-Bench version following the Versioning Policy
 4. Include the exact BC-ALAgents commit SHA in the BC-Bench release notes

--- a/docs/code-review.md
+++ b/docs/code-review.md
@@ -39,9 +39,9 @@ bcbench evaluate claude <entry> --category code-review
 bcbench evaluate pr-review <entry>
 ```
 
-BC-ALAgents is the PR Review harness boundary. Its repo and commit are pinned under `pr_review.engine` in `src/bcbench/agent/shared/config.yaml`, and that engine commit owns the BCQuality version through its own configuration. Engine updates require a new BC-Bench version and must record the BC-ALAgents commit SHA in the release notes.
+BC-ALAgents is the PR Review harness boundary. Its repo and commit are pinned with the other harnesses in `.github/actions/install-agent-harnesses`, and that engine commit owns the BCQuality version through its own configuration. Engine updates require a new BC-Bench version and must record the BC-ALAgents commit SHA in the release notes.
 
-For an experiment, push the pipeline and/or BCQuality changes through a BC-ALAgents branch, then run BC-Bench with that BC-ALAgents repo/ref. This keeps the reproducible dependency chain BC-Bench -> BC-ALAgents -> BCQuality. A local BC-ALAgents checkout can be supplied with `--engine-local-path` for smoke testing.
+For an experiment, push the pipeline and/or BCQuality changes through a BC-ALAgents branch, update the action pin to that immutable commit, then run BC-Bench from the corresponding BC-Bench commit. This keeps the reproducible dependency chain BC-Bench -> BC-ALAgents -> BCQuality. A local BC-ALAgents checkout can be supplied with `--engine-path` for smoke testing.
 
 BC PR Review records wall-clock duration, prompt/completion/total tokens, and exact AI credits. Usage values come from the engine's strictly validated schema-v1 `_run-metrics.json`, never from console transcripts. API-call details, knowledge-filter counts, token subcategories, completeness diagnostics, and producer metadata remain in that raw artifact rather than being promoted into BC-Bench result and leaderboard schemas.
 

--- a/docs/code-review.md
+++ b/docs/code-review.md
@@ -39,7 +39,9 @@ bcbench evaluate claude <entry> --category code-review
 bcbench evaluate pr-review <entry>
 ```
 
-The evaluation workflow pins BC-ALAgents to a commit SHA, and each result records the exact engine revision and filtered BCQuality content. Engine updates require a new BC-Bench version and must record that SHA in the release notes.
+The evaluation workflow pins BC-ALAgents and GitHub Copilot CLI versions for reproducible runs. Engine updates require a new BC-Bench version and must record the BC-ALAgents commit SHA in the release notes.
+
+BC PR Review records wall-clock duration, prompt/completion/total tokens, and exact AI credits. Usage values come from the engine's strictly validated schema-v1 `_run-metrics.json`, never from console transcripts. API-call details, knowledge-filter counts, token subcategories, completeness diagnostics, and producer metadata remain in that raw artifact rather than being promoted into BC-Bench result and leaderboard schemas.
 
 ## Baseline Leaderboard
 
@@ -48,10 +50,13 @@ The evaluation workflow pins BC-ALAgents to a commit SHA, and each result record
   <thead>
     <tr>
       <th>Agent</th>
+      <th>Engine</th>
+      <th>BCQuality</th>
       <th>Model</th>
       <th>Micro F1 (95% CI)</th>
       <th>Precision</th>
       <th>Recall</th>
+      <th>Valid Output</th>
       <th>Avg Time</th>
       <th>Ver</th>
     </tr>
@@ -59,13 +64,16 @@ The evaluation workflow pins BC-ALAgents to a commit SHA, and each result record
   <tbody>
     {% assign sorted_results = site.data.code-review.aggregate | sort: "f1" | reverse %}
     {% for agg in sorted_results %}
-      {% if agg.experiment == null %}
+      {% if agg.experiment == null or agg.experiment.is_experiment == false %}
     <tr>
       <td>{{ agg.agent_name }}</td>
+      <td>{{ agg.experiment.pr_review_engine.display_name | default: "self-contained" }}</td>
+      <td>{{ agg.experiment.bcquality.display_name | default: "self-contained" }}</td>
       <td>{{ agg.model }}</td>
       <td>{{ agg.f1 | times: 100.0 | round: 1 }}%{% if agg.f1_ci_low %} ({{ agg.f1_ci_low | times: 100.0 | round: 1 }}-{{ agg.f1_ci_high | times: 100.0 | round: 1 }}%){% endif %}</td>
       <td>{{ agg.precision | times: 100.0 | round: 1 }}%</td>
       <td>{{ agg.recall | times: 100.0 | round: 1 }}%</td>
+      <td>{% if agg.valid_review_output_rate != null %}{{ agg.valid_review_output_rate | times: 100.0 | round: 1 }}%{% else %}—{% endif %}</td>
       <td>{{ agg.average_duration | round: 1 }}s</td>
       <td><a href="https://github.com/microsoft/BC-Bench/releases/tag/v{{ agg.benchmark_version }}" target="_blank">{{ agg.benchmark_version }}</a></td>
     </tr>
@@ -77,24 +85,67 @@ The evaluation workflow pins BC-ALAgents to a commit SHA, and each result record
 <p><em>No results available yet. Check back soon!</em></p>
 {% endif %}
 
+## Performance Leaderboard
+
+{% if site.data.code-review.aggregate and site.data.code-review.aggregate.size > 0 %}
+<table>
+  <thead>
+    <tr>
+      <th>Agent</th>
+      <th>Engine</th>
+      <th>BCQuality</th>
+      <th>Model</th>
+      <th>Avg Time</th>
+      <th>Avg Prompt Tokens</th>
+      <th>Avg Completion Tokens</th>
+      <th>Avg Total Tokens</th>
+      <th>Avg AI Credits</th>
+      <th>Ver</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% assign performance_results = site.data.code-review.aggregate | sort: "average_duration" %}
+    {% for agg in performance_results %}
+    <tr>
+      <td>{{ agg.agent_name }}</td>
+      <td>{{ agg.experiment.pr_review_engine.display_name | default: "self-contained" }}</td>
+      <td>{{ agg.experiment.bcquality.display_name | default: "self-contained" }}</td>
+      <td>{{ agg.model }}</td>
+      <td>{{ agg.average_duration | round: 1 }}s</td>
+      <td>{% if agg.average_prompt_tokens != null %}{{ agg.average_prompt_tokens | round: 0 }}{% else %}—{% endif %}</td>
+      <td>{% if agg.average_completion_tokens != null %}{{ agg.average_completion_tokens | round: 0 }}{% else %}—{% endif %}</td>
+      <td>{% if agg.average_total_tokens != null %}{{ agg.average_total_tokens | round: 0 }}{% else %}—{% endif %}</td>
+      <td>{% if agg.average_ai_credits != null %}{{ agg.average_ai_credits | round: 4 }}{% else %}—{% endif %}</td>
+      <td><a href="https://github.com/microsoft/BC-Bench/releases/tag/v{{ agg.benchmark_version }}" target="_blank">{{ agg.benchmark_version }}</a></td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% else %}
+<p><em>No performance results available yet. Check back soon!</em></p>
+{% endif %}
+
 ## Experiment Leaderboard
 
 Compares review-knowledge configurations for the same model (see the Baseline Leaderboard above for the plain agent):
 
 - **Inline knowledge (pre-#8700)** — the review checklists BCApps shipped inline before adopting BCQuality, injected as custom instructions.
 
-{% assign experiment_rows = site.data.code-review.aggregate | where_exp: "agg", "agg.experiment" %}
+{% assign experiment_rows = site.data.code-review.aggregate | where_exp: "agg", "agg.experiment.is_experiment == true or agg.experiment.custom_instructions == true" %}
 {% if experiment_rows and experiment_rows.size > 0 %}
 <table>
   <thead>
     <tr>
       <th>Variant</th>
       <th>Agent</th>
+      <th>Engine</th>
+      <th>BCQuality</th>
       <th>Model</th>
       <th>Micro F1 (95% CI)</th>
       <th>Macro F1 (95% CI)</th>
       <th>Precision</th>
       <th>Recall</th>
+      <th>Valid Output</th>
       <th>Avg Time</th>
       <th>Ver</th>
     </tr>
@@ -105,14 +156,17 @@ Compares review-knowledge configurations for the same model (see the Baseline Le
     <tr>
       <td>
         {%- if agg.experiment.custom_instructions -%}Inline knowledge (pre-#8700)
-        {%- else -%}Other{%- endif -%}
+        {%- else -%}Source variant{%- endif -%}
       </td>
       <td>{{ agg.agent_name }}</td>
+      <td>{{ agg.experiment.pr_review_engine.display_name | default: "self-contained" }}</td>
+      <td>{{ agg.experiment.bcquality.display_name | default: "self-contained" }}</td>
       <td>{{ agg.model }}</td>
       <td>{{ agg.f1 | times: 100.0 | round: 1 }}%{% if agg.f1_ci_low %} ({{ agg.f1_ci_low | times: 100.0 | round: 1 }}-{{ agg.f1_ci_high | times: 100.0 | round: 1 }}%){% endif %}</td>
       <td>{{ agg.macro_f1 | times: 100.0 | round: 1 }}%{% if agg.macro_f1_ci_low %} ({{ agg.macro_f1_ci_low | times: 100.0 | round: 1 }}-{{ agg.macro_f1_ci_high | times: 100.0 | round: 1 }}%){% endif %}</td>
       <td>{{ agg.precision | times: 100.0 | round: 1 }}%</td>
       <td>{{ agg.recall | times: 100.0 | round: 1 }}%</td>
+      <td>{% if agg.valid_review_output_rate != null %}{{ agg.valid_review_output_rate | times: 100.0 | round: 1 }}%{% else %}—{% endif %}</td>
       <td>{{ agg.average_duration | round: 1 }}s</td>
       <td><a href="https://github.com/microsoft/BC-Bench/releases/tag/v{{ agg.benchmark_version }}" target="_blank">{{ agg.benchmark_version }}</a></td>
     </tr>

--- a/docs/code-review.md
+++ b/docs/code-review.md
@@ -39,7 +39,9 @@ bcbench evaluate claude <entry> --category code-review
 bcbench evaluate pr-review <entry>
 ```
 
-The evaluation workflow pins BC-ALAgents and GitHub Copilot CLI versions for reproducible runs. Engine updates require a new BC-Bench version and must record the BC-ALAgents commit SHA in the release notes.
+BC-ALAgents is the PR Review harness boundary. Its repo and commit are pinned under `pr_review.engine` in `src/bcbench/agent/shared/config.yaml`, and that engine commit owns the BCQuality version through its own configuration. Engine updates require a new BC-Bench version and must record the BC-ALAgents commit SHA in the release notes.
+
+For an experiment, push the pipeline and/or BCQuality changes through a BC-ALAgents branch, then run BC-Bench with that BC-ALAgents repo/ref. This keeps the reproducible dependency chain BC-Bench -> BC-ALAgents -> BCQuality. A local BC-ALAgents checkout can be supplied with `--engine-local-path` for smoke testing.
 
 BC PR Review records wall-clock duration, prompt/completion/total tokens, and exact AI credits. Usage values come from the engine's strictly validated schema-v1 `_run-metrics.json`, never from console transcripts. API-call details, knowledge-filter counts, token subcategories, completeness diagnostics, and producer metadata remain in that raw artifact rather than being promoted into BC-Bench result and leaderboard schemas.
 
@@ -50,8 +52,6 @@ BC PR Review records wall-clock duration, prompt/completion/total tokens, and ex
   <thead>
     <tr>
       <th>Agent</th>
-      <th>Engine</th>
-      <th>BCQuality</th>
       <th>Model</th>
       <th>Micro F1 (95% CI)</th>
       <th>Precision</th>
@@ -67,8 +67,6 @@ BC PR Review records wall-clock duration, prompt/completion/total tokens, and ex
       {% if agg.experiment == null or agg.experiment.is_experiment == false %}
     <tr>
       <td>{{ agg.agent_name }}</td>
-      <td>{{ agg.experiment.pr_review_engine.display_name | default: "self-contained" }}</td>
-      <td>{{ agg.experiment.bcquality.display_name | default: "self-contained" }}</td>
       <td>{{ agg.model }}</td>
       <td>{{ agg.f1 | times: 100.0 | round: 1 }}%{% if agg.f1_ci_low %} ({{ agg.f1_ci_low | times: 100.0 | round: 1 }}-{{ agg.f1_ci_high | times: 100.0 | round: 1 }}%){% endif %}</td>
       <td>{{ agg.precision | times: 100.0 | round: 1 }}%</td>
@@ -92,8 +90,6 @@ BC PR Review records wall-clock duration, prompt/completion/total tokens, and ex
   <thead>
     <tr>
       <th>Agent</th>
-      <th>Engine</th>
-      <th>BCQuality</th>
       <th>Model</th>
       <th>Avg Time</th>
       <th>Avg Prompt Tokens</th>
@@ -108,8 +104,6 @@ BC PR Review records wall-clock duration, prompt/completion/total tokens, and ex
     {% for agg in performance_results %}
     <tr>
       <td>{{ agg.agent_name }}</td>
-      <td>{{ agg.experiment.pr_review_engine.display_name | default: "self-contained" }}</td>
-      <td>{{ agg.experiment.bcquality.display_name | default: "self-contained" }}</td>
       <td>{{ agg.model }}</td>
       <td>{{ agg.average_duration | round: 1 }}s</td>
       <td>{% if agg.average_prompt_tokens != null %}{{ agg.average_prompt_tokens | round: 0 }}{% else %}—{% endif %}</td>
@@ -131,15 +125,13 @@ Compares review-knowledge configurations for the same model (see the Baseline Le
 
 - **Inline knowledge (pre-#8700)** — the review checklists BCApps shipped inline before adopting BCQuality, injected as custom instructions.
 
-{% assign experiment_rows = site.data.code-review.aggregate | where_exp: "agg", "agg.experiment.is_experiment == true or agg.experiment.custom_instructions == true" %}
+{% assign experiment_rows = site.data.code-review.aggregate | where_exp: "agg", "agg.experiment != null and agg.experiment.is_experiment != false" %}
 {% if experiment_rows and experiment_rows.size > 0 %}
 <table>
   <thead>
     <tr>
       <th>Variant</th>
       <th>Agent</th>
-      <th>Engine</th>
-      <th>BCQuality</th>
       <th>Model</th>
       <th>Micro F1 (95% CI)</th>
       <th>Macro F1 (95% CI)</th>
@@ -155,12 +147,9 @@ Compares review-knowledge configurations for the same model (see the Baseline Le
     {% for agg in experiment_results %}
     <tr>
       <td>
-        {%- if agg.experiment.custom_instructions -%}Inline knowledge (pre-#8700)
-        {%- else -%}Source variant{%- endif -%}
+        {%- if agg.experiment.custom_instructions -%}Inline knowledge (pre-#8700){%- else -%}Other{%- endif -%}
       </td>
       <td>{{ agg.agent_name }}</td>
-      <td>{{ agg.experiment.pr_review_engine.display_name | default: "self-contained" }}</td>
-      <td>{{ agg.experiment.bcquality.display_name | default: "self-contained" }}</td>
       <td>{{ agg.model }}</td>
       <td>{{ agg.f1 | times: 100.0 | round: 1 }}%{% if agg.f1_ci_low %} ({{ agg.f1_ci_low | times: 100.0 | round: 1 }}-{{ agg.f1_ci_high | times: 100.0 | round: 1 }}%){% endif %}</td>
       <td>{{ agg.macro_f1 | times: 100.0 | round: 1 }}%{% if agg.macro_f1_ci_low %} ({{ agg.macro_f1_ci_low | times: 100.0 | round: 1 }}-{{ agg.macro_f1_ci_high | times: 100.0 | round: 1 }}%){% endif %}</td>

--- a/src/bcbench/agent/pr_review/agent.py
+++ b/src/bcbench/agent/pr_review/agent.py
@@ -132,7 +132,9 @@ def _write_review_json(output_dir: Path, repo_path: Path) -> int:
     if outcome == "failed":
         reason = report.get("outcomeReason") or "unknown reason"
         raise AgentError(f"Engine review failed: {reason}")
-    if outcome not in {"completed", "partial", "not-applicable", "no-knowledge"}:
+    if outcome == "not-applicable":
+        raise AgentError("Engine review was not applicable. BC-Bench code-review entries must contain AL changes.")
+    if outcome not in {"completed", "partial", "no-knowledge"}:
         raise AgentError(f"Engine {_FINDINGS_OUTPUT_FILE} has unsupported outcome {outcome!r}.")
     if not isinstance(report.get("findings"), list):
         raise AgentError(f"Engine report in {_FINDINGS_OUTPUT_FILE} has no findings list (got {type(report.get('findings')).__name__}); refusing to score it as a clean review.")

--- a/src/bcbench/agent/pr_review/agent.py
+++ b/src/bcbench/agent/pr_review/agent.py
@@ -15,11 +15,13 @@ import os
 import shutil
 import subprocess
 import time
+from hashlib import sha256
 from pathlib import Path
 from typing import Any
 
 import yaml
 
+from bcbench.agent.pr_review.metrics import build_pr_review_metrics
 from bcbench.agent.pr_review.review_output import engine_report_to_review_comments, load_engine_report
 from bcbench.config import get_config
 from bcbench.dataset import BaseDatasetEntry
@@ -27,7 +29,7 @@ from bcbench.dataset.codereview import CodeReviewEntry
 from bcbench.exceptions import AgentError, AgentTimeoutError
 from bcbench.logger import get_logger
 from bcbench.operations import commit_changes, has_changes, init_repo
-from bcbench.types import AgentMetrics, EvaluationCategory, ExperimentConfiguration
+from bcbench.types import AgentMetrics, EvaluationCategory, ExperimentConfiguration, RepositoryProvenance
 
 logger = get_logger(__name__)
 _config = get_config()
@@ -57,6 +59,80 @@ def _resolve_pwsh() -> str:
     if not pwsh:
         raise AgentError("PowerShell (pwsh) not found in PATH. The BC-ALAgents engine requires PowerShell 7+.")
     return pwsh
+
+
+def _git_output(root: Path, *args: str) -> str | None:
+    try:
+        return (
+            subprocess.check_output(
+                ["git", "-C", str(root), *args],
+                stderr=subprocess.DEVNULL,
+                text=True,
+                encoding="utf-8",
+            ).strip()
+            or None
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+
+
+def _git_bytes(root: Path, *args: str) -> bytes | None:
+    try:
+        return subprocess.check_output(
+            ["git", "-C", str(root), *args],
+            stderr=subprocess.DEVNULL,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+
+
+def _dirty_content_hash(root: Path) -> str:
+    metadata = _git_bytes(root, "diff", "HEAD", "--raw", "-z", "--abbrev=40", "--no-renames", "--no-ext-diff")
+    tracked = _git_bytes(root, "diff", "HEAD", "--name-only", "-z", "--no-renames", "--no-ext-diff")
+    untracked = _git_bytes(root, "ls-files", "--others", "--exclude-standard", "-z")
+    if metadata is None or tracked is None or untracked is None:
+        raise AgentError(f"Could not fingerprint dirty repository at {root}.")
+
+    fingerprint = sha256(metadata)
+    changed_paths = sorted(set(tracked.rstrip(b"\0").split(b"\0")) | set(untracked.rstrip(b"\0").split(b"\0")))
+    for raw_path in filter(None, changed_paths):
+        relative_path = os.fsdecode(raw_path)
+        absolute_path = root / relative_path
+        if not absolute_path.exists():
+            object_hash = "deleted"
+        elif absolute_path.is_dir():
+            object_hash = _git_output(absolute_path, "rev-parse", "HEAD")
+        else:
+            object_hash = _git_output(root, "hash-object", "--no-filters", "--", relative_path)
+        if object_hash is None:
+            raise AgentError(f"Could not fingerprint changed path {relative_path} in {root}.")
+        fingerprint.update(raw_path)
+        fingerprint.update(b"\0")
+        fingerprint.update(object_hash.encode())
+    return fingerprint.hexdigest()
+
+
+def _repository_provenance(
+    root: Path,
+    repository: str | None = None,
+    ref: str | None = None,
+    *,
+    is_variant: bool | None = None,
+) -> RepositoryProvenance | None:
+    commit_sha = _git_output(root, "rev-parse", "HEAD")
+    resolved_repository = repository or _git_output(root, "config", "--get", "remote.origin.url")
+    resolved_ref = ref or _git_output(root, "branch", "--show-current")
+    dirty = bool(_git_output(root, "status", "--porcelain")) if commit_sha else False
+    if not any((resolved_repository, resolved_ref, commit_sha)):
+        return None
+    return RepositoryProvenance(
+        repository=resolved_repository,
+        ref=resolved_ref,
+        commit_sha=commit_sha,
+        dirty=dirty,
+        content_hash=_dirty_content_hash(root) if dirty else None,
+        is_variant=bool(is_variant or dirty or (is_variant is None and resolved_ref)),
+    )
 
 
 def _commit_patch_as_head(repo_path: Path) -> None:
@@ -199,7 +275,15 @@ def run_pr_review_agent(
         "AGENT_MINIMUM_SEVERITY": severity,
     }
 
-    config = ExperimentConfiguration()
+    config = ExperimentConfiguration(
+        pr_review_engine=_repository_provenance(engine_root),
+        bcquality=_repository_provenance(
+            bcquality_local_path or bcquality_root,
+            bcquality_repo,
+            bcquality_ref,
+            is_variant=bool(bcquality_repo or bcquality_ref or bcquality_local_path),
+        ),
+    )
 
     start = time.monotonic()
     try:
@@ -229,4 +313,4 @@ def run_pr_review_agent(
         logger.exception("Unexpected error running engine review")
         raise
     else:
-        return AgentMetrics(execution_time=time.monotonic() - start), config
+        return build_pr_review_metrics(output_dir, time.monotonic() - start), config

--- a/src/bcbench/agent/pr_review/agent.py
+++ b/src/bcbench/agent/pr_review/agent.py
@@ -27,7 +27,7 @@ from bcbench.dataset import BaseDatasetEntry
 from bcbench.dataset.codereview import CodeReviewEntry
 from bcbench.exceptions import AgentError, AgentTimeoutError
 from bcbench.logger import get_logger
-from bcbench.operations import clone_repo_at_revision, commit_changes, has_changes, init_repo
+from bcbench.operations import commit_changes, has_changes, init_repo
 from bcbench.types import AgentMetrics, EvaluationCategory, ExperimentConfiguration
 
 logger = get_logger(__name__)
@@ -43,11 +43,13 @@ def _load_pr_review_settings() -> dict[str, Any]:
     return yaml.safe_load(config_file.read_text(encoding="utf-8"))["pr_review"]
 
 
-def _resolve_pr_review_root(engine_path: Path) -> Path:
+def _resolve_pr_review_root(engine_path: Path | None) -> Path:
+    if engine_path is None:
+        raise AgentError("Engine root not configured. Pass --engine-path or set BC_PR_REVIEW_ROOT.")
     root = engine_path.expanduser().resolve()
     engine = root / "agents" / "ALReviewAgent" / "scripts" / "Invoke-CopilotPRReview.ps1"
     if not engine.exists():
-        raise AgentError(f"Engine orchestrator not found at {engine}. Check the BC-ALAgents source configuration.")
+        raise AgentError(f"Engine orchestrator not found at {engine}. Check --engine-path points at a BC-ALAgents checkout.")
     return root
 
 
@@ -60,20 +62,6 @@ def _resolve_pwsh() -> str:
 
 def _environment_without_bcquality_overrides() -> dict[str, str]:
     return {name: value for name, value in os.environ.items() if not name.startswith("BCQUALITY_")}
-
-
-def _prepare_pr_review_root(
-    repo: str | None,
-    ref: str | None,
-    local_path: Path | None,
-    destination: Path,
-) -> Path:
-    if local_path:
-        return _resolve_pr_review_root(local_path)
-    if not repo or not ref:
-        raise AgentError("BC-ALAgents repo and ref must be configured when no local path is provided.")
-    clone_repo_at_revision(repo, ref, destination)
-    return _resolve_pr_review_root(destination)
 
 
 def _commit_patch_as_head(repo_path: Path) -> None:
@@ -149,9 +137,7 @@ def run_pr_review_agent(
     category: EvaluationCategory,
     repo_path: Path,
     output_dir: Path,
-    engine_repo: str | None = None,
-    engine_ref: str | None = None,
-    engine_local_path: Path | None = None,
+    engine_path: Path | None = None,
     min_severity: str | None = None,
 ) -> tuple[AgentMetrics | None, ExperimentConfiguration]:
     """Run the engine's complete local review pipeline and write review.json.
@@ -172,10 +158,7 @@ def run_pr_review_agent(
     repo_path = repo_path.resolve()
     output_dir = output_dir.resolve()
     settings = _load_pr_review_settings()
-    engine_cfg = settings["engine"]
-    engine_repo = engine_repo or engine_cfg["repo"]
-    engine_ref = engine_ref or engine_cfg["ref"]
-    engine_root = _prepare_pr_review_root(engine_repo, engine_ref, engine_local_path, output_dir / "bc-alagents")
+    engine_root = _resolve_pr_review_root(engine_path)
     pwsh = _resolve_pwsh()
     severity = min_severity or settings["min_severity"]
     output_dir.mkdir(parents=True, exist_ok=True)

--- a/src/bcbench/agent/pr_review/agent.py
+++ b/src/bcbench/agent/pr_review/agent.py
@@ -15,7 +15,6 @@ import os
 import shutil
 import subprocess
 import time
-from hashlib import sha256
 from pathlib import Path
 from typing import Any
 
@@ -28,8 +27,8 @@ from bcbench.dataset import BaseDatasetEntry
 from bcbench.dataset.codereview import CodeReviewEntry
 from bcbench.exceptions import AgentError, AgentTimeoutError
 from bcbench.logger import get_logger
-from bcbench.operations import commit_changes, has_changes, init_repo
-from bcbench.types import AgentMetrics, EvaluationCategory, ExperimentConfiguration, RepositoryProvenance
+from bcbench.operations import clone_repo_at_revision, commit_changes, has_changes, init_repo
+from bcbench.types import AgentMetrics, EvaluationCategory, ExperimentConfiguration
 
 logger = get_logger(__name__)
 _config = get_config()
@@ -44,13 +43,11 @@ def _load_pr_review_settings() -> dict[str, Any]:
     return yaml.safe_load(config_file.read_text(encoding="utf-8"))["pr_review"]
 
 
-def _resolve_pr_review_root(engine_path: Path | None) -> Path:
-    if engine_path is None:
-        raise AgentError("Engine root not configured. Pass --engine-path or set BC_PR_REVIEW_ROOT.")
+def _resolve_pr_review_root(engine_path: Path) -> Path:
     root = engine_path.expanduser().resolve()
     engine = root / "agents" / "ALReviewAgent" / "scripts" / "Invoke-CopilotPRReview.ps1"
     if not engine.exists():
-        raise AgentError(f"Engine orchestrator not found at {engine}. Check --engine-path points at a BC-ALAgents checkout.")
+        raise AgentError(f"Engine orchestrator not found at {engine}. Check the BC-ALAgents source configuration.")
     return root
 
 
@@ -61,78 +58,22 @@ def _resolve_pwsh() -> str:
     return pwsh
 
 
-def _git_output(root: Path, *args: str) -> str | None:
-    try:
-        return (
-            subprocess.check_output(
-                ["git", "-C", str(root), *args],
-                stderr=subprocess.DEVNULL,
-                text=True,
-                encoding="utf-8",
-            ).strip()
-            or None
-        )
-    except (OSError, subprocess.CalledProcessError):
-        return None
+def _environment_without_bcquality_overrides() -> dict[str, str]:
+    return {name: value for name, value in os.environ.items() if not name.startswith("BCQUALITY_")}
 
 
-def _git_bytes(root: Path, *args: str) -> bytes | None:
-    try:
-        return subprocess.check_output(
-            ["git", "-C", str(root), *args],
-            stderr=subprocess.DEVNULL,
-        )
-    except (OSError, subprocess.CalledProcessError):
-        return None
-
-
-def _dirty_content_hash(root: Path) -> str:
-    metadata = _git_bytes(root, "diff", "HEAD", "--raw", "-z", "--abbrev=40", "--no-renames", "--no-ext-diff")
-    tracked = _git_bytes(root, "diff", "HEAD", "--name-only", "-z", "--no-renames", "--no-ext-diff")
-    untracked = _git_bytes(root, "ls-files", "--others", "--exclude-standard", "-z")
-    if metadata is None or tracked is None or untracked is None:
-        raise AgentError(f"Could not fingerprint dirty repository at {root}.")
-
-    fingerprint = sha256(metadata)
-    changed_paths = sorted(set(tracked.rstrip(b"\0").split(b"\0")) | set(untracked.rstrip(b"\0").split(b"\0")))
-    for raw_path in filter(None, changed_paths):
-        relative_path = os.fsdecode(raw_path)
-        absolute_path = root / relative_path
-        if not absolute_path.exists():
-            object_hash = "deleted"
-        elif absolute_path.is_dir():
-            object_hash = _git_output(absolute_path, "rev-parse", "HEAD")
-        else:
-            object_hash = _git_output(root, "hash-object", "--no-filters", "--", relative_path)
-        if object_hash is None:
-            raise AgentError(f"Could not fingerprint changed path {relative_path} in {root}.")
-        fingerprint.update(raw_path)
-        fingerprint.update(b"\0")
-        fingerprint.update(object_hash.encode())
-    return fingerprint.hexdigest()
-
-
-def _repository_provenance(
-    root: Path,
-    repository: str | None = None,
-    ref: str | None = None,
-    *,
-    is_variant: bool | None = None,
-) -> RepositoryProvenance | None:
-    commit_sha = _git_output(root, "rev-parse", "HEAD")
-    resolved_repository = repository or _git_output(root, "config", "--get", "remote.origin.url")
-    resolved_ref = ref or _git_output(root, "branch", "--show-current")
-    dirty = bool(_git_output(root, "status", "--porcelain")) if commit_sha else False
-    if not any((resolved_repository, resolved_ref, commit_sha)):
-        return None
-    return RepositoryProvenance(
-        repository=resolved_repository,
-        ref=resolved_ref,
-        commit_sha=commit_sha,
-        dirty=dirty,
-        content_hash=_dirty_content_hash(root) if dirty else None,
-        is_variant=bool(is_variant or dirty or (is_variant is None and resolved_ref)),
-    )
+def _prepare_pr_review_root(
+    repo: str | None,
+    ref: str | None,
+    local_path: Path | None,
+    destination: Path,
+) -> Path:
+    if local_path:
+        return _resolve_pr_review_root(local_path)
+    if not repo or not ref:
+        raise AgentError("BC-ALAgents repo and ref must be configured when no local path is provided.")
+    clone_repo_at_revision(repo, ref, destination)
+    return _resolve_pr_review_root(destination)
 
 
 def _commit_patch_as_head(repo_path: Path) -> None:
@@ -158,24 +99,14 @@ def _prepare_bcquality_root(
     engine_root: Path,
     pwsh: str,
     dest: Path,
-    bcquality_ref: str | None,
-    bcquality_repo: str | None = None,
-    bcquality_local_path: Path | None = None,
 ) -> Path:
-    env = {**os.environ}
-    if bcquality_repo:
-        env["BCQUALITY_REPO"] = bcquality_repo
-    if bcquality_ref:
-        env["BCQUALITY_REF"] = bcquality_ref
     args = [pwsh, "-NoProfile", "-File", str(_PREPARE_BCQUALITY_SCRIPT), "-EngineRoot", str(engine_root), "-Root", str(dest)]
-    if bcquality_local_path:
-        args += ["-LocalPath", str(bcquality_local_path)]
     result = subprocess.run(
         args,
         capture_output=True,
         text=True,
         encoding="utf-8",
-        env=env,
+        env=_environment_without_bcquality_overrides(),
         check=False,
     )
     if result.returncode != 0:
@@ -216,10 +147,9 @@ def run_pr_review_agent(
     category: EvaluationCategory,
     repo_path: Path,
     output_dir: Path,
-    engine_path: Path | None = None,
-    bcquality_ref: str | None = None,
-    bcquality_repo: str | None = None,
-    bcquality_local_path: Path | None = None,
+    engine_repo: str | None = None,
+    engine_ref: str | None = None,
+    engine_local_path: Path | None = None,
     min_severity: str | None = None,
 ) -> tuple[AgentMetrics | None, ExperimentConfiguration]:
     """Run the engine's complete local review pipeline and write review.json.
@@ -227,7 +157,7 @@ def run_pr_review_agent(
     Separate from run_copilot_agent by design: this spawns the PROD BC-ALAgents
     PowerShell orchestrator (Copilot is spawned inside the engine, not here), so it
     owns none of the copilot-harness prompt/MCP/LSP wiring and takes engine-specific
-    inputs (BCQuality source, min severity) for the code-review category only.
+    inputs (BC-ALAgents source, min severity) for the code-review category only.
 
     Returns:
         Tuple of (AgentMetrics, ExperimentConfiguration).
@@ -240,29 +170,22 @@ def run_pr_review_agent(
     repo_path = repo_path.resolve()
     output_dir = output_dir.resolve()
     settings = _load_pr_review_settings()
-    engine_root = _resolve_pr_review_root(engine_path)
+    engine_cfg = settings["engine"]
+    engine_repo = engine_repo or engine_cfg["repo"]
+    engine_ref = engine_ref or engine_cfg["ref"]
+    engine_root = _prepare_pr_review_root(engine_repo, engine_ref, engine_local_path, output_dir / "bc-alagents")
     pwsh = _resolve_pwsh()
     severity = min_severity or settings["min_severity"]
-    bcquality_cfg = settings["bcquality"]
-    bcquality_repo = bcquality_repo or bcquality_cfg["repo"]
-    bcquality_ref = bcquality_ref or bcquality_cfg["ref"]
     output_dir.mkdir(parents=True, exist_ok=True)
     logger.info(f"Running BC-ALAgents review engine on: {entry.instance_id}")
 
     _commit_patch_as_head(repo_path)
     trusted_workspace = _init_trusted_workspace(output_dir / "trusted")
-    bcquality_root = _prepare_bcquality_root(
-        engine_root,
-        pwsh,
-        output_dir / "bcquality",
-        bcquality_ref,
-        bcquality_repo,
-        bcquality_local_path,
-    )
+    bcquality_root = _prepare_bcquality_root(engine_root, pwsh, output_dir / "bcquality")
 
     engine = engine_root / "agents" / "ALReviewAgent" / "scripts" / "Invoke-CopilotPRReview.ps1"
     env = {
-        **os.environ,
+        **_environment_without_bcquality_overrides(),
         "REVIEW_SOURCE": "local",
         "REVIEW_PHASE": "all",
         "BASE_REF": entry.base_commit,
@@ -275,15 +198,7 @@ def run_pr_review_agent(
         "AGENT_MINIMUM_SEVERITY": severity,
     }
 
-    config = ExperimentConfiguration(
-        pr_review_engine=_repository_provenance(engine_root),
-        bcquality=_repository_provenance(
-            bcquality_local_path or bcquality_root,
-            bcquality_repo,
-            bcquality_ref,
-            is_variant=bool(bcquality_repo or bcquality_ref or bcquality_local_path),
-        ),
-    )
+    config = ExperimentConfiguration()
 
     start = time.monotonic()
     try:

--- a/src/bcbench/agent/pr_review/metrics.py
+++ b/src/bcbench/agent/pr_review/metrics.py
@@ -1,0 +1,88 @@
+import json
+from pathlib import Path
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+
+from bcbench.exceptions import AgentError
+from bcbench.types import AgentMetrics
+
+RUN_METRICS_FILE_NAME = "_run-metrics.json"
+_NonNegativeInt = Annotated[int, Field(ge=0)]
+_NonNegativeFloat = Annotated[float, Field(ge=0)]
+
+
+class _RunMetrics(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    schema_version: Literal[1]
+    metrics_source: Literal["copilot-cli-otel", "not-applicable"]
+    cli_version: str | None
+    wall_time_seconds: _NonNegativeFloat | None
+    prompt_tokens: _NonNegativeInt | None
+    cached_tokens: _NonNegativeInt | None
+    cache_creation_tokens: _NonNegativeInt | None
+    completion_tokens: _NonNegativeInt | None
+    reasoning_tokens: _NonNegativeInt | None
+    total_tokens: _NonNegativeInt | None
+    api_calls: _NonNegativeInt | None
+    failed_api_calls: _NonNegativeInt | None
+    usage_api_calls: _NonNegativeInt | None
+    ai_credits: _NonNegativeFloat | None
+    premium_requests: _NonNegativeFloat | None
+    models: list[str]
+    usage_complete: bool
+    malformed_records: _NonNegativeInt
+
+    @model_validator(mode="after")
+    def validate_not_applicable_shape(self) -> "_RunMetrics":
+        if self.metrics_source != "not-applicable":
+            return self
+        expected = {
+            "cli_version": None,
+            "wall_time_seconds": 0,
+            "prompt_tokens": 0,
+            "cached_tokens": 0,
+            "cache_creation_tokens": 0,
+            "completion_tokens": 0,
+            "reasoning_tokens": None,
+            "total_tokens": 0,
+            "api_calls": 0,
+            "failed_api_calls": 0,
+            "usage_api_calls": 0,
+            "ai_credits": 0.0,
+            "premium_requests": None,
+            "models": [],
+            "usage_complete": True,
+            "malformed_records": 0,
+        }
+        invalid = [name for name, value in expected.items() if getattr(self, name) != value]
+        if invalid:
+            raise ValueError(f"not-applicable metrics have invalid fields: {', '.join(invalid)}")
+        return self
+
+
+def _load_run_metrics(path: Path) -> _RunMetrics:
+    if not path.exists():
+        raise AgentError(f"Engine run metrics artifact not found at {path}.")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8-sig"))
+    except (json.JSONDecodeError, OSError) as exc:
+        raise AgentError(f"Could not read engine run metrics artifact {path}: {exc}") from exc
+    try:
+        return _RunMetrics.model_validate(payload)
+    except ValidationError as exc:
+        raise AgentError(f"Engine run metrics artifact {path} does not satisfy schema version 1: {exc}") from exc
+
+
+def build_pr_review_metrics(output_dir: Path, execution_time: float) -> AgentMetrics:
+    run = _load_run_metrics(output_dir / RUN_METRICS_FILE_NAME)
+    usage_values_available = run.malformed_records == 0
+    token_values_available = usage_values_available and run.usage_complete
+    return AgentMetrics(
+        execution_time=execution_time,
+        prompt_tokens=run.prompt_tokens if token_values_available else None,
+        completion_tokens=run.completion_tokens if token_values_available else None,
+        total_tokens=run.total_tokens if token_values_available else None,
+        ai_credits=run.ai_credits if usage_values_available else None,
+    )

--- a/src/bcbench/agent/pr_review/metrics.py
+++ b/src/bcbench/agent/pr_review/metrics.py
@@ -78,6 +78,8 @@ def _load_run_metrics(path: Path) -> _RunMetrics:
 
 def build_pr_review_metrics(output_dir: Path, execution_time: float) -> AgentMetrics:
     run = _load_run_metrics(output_dir / RUN_METRICS_FILE_NAME)
+    if run.metrics_source == "not-applicable":
+        raise AgentError("Engine metrics were not applicable. BC-Bench code-review entries must contain AL changes.")
     usage_values_available = run.malformed_records == 0
     token_values_available = usage_values_available and run.usage_complete
     return AgentMetrics(

--- a/src/bcbench/agent/pr_review/metrics.py
+++ b/src/bcbench/agent/pr_review/metrics.py
@@ -16,6 +16,7 @@ class _RunMetrics(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
 
     schema_version: Literal[1]
+    # "not-applicable" means engine preflight found no .al files, skipped the review, and emitted exact zero usage.
     metrics_source: Literal["copilot-cli-otel", "not-applicable"]
     cli_version: str | None
     wall_time_seconds: _NonNegativeFloat | None

--- a/src/bcbench/agent/pr_review/scripts/Prepare-BCQualityRoot.ps1
+++ b/src/bcbench/agent/pr_review/scripts/Prepare-BCQualityRoot.ps1
@@ -8,22 +8,12 @@
     does: read the engine's pinned repo/ref via Get-BCQualityConfig.ps1, shallow
     fetch that ref, then run Invoke-BCQualityFilter.ps1 over the checkout.
 
-    Honors the same BCQUALITY_* environment overrides Get-BCQualityConfig reads
-    (e.g. BCQUALITY_REPO, BCQUALITY_REF), so a caller can pin a different content
-    repo/ref (such as a private branch or fork) without editing the engine.
-
-    Pass -LocalPath to iterate on a local BCQuality checkout without pushing: the
-    checkout is COPIED into -Root (excluding .git) and filtered there, so the
-    original working tree is never modified (the filter deletes files). This is the
-    fast inner loop for optimizing BCQuality structure and re-scoring in BC-Bench.
-
     Emits the resolved root as `root=<path>` on stdout for the Python caller.
 #>
 [CmdletBinding()]
 param(
     [Parameter(Mandatory)] [string] $EngineRoot,
-    [Parameter(Mandatory)] [string] $Root,
-    [string] $LocalPath
+    [Parameter(Mandatory)] [string] $Root
 )
 
 Set-StrictMode -Version Latest
@@ -39,37 +29,20 @@ if (-not (Get-Module -ListAvailable -Name powershell-yaml)) {
     Install-Module powershell-yaml -Scope CurrentUser -Force -AllowClobber
 }
 
-# Get-BCQualityConfig honors BCQUALITY_REPO/REF and the knowledge/layer overrides;
-# the resulting $cfg drives both the fetch (repo/ref) and the filter (allow/deny).
+# The engine configuration drives both the BCQuality fetch and filter.
 $cfg = & $getConfig
+$repo = $cfg.bcquality.repo
+$ref = $cfg.bcquality.ref
 
-if ($LocalPath) {
-    $src = (Resolve-Path -LiteralPath $LocalPath).Path
-    if (-not (Test-Path -LiteralPath $src)) { throw "BCQuality -LocalPath does not exist: $src" }
-
-    Write-Host "Copying local BCQuality from $src into $Root (excluding .git)"
-    if (Test-Path -LiteralPath $Root) { Remove-Item -LiteralPath $Root -Recurse -Force }
-    New-Item -ItemType Directory -Force -Path $Root | Out-Null
-    Get-ChildItem -LiteralPath $src -Force | Where-Object { $_.Name -ne '.git' } | ForEach-Object {
-        Copy-Item -LiteralPath $_.FullName -Destination $Root -Recurse -Force
-    }
-
-}
-else {
-    $repo = $cfg.bcquality.repo
-    $ref = $cfg.bcquality.ref
-
-    Write-Host "Fetching BCQuality from $repo@$ref into $Root"
-    if (Test-Path -LiteralPath $Root) { Remove-Item -LiteralPath $Root -Recurse -Force }
-    New-Item -ItemType Directory -Force -Path $Root | Out-Null
-    git -C $Root init -q
-    git -C $Root remote add origin $repo
-    git -C $Root fetch --depth=1 origin "$ref"
-    if ($LASTEXITCODE -ne 0) { throw "git fetch of BCQuality ref '$ref' failed (exit $LASTEXITCODE)" }
-    git -C $Root checkout -q FETCH_HEAD
-    if ($LASTEXITCODE -ne 0) { throw "git checkout of BCQuality ref '$ref' failed (exit $LASTEXITCODE)" }
-
-}
+Write-Host "Fetching BCQuality from $repo@$ref into $Root"
+if (Test-Path -LiteralPath $Root) { Remove-Item -LiteralPath $Root -Recurse -Force }
+New-Item -ItemType Directory -Force -Path $Root | Out-Null
+git -C $Root init -q
+git -C $Root remote add origin $repo
+git -C $Root fetch --depth=1 origin "$ref"
+if ($LASTEXITCODE -ne 0) { throw "git fetch of BCQuality ref '$ref' failed (exit $LASTEXITCODE)" }
+git -C $Root checkout -q FETCH_HEAD
+if ($LASTEXITCODE -ne 0) { throw "git checkout of BCQuality ref '$ref' failed (exit $LASTEXITCODE)" }
 
 & $filter -BCQualityRoot $Root -Config $cfg | Out-Null
 

--- a/src/bcbench/agent/shared/config.yaml
+++ b/src/bcbench/agent/shared/config.yaml
@@ -197,11 +197,7 @@ mcp:
 # the production orchestrator's complete local, non-posting path to measure BC PR Review
 # + BCQuality on the code-review category, including production parsing and filtering.
 # Generic Copilot and Claude runners use code-review-template above on the same category.
-# BC-ALAgents is the harness boundary. Its pinned configuration owns the BCQuality version.
-# CLI flags can override this repo/ref or use a local checkout for harness experiments.
-# Local checkouts are for smoke tests only; comparison runs require remote commits.
+# BC-ALAgents is the harness boundary and its configuration owns the BCQuality version.
+# The evaluation workflow pins BC-ALAgents through install-agent-harnesses.
 pr_review:
   min_severity: Medium
-  engine:
-    repo: microsoft/BC-ALAgents
-    ref: 533dd39dfe29218c09e5e31c39c78bb72fa20aa2

--- a/src/bcbench/agent/shared/config.yaml
+++ b/src/bcbench/agent/shared/config.yaml
@@ -197,12 +197,11 @@ mcp:
 # the production orchestrator's complete local, non-posting path to measure BC PR Review
 # + BCQuality on the code-review category, including production parsing and filtering.
 # Generic Copilot and Claude runners use code-review-template above on the same category.
-# Dirty engine checkouts and local BCQuality paths are for smoke tests only.
-# Full comparison runs require clean commits available remotely.
-# BCQuality repo/ref remain experiment settings; repo supports testing forks while null values
-# use the engine's pinned content source. CLI flags override these values.
+# BC-ALAgents is the harness boundary. Its pinned configuration owns the BCQuality version.
+# CLI flags can override this repo/ref or use a local checkout for harness experiments.
+# Local checkouts are for smoke tests only; comparison runs require remote commits.
 pr_review:
   min_severity: Medium
-  bcquality:
-    repo: null
-    ref: null
+  engine:
+    repo: microsoft/BC-ALAgents
+    ref: 533dd39dfe29218c09e5e31c39c78bb72fa20aa2

--- a/src/bcbench/cli_options.py
+++ b/src/bcbench/cli_options.py
@@ -11,24 +11,12 @@ from bcbench.types import EvaluationCategory
 # Note: Defaults are provided in function signatures, not here
 RepoPath = Annotated[Path, typer.Option(help="Path to repository")]
 
-PRReviewEnginePath = Annotated[
+PRReviewEngineLocalPath = Annotated[
     Path | None,
     typer.Option(
-        "--engine-path",
+        "--engine-local-path",
         envvar="BC_PR_REVIEW_ROOT",
         help="Path to a local BC-ALAgents checkout",
-        exists=True,
-        file_okay=False,
-        dir_okay=True,
-        resolve_path=True,
-    ),
-]
-
-BCQualityLocalPath = Annotated[
-    Path | None,
-    typer.Option(
-        "--bcquality-local-path",
-        help="Path to a local BCQuality checkout (copied and filtered; never modified)",
         exists=True,
         file_okay=False,
         dir_okay=True,

--- a/src/bcbench/cli_options.py
+++ b/src/bcbench/cli_options.py
@@ -11,10 +11,10 @@ from bcbench.types import EvaluationCategory
 # Note: Defaults are provided in function signatures, not here
 RepoPath = Annotated[Path, typer.Option(help="Path to repository")]
 
-PRReviewEngineLocalPath = Annotated[
+PRReviewEnginePath = Annotated[
     Path | None,
     typer.Option(
-        "--engine-local-path",
+        "--engine-path",
         envvar="BC_PR_REVIEW_ROOT",
         help="Path to a local BC-ALAgents checkout",
         exists=True,

--- a/src/bcbench/commands/evaluate.py
+++ b/src/bcbench/commands/evaluate.py
@@ -14,7 +14,7 @@ from bcbench.cli_options import (
     CopilotModel,
     EvaluationCategoryOption,
     OutputDir,
-    PRReviewEngineLocalPath,
+    PRReviewEnginePath,
     RepoPath,
     RunId,
 )
@@ -157,9 +157,7 @@ def evaluate_pr_review(
     repo_path: RepoPath = _config.paths.testbed_path,
     output_dir: OutputDir = _config.paths.evaluation_results_path,
     run_id: RunId = "pr_review_test_run",
-    engine_repo: Annotated[str | None, typer.Option(help="Override the BC-ALAgents repository (defaults to config)")] = None,
-    engine_ref: Annotated[str | None, typer.Option(help="Override the BC-ALAgents commit or ref (defaults to config)")] = None,
-    engine_local_path: PRReviewEngineLocalPath = None,
+    engine_path: PRReviewEnginePath = None,
     min_severity: Annotated[str | None, typer.Option(help="AGENT_MINIMUM_SEVERITY floor (defaults to config)")] = None,
 ) -> None:
     """
@@ -168,9 +166,8 @@ def evaluate_pr_review(
     This production-fidelity runner is fixed to the code-review category, while the same
     category can also run through the generic copilot and claude commands for cross-system
     comparison. The resulting review.json is scored by the shared code-review pipeline.
-    By default, BC-ALAgents is cloned at the repo/ref pinned in config. Use
-    --engine-local-path (or BC_PR_REVIEW_ROOT) for local harness development.
-    Requires PowerShell 7+, GitHub CLI authentication, and an authenticated Copilot CLI.
+    Requires a local BC-ALAgents checkout (--engine-path or BC_PR_REVIEW_ROOT),
+    PowerShell 7+, and an authenticated Copilot CLI.
 
     To only generate review.json without scoring, use 'bcbench run pr-review' instead.
     """
@@ -198,9 +195,7 @@ def evaluate_pr_review(
             category=category,
             model=ctx.model,
             output_dir=ctx.result_dir,
-            engine_repo=engine_repo,
-            engine_ref=engine_ref,
-            engine_local_path=engine_local_path,
+            engine_path=engine_path,
             min_severity=min_severity,
         ),
     )

--- a/src/bcbench/commands/evaluate.py
+++ b/src/bcbench/commands/evaluate.py
@@ -7,7 +7,6 @@ import typer
 
 from bcbench.agent import BCalBackendConfig, run_bcal_agent, run_claude_code, run_copilot_agent, run_pr_review_agent
 from bcbench.cli_options import (
-    BCQualityLocalPath,
     ClaudeCodeModel,
     ContainerName,
     ContainerPassword,
@@ -15,7 +14,7 @@ from bcbench.cli_options import (
     CopilotModel,
     EvaluationCategoryOption,
     OutputDir,
-    PRReviewEnginePath,
+    PRReviewEngineLocalPath,
     RepoPath,
     RunId,
 )
@@ -158,10 +157,9 @@ def evaluate_pr_review(
     repo_path: RepoPath = _config.paths.testbed_path,
     output_dir: OutputDir = _config.paths.evaluation_results_path,
     run_id: RunId = "pr_review_test_run",
-    engine_path: PRReviewEnginePath = None,
-    bcquality_ref: Annotated[str | None, typer.Option(help="Override the BCQuality ref (defaults to the engine's pinned ref)")] = None,
-    bcquality_repo: Annotated[str | None, typer.Option(help="Override the BCQuality repo, e.g. a private fork (defaults to config/engine)")] = None,
-    bcquality_local_path: BCQualityLocalPath = None,
+    engine_repo: Annotated[str | None, typer.Option(help="Override the BC-ALAgents repository (defaults to config)")] = None,
+    engine_ref: Annotated[str | None, typer.Option(help="Override the BC-ALAgents commit or ref (defaults to config)")] = None,
+    engine_local_path: PRReviewEngineLocalPath = None,
     min_severity: Annotated[str | None, typer.Option(help="AGENT_MINIMUM_SEVERITY floor (defaults to config)")] = None,
 ) -> None:
     """
@@ -170,9 +168,9 @@ def evaluate_pr_review(
     This production-fidelity runner is fixed to the code-review category, while the same
     category can also run through the generic copilot and claude commands for cross-system
     comparison. The resulting review.json is scored by the shared code-review pipeline.
-    Requires a local BC-ALAgents checkout
-    (--engine-path or BC_PR_REVIEW_ROOT), PowerShell 7+, and an authenticated
-    Copilot CLI.
+    By default, BC-ALAgents is cloned at the repo/ref pinned in config. Use
+    --engine-local-path (or BC_PR_REVIEW_ROOT) for local harness development.
+    Requires PowerShell 7+, GitHub CLI authentication, and an authenticated Copilot CLI.
 
     To only generate review.json without scoring, use 'bcbench run pr-review' instead.
     """
@@ -200,10 +198,9 @@ def evaluate_pr_review(
             category=category,
             model=ctx.model,
             output_dir=ctx.result_dir,
-            engine_path=engine_path,
-            bcquality_ref=bcquality_ref,
-            bcquality_repo=bcquality_repo,
-            bcquality_local_path=bcquality_local_path,
+            engine_repo=engine_repo,
+            engine_ref=engine_ref,
+            engine_local_path=engine_local_path,
             min_severity=min_severity,
         ),
     )

--- a/src/bcbench/commands/run.py
+++ b/src/bcbench/commands/run.py
@@ -11,7 +11,7 @@ from bcbench.cli_options import (
     CopilotModel,
     EvaluationCategoryOption,
     OutputDir,
-    PRReviewEngineLocalPath,
+    PRReviewEnginePath,
     RepoPath,
 )
 from bcbench.config import get_config
@@ -99,9 +99,7 @@ def run_pr_review(
     model: CopilotModel = "gpt-5.6-luna",
     repo_path: RepoPath = _config.paths.testbed_path,
     output_dir: OutputDir = _config.paths.evaluation_results_path,
-    engine_repo: Annotated[str | None, typer.Option(help="Override the BC-ALAgents repository (defaults to config)")] = None,
-    engine_ref: Annotated[str | None, typer.Option(help="Override the BC-ALAgents commit or ref (defaults to config)")] = None,
-    engine_local_path: PRReviewEngineLocalPath = None,
+    engine_path: PRReviewEnginePath = None,
     min_severity: Annotated[str | None, typer.Option(help="AGENT_MINIMUM_SEVERITY floor (defaults to config)")] = None,
 ) -> None:
     """
@@ -110,10 +108,9 @@ def run_pr_review(
     This production-fidelity runner is fixed to the code-review category, while the same
     category can also run through the generic copilot and claude commands for cross-system
     comparison. Writes review.json without scoring; for full evaluation use
-    'bcbench evaluate pr-review'. By default, BC-ALAgents is cloned at the repo/ref
-    pinned in config. Use --engine-local-path (or BC_PR_REVIEW_ROOT) for local
-    harness development. Requires PowerShell 7+, GitHub CLI authentication, and
-    an authenticated Copilot CLI.
+    'bcbench evaluate pr-review'. Requires a local BC-ALAgents checkout
+    (--engine-path or BC_PR_REVIEW_ROOT), PowerShell 7+, and an authenticated
+    Copilot CLI.
 
     Example:
         uv run bcbench run pr-review synthetic__style-018 --repo-path /path/to/testbed
@@ -128,9 +125,7 @@ def run_pr_review(
         repo_path=repo_path,
         category=category,
         output_dir=output_dir,
-        engine_repo=engine_repo,
-        engine_ref=engine_ref,
-        engine_local_path=engine_local_path,
+        engine_path=engine_path,
         min_severity=min_severity,
     )
 

--- a/src/bcbench/commands/run.py
+++ b/src/bcbench/commands/run.py
@@ -6,13 +6,12 @@ import typer
 
 from bcbench.agent import BCalBackendConfig, run_bcal_agent, run_claude_code, run_copilot_agent, run_pr_review_agent
 from bcbench.cli_options import (
-    BCQualityLocalPath,
     ClaudeCodeModel,
     ContainerName,
     CopilotModel,
     EvaluationCategoryOption,
     OutputDir,
-    PRReviewEnginePath,
+    PRReviewEngineLocalPath,
     RepoPath,
 )
 from bcbench.config import get_config
@@ -100,10 +99,9 @@ def run_pr_review(
     model: CopilotModel = "gpt-5.6-luna",
     repo_path: RepoPath = _config.paths.testbed_path,
     output_dir: OutputDir = _config.paths.evaluation_results_path,
-    engine_path: PRReviewEnginePath = None,
-    bcquality_ref: Annotated[str | None, typer.Option(help="Override the BCQuality ref (defaults to the engine's pinned ref)")] = None,
-    bcquality_repo: Annotated[str | None, typer.Option(help="Override the BCQuality repo, e.g. a private fork (defaults to config/engine)")] = None,
-    bcquality_local_path: BCQualityLocalPath = None,
+    engine_repo: Annotated[str | None, typer.Option(help="Override the BC-ALAgents repository (defaults to config)")] = None,
+    engine_ref: Annotated[str | None, typer.Option(help="Override the BC-ALAgents commit or ref (defaults to config)")] = None,
+    engine_local_path: PRReviewEngineLocalPath = None,
     min_severity: Annotated[str | None, typer.Option(help="AGENT_MINIMUM_SEVERITY floor (defaults to config)")] = None,
 ) -> None:
     """
@@ -112,9 +110,10 @@ def run_pr_review(
     This production-fidelity runner is fixed to the code-review category, while the same
     category can also run through the generic copilot and claude commands for cross-system
     comparison. Writes review.json without scoring; for full evaluation use
-    'bcbench evaluate pr-review'. Requires a local BC-ALAgents checkout
-    (--engine-path or BC_PR_REVIEW_ROOT), PowerShell 7+, and an authenticated
-    Copilot CLI.
+    'bcbench evaluate pr-review'. By default, BC-ALAgents is cloned at the repo/ref
+    pinned in config. Use --engine-local-path (or BC_PR_REVIEW_ROOT) for local
+    harness development. Requires PowerShell 7+, GitHub CLI authentication, and
+    an authenticated Copilot CLI.
 
     Example:
         uv run bcbench run pr-review synthetic__style-018 --repo-path /path/to/testbed
@@ -129,10 +128,9 @@ def run_pr_review(
         repo_path=repo_path,
         category=category,
         output_dir=output_dir,
-        engine_path=engine_path,
-        bcquality_ref=bcquality_ref,
-        bcquality_repo=bcquality_repo,
-        bcquality_local_path=bcquality_local_path,
+        engine_repo=engine_repo,
+        engine_ref=engine_ref,
+        engine_local_path=engine_local_path,
         min_severity=min_severity,
     )
 

--- a/src/bcbench/results/bceval_export.py
+++ b/src/bcbench/results/bceval_export.py
@@ -21,10 +21,10 @@ def _experiment_metadata(experiment: ExperimentConfiguration | None, git_ref: st
     bc-eval promotes the ``EvalRunType`` key to the Kusto ``EvalRunType``/``testJobType`` fields
     when ``--eval-run-type`` is left at its default, so no extra CLI flag is needed.
     """
-    is_experiment: bool = experiment is not None and not experiment.is_empty()
+    is_experiment: bool = bool(experiment and experiment.is_experiment)
     return {
         "EvalRunType": "experiment" if is_experiment else "baseline",
-        "experiment": experiment.model_dump(mode="json") if (is_experiment and experiment) else None,
+        "experiment": experiment.model_dump(mode="json") if experiment and not experiment.is_empty() else None,
         "git_branch": git_ref,
         "benchmark_version": benchmark_version,
     }

--- a/src/bcbench/results/bceval_export.py
+++ b/src/bcbench/results/bceval_export.py
@@ -21,10 +21,10 @@ def _experiment_metadata(experiment: ExperimentConfiguration | None, git_ref: st
     bc-eval promotes the ``EvalRunType`` key to the Kusto ``EvalRunType``/``testJobType`` fields
     when ``--eval-run-type`` is left at its default, so no extra CLI flag is needed.
     """
-    is_experiment: bool = bool(experiment and experiment.is_experiment)
+    is_experiment: bool = experiment is not None and not experiment.is_empty()
     return {
         "EvalRunType": "experiment" if is_experiment else "baseline",
-        "experiment": experiment.model_dump(mode="json") if experiment and not experiment.is_empty() else None,
+        "experiment": experiment.model_dump(mode="json") if is_experiment and experiment else None,
         "git_branch": git_ref,
         "benchmark_version": benchmark_version,
     }

--- a/src/bcbench/results/codereview.py
+++ b/src/bcbench/results/codereview.py
@@ -484,9 +484,9 @@ class CodeReviewResultSummary(JudgeBasedEvaluationResultSummary):
         valid_output_count: int = sum(1 for r in code_review_results if r.valid_review_output)
         valid_output_rate: float = valid_output_count / total_results
 
-        def average_metric(name: str) -> float | None:
-            values = [value for result in code_review_results if result.metrics and (value := getattr(result.metrics, name)) is not None]
-            return sum(values) / len(values) if values else None
+        def average_metric(values: Sequence[int | float | None]) -> float | None:
+            available = [value for value in values if value is not None]
+            return sum(available) / len(available) if available else None
 
         return summary.model_copy(
             update={
@@ -509,9 +509,9 @@ class CodeReviewResultSummary(JudgeBasedEvaluationResultSummary):
                 "severity_mae": round(severity_mae, 3),
                 "valid_review_output_rate": round(valid_output_rate, 3),
                 "instance_results": {r.instance_id: round(r.f1, 6) for r in code_review_results},
-                "average_prompt_tokens": average_metric("prompt_tokens"),
-                "average_completion_tokens": average_metric("completion_tokens"),
-                "average_total_tokens": average_metric("total_tokens"),
-                "average_ai_credits": average_metric("ai_credits"),
+                "average_prompt_tokens": average_metric([result.metrics.prompt_tokens if result.metrics else None for result in code_review_results]),
+                "average_completion_tokens": average_metric([result.metrics.completion_tokens if result.metrics else None for result in code_review_results]),
+                "average_total_tokens": average_metric([result.metrics.total_tokens if result.metrics else None for result in code_review_results]),
+                "average_ai_credits": average_metric([result.metrics.ai_credits if result.metrics else None for result in code_review_results]),
             }
         )

--- a/src/bcbench/results/codereview.py
+++ b/src/bcbench/results/codereview.py
@@ -288,6 +288,9 @@ class CodeReviewResultSummary(JudgeBasedEvaluationResultSummary):
     Macro metrics average per-task scores (each task weighted equally).
     """
 
+    average_prompt_tokens: float | None = None
+    average_completion_tokens: float | None = None
+
     generated_comment_count: int = Field(default=0, ge=0)
     expected_comment_count: int = Field(default=0, ge=0)
     matched_comment_count: int = Field(default=0, ge=0)
@@ -310,9 +313,25 @@ class CodeReviewResultSummary(JudgeBasedEvaluationResultSummary):
     severity_mae: float = 0.0
     valid_review_output_rate: float = Field(default=0.0, ge=0.0, le=1.0)
 
+    average_total_tokens: float | None = None
+
     # Per-task F1 keyed by instance_id, retained so the leaderboard can bootstrap a confidence
     # interval over tasks (meaningful even for a single run) instead of only over runs.
     instance_results: dict[str, float] = Field(default_factory=dict)
+
+    def _performance_markdown(self) -> str:
+        def metric(value: float | None, digits: int = 1) -> str:
+            return f"{value:.{digits}f}" if value is not None else "n/a"
+
+        return (
+            "## Performance\n"
+            "\n"
+            "| Avg duration (s) | Avg prompt tokens | Avg completion tokens | Avg total tokens | Avg AI credits |\n"
+            "|-----------------:|------------------:|----------------------:|-----------------:|---------------:|\n"
+            f"| {self.average_duration:.1f} | {metric(self.average_prompt_tokens)} | {metric(self.average_completion_tokens)} | "
+            f"{metric(self.average_total_tokens)} | {metric(self.average_ai_credits, 4)} |\n"
+            "\n"
+        )
 
     def render_github_metrics_markdown(self) -> str:
         micro_p = self.precision * 100
@@ -351,6 +370,7 @@ class CodeReviewResultSummary(JudgeBasedEvaluationResultSummary):
             "|-------------:|-------------------------:|\n"
             f"| {self.severity_mae:.3f} | {valid_rate:.1f}% |\n"
             "\n"
+            f"{self._performance_markdown()}"
             f"{_METRIC_EXPLANATIONS}"
         )
 
@@ -396,6 +416,17 @@ class CodeReviewResultSummary(JudgeBasedEvaluationResultSummary):
                 "Quality",
                 ["Severity MAE", "Valid review output rate"],
                 [f"{self.severity_mae:.3f}", f"{self.valid_review_output_rate * 100:.1f}%"],
+            ),
+            _build_console_table(
+                "Performance",
+                ["Avg duration (s)", "Prompt", "Completion", "Total", "AI credits"],
+                [
+                    f"{self.average_duration:.1f}",
+                    f"{self.average_prompt_tokens:.1f}" if self.average_prompt_tokens is not None else "n/a",
+                    f"{self.average_completion_tokens:.1f}" if self.average_completion_tokens is not None else "n/a",
+                    f"{self.average_total_tokens:.1f}" if self.average_total_tokens is not None else "n/a",
+                    f"{self.average_ai_credits:.4f}" if self.average_ai_credits is not None else "n/a",
+                ],
             ),
             Panel(
                 _CONSOLE_METRIC_EXPLANATIONS,
@@ -453,6 +484,10 @@ class CodeReviewResultSummary(JudgeBasedEvaluationResultSummary):
         valid_output_count: int = sum(1 for r in code_review_results if r.valid_review_output)
         valid_output_rate: float = valid_output_count / total_results
 
+        def average_metric(name: str) -> float | None:
+            values = [value for result in code_review_results if result.metrics and (value := getattr(result.metrics, name)) is not None]
+            return sum(values) / len(values) if values else None
+
         return summary.model_copy(
             update={
                 "generated_comment_count": generated_total,
@@ -474,5 +509,9 @@ class CodeReviewResultSummary(JudgeBasedEvaluationResultSummary):
                 "severity_mae": round(severity_mae, 3),
                 "valid_review_output_rate": round(valid_output_rate, 3),
                 "instance_results": {r.instance_id: round(r.f1, 6) for r in code_review_results},
+                "average_prompt_tokens": average_metric("prompt_tokens"),
+                "average_completion_tokens": average_metric("completion_tokens"),
+                "average_total_tokens": average_metric("total_tokens"),
+                "average_ai_credits": average_metric("ai_credits"),
             }
         )

--- a/src/bcbench/results/leaderboard.py
+++ b/src/bcbench/results/leaderboard.py
@@ -147,6 +147,12 @@ class CodeReviewLeaderboardAggregate(JudgeBasedLeaderboardAggregate):
     macro_precision: float = 0.0
     macro_recall: float = 0.0
 
+    valid_review_output_rate: float = 0.0
+    average_prompt_tokens: float | None = None
+    average_completion_tokens: float | None = None
+    average_total_tokens: float | None = None
+    average_ai_credits: float | None = None
+
     @classmethod
     def from_runs(cls, runs: Sequence[EvaluationResultSummary]) -> "CodeReviewLeaderboardAggregate":
         from bcbench.results.codereview import CodeReviewResultSummary
@@ -156,6 +162,10 @@ class CodeReviewLeaderboardAggregate(JudgeBasedLeaderboardAggregate):
 
         cr_runs: list[CodeReviewResultSummary] = [run for run in runs if isinstance(run, CodeReviewResultSummary)]
         n = len(cr_runs)
+
+        def mean_metric(name: str) -> float | None:
+            values = [value for run in cr_runs if (value := getattr(run, name)) is not None]
+            return sum(values) / len(values) if values else None
 
         # The micro headline pools every comment across the dataset, so there is no per-task
         # decomposition to resample; its CI is intentionally over run-level means and captures
@@ -184,6 +194,11 @@ class CodeReviewLeaderboardAggregate(JudgeBasedLeaderboardAggregate):
                 "macro_f_beta_2": sum(r.macro_f_beta_2 for r in cr_runs) / n,
                 "macro_precision": sum(r.macro_precision for r in cr_runs) / n,
                 "macro_recall": sum(r.macro_recall for r in cr_runs) / n,
+                "valid_review_output_rate": sum(r.valid_review_output_rate for r in cr_runs) / n,
+                "average_prompt_tokens": mean_metric("average_prompt_tokens"),
+                "average_completion_tokens": mean_metric("average_completion_tokens"),
+                "average_total_tokens": mean_metric("average_total_tokens"),
+                "average_ai_credits": mean_metric("average_ai_credits"),
             }
         )
 

--- a/src/bcbench/results/leaderboard.py
+++ b/src/bcbench/results/leaderboard.py
@@ -163,9 +163,9 @@ class CodeReviewLeaderboardAggregate(JudgeBasedLeaderboardAggregate):
         cr_runs: list[CodeReviewResultSummary] = [run for run in runs if isinstance(run, CodeReviewResultSummary)]
         n = len(cr_runs)
 
-        def mean_metric(name: str) -> float | None:
-            values = [value for run in cr_runs if (value := getattr(run, name)) is not None]
-            return sum(values) / len(values) if values else None
+        def mean_metric(values: Sequence[float | None]) -> float | None:
+            available = [value for value in values if value is not None]
+            return sum(available) / len(available) if available else None
 
         # The micro headline pools every comment across the dataset, so there is no per-task
         # decomposition to resample; its CI is intentionally over run-level means and captures
@@ -195,10 +195,10 @@ class CodeReviewLeaderboardAggregate(JudgeBasedLeaderboardAggregate):
                 "macro_precision": sum(r.macro_precision for r in cr_runs) / n,
                 "macro_recall": sum(r.macro_recall for r in cr_runs) / n,
                 "valid_review_output_rate": sum(r.valid_review_output_rate for r in cr_runs) / n,
-                "average_prompt_tokens": mean_metric("average_prompt_tokens"),
-                "average_completion_tokens": mean_metric("average_completion_tokens"),
-                "average_total_tokens": mean_metric("average_total_tokens"),
-                "average_ai_credits": mean_metric("average_ai_credits"),
+                "average_prompt_tokens": mean_metric([run.average_prompt_tokens for run in cr_runs]),
+                "average_completion_tokens": mean_metric([run.average_completion_tokens for run in cr_runs]),
+                "average_total_tokens": mean_metric([run.average_total_tokens for run in cr_runs]),
+                "average_ai_credits": mean_metric([run.average_ai_credits for run in cr_runs]),
             }
         )
 

--- a/src/bcbench/results/summary.py
+++ b/src/bcbench/results/summary.py
@@ -123,10 +123,9 @@ class EvaluationResultSummary(BaseModel, ABC):
     def to_dict(self) -> dict[str, Any]:
         data = self.model_dump(mode="json")
         data["average_duration"] = round(data["average_duration"], 1)
-        data["average_prompt_tokens"] = round(data["average_prompt_tokens"], 1)
-        data["average_completion_tokens"] = round(data["average_completion_tokens"], 1)
+        data["average_prompt_tokens"] = round(data["average_prompt_tokens"], 1) if data["average_prompt_tokens"] is not None else None
+        data["average_completion_tokens"] = round(data["average_completion_tokens"], 1) if data["average_completion_tokens"] is not None else None
         data["average_llm_duration"] = round(data["average_llm_duration"], 1) if data["average_llm_duration"] is not None else None
-        data["average_ai_credits"] = round(data["average_ai_credits"], 2) if data["average_ai_credits"] is not None else None
         return data
 
     def save(self, output_dir: Path, summary_file: str) -> None:

--- a/src/bcbench/types.py
+++ b/src/bcbench/types.py
@@ -6,8 +6,9 @@ from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Literal, TypedDict
+from urllib.parse import urlsplit
 
-from pydantic import BaseModel, ConfigDict, StringConstraints, model_validator
+from pydantic import BaseModel, ConfigDict, StringConstraints, computed_field, field_validator, model_validator
 
 if TYPE_CHECKING:
     from bcbench.dataset import BaseDatasetEntry
@@ -80,8 +81,62 @@ class AgentMetrics(BaseModel):
     prompt_tokens: int | None = None
     completion_tokens: int | None = None
 
+    total_tokens: int | None = None
+
     # Tool usage statistics from agent logs
     tool_usage: dict[str, int] | None = None
+
+
+class RepositoryProvenance(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    repository: str | None = None
+    ref: str | None = None
+    commit_sha: CommitSha | None = None
+    dirty: bool = False
+    content_hash: str | None = None
+    is_variant: bool = False
+
+    @field_validator("repository")
+    @classmethod
+    def _sanitize_repository(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+
+        without_metadata = value.split("?", 1)[0].split("#", 1)[0]
+        if "://" in without_metadata:
+            parsed = urlsplit(without_metadata)
+            path = parsed.path.strip("/")
+            if parsed.scheme == "file":
+                return path.replace("\\", "/").rsplit("/", 1)[-1]
+            return f"{parsed.hostname}/{path}" if parsed.hostname and path else parsed.hostname or path or None
+
+        if "@" in without_metadata and ":" in without_metadata.split("@", 1)[1]:
+            host, path = without_metadata.split("@", 1)[1].split(":", 1)
+            return f"{host}/{path.lstrip('/')}"
+
+        normalized = without_metadata.replace("\\", "/")
+        if normalized.startswith("/") or (len(normalized) >= 2 and normalized[1] == ":"):
+            return normalized.rstrip("/").rsplit("/", 1)[-1]
+        return normalized
+
+    @model_validator(mode="after")
+    def _require_dirty_content_hash(self) -> RepositoryProvenance:
+        if self.dirty and self.content_hash is None:
+            raise ValueError("Dirty repository provenance requires a content hash")
+        return self
+
+    @computed_field
+    @property
+    def display_name(self) -> str:
+        repository = self.repository.removesuffix(".git").replace("\\", "/") if self.repository else "local"
+        if repository.startswith("git@") and ":" in repository:
+            repository = repository.split(":", 1)[1]
+        elif "://" in repository or (repository.count("/") >= 2 and "." in repository.split("/", 1)[0]):
+            repository = "/".join(repository.rsplit("/", 2)[-2:])
+        revision = self.commit_sha[:8] if self.commit_sha else self.ref
+        suffix = f"+dirty.{self.content_hash[:8]}" if self.dirty and self.content_hash else "+dirty" if self.dirty else ""
+        return f"{repository}@{revision}{suffix}" if revision else f"{repository}{suffix}"
 
 
 class ExperimentConfiguration(BaseModel):
@@ -111,13 +166,39 @@ class ExperimentConfiguration(BaseModel):
     # Plugins loaded for this experiment: "<name>@<revision>" (github) or "<name>@local"
     plugins: list[str] | None = None
 
+    pr_review_engine: RepositoryProvenance | None = None
+    bcquality: RepositoryProvenance | None = None
+
+    @computed_field
+    @property
+    def is_experiment(self) -> bool:
+        return (
+            self.mcp_servers is not None
+            or self.al_lsp_enabled
+            or self.custom_instructions
+            or self.skills_enabled
+            or self.custom_agent is not None
+            or self.plugins is not None
+            or bool(self.pr_review_engine and (self.pr_review_engine.is_variant or self.pr_review_engine.dirty))
+            or bool(self.bcquality and (self.bcquality.is_variant or self.bcquality.dirty))
+        )
+
     def is_empty(self) -> bool:
         """Check if this configuration has all default/empty values.
 
         An empty configuration means no special experiment settings were used.
         This is useful for comparing with None (no experiment) vs default experiment.
         """
-        return self.mcp_servers is None and self.al_lsp_enabled is False and self.custom_instructions is False and self.skills_enabled is False and self.custom_agent is None and self.plugins is None
+        return (
+            self.mcp_servers is None
+            and self.al_lsp_enabled is False
+            and self.custom_instructions is False
+            and self.skills_enabled is False
+            and self.custom_agent is None
+            and self.plugins is None
+            and self.pr_review_engine is None
+            and self.bcquality is None
+        )
 
 
 # Where an agent plugin comes from: local, or cloned from GitHub
@@ -198,8 +279,16 @@ class AgentHarness(StrEnum):
                     completion_tokens=None,
                     tool_usage=None,
                 )
-            case AgentHarness.BCAL | AgentHarness.PR_REVIEW:
+            case AgentHarness.BCAL:
                 expected = AgentMetrics(execution_time=None)
+            case AgentHarness.PR_REVIEW:
+                expected = AgentMetrics(
+                    execution_time=None,
+                    prompt_tokens=None,
+                    completion_tokens=None,
+                    total_tokens=None,
+                    ai_credits=None,
+                )
             case _:
                 raise ValueError(f"Unknown AgentHarness: {self}")
 

--- a/src/bcbench/types.py
+++ b/src/bcbench/types.py
@@ -6,9 +6,8 @@ from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Literal, TypedDict
-from urllib.parse import urlsplit
 
-from pydantic import BaseModel, ConfigDict, StringConstraints, computed_field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, StringConstraints, model_validator
 
 if TYPE_CHECKING:
     from bcbench.dataset import BaseDatasetEntry
@@ -87,58 +86,6 @@ class AgentMetrics(BaseModel):
     tool_usage: dict[str, int] | None = None
 
 
-class RepositoryProvenance(BaseModel):
-    model_config = ConfigDict(frozen=True)
-
-    repository: str | None = None
-    ref: str | None = None
-    commit_sha: CommitSha | None = None
-    dirty: bool = False
-    content_hash: str | None = None
-    is_variant: bool = False
-
-    @field_validator("repository")
-    @classmethod
-    def _sanitize_repository(cls, value: str | None) -> str | None:
-        if value is None:
-            return None
-
-        without_metadata = value.split("?", 1)[0].split("#", 1)[0]
-        if "://" in without_metadata:
-            parsed = urlsplit(without_metadata)
-            path = parsed.path.strip("/")
-            if parsed.scheme == "file":
-                return path.replace("\\", "/").rsplit("/", 1)[-1]
-            return f"{parsed.hostname}/{path}" if parsed.hostname and path else parsed.hostname or path or None
-
-        if "@" in without_metadata and ":" in without_metadata.split("@", 1)[1]:
-            host, path = without_metadata.split("@", 1)[1].split(":", 1)
-            return f"{host}/{path.lstrip('/')}"
-
-        normalized = without_metadata.replace("\\", "/")
-        if normalized.startswith("/") or (len(normalized) >= 2 and normalized[1] == ":"):
-            return normalized.rstrip("/").rsplit("/", 1)[-1]
-        return normalized
-
-    @model_validator(mode="after")
-    def _require_dirty_content_hash(self) -> RepositoryProvenance:
-        if self.dirty and self.content_hash is None:
-            raise ValueError("Dirty repository provenance requires a content hash")
-        return self
-
-    @computed_field
-    @property
-    def display_name(self) -> str:
-        repository = self.repository.removesuffix(".git").replace("\\", "/") if self.repository else "local"
-        if repository.startswith("git@") and ":" in repository:
-            repository = repository.split(":", 1)[1]
-        elif "://" in repository or (repository.count("/") >= 2 and "." in repository.split("/", 1)[0]):
-            repository = "/".join(repository.rsplit("/", 2)[-2:])
-        revision = self.commit_sha[:8] if self.commit_sha else self.ref
-        suffix = f"+dirty.{self.content_hash[:8]}" if self.dirty and self.content_hash else "+dirty" if self.dirty else ""
-        return f"{repository}@{revision}{suffix}" if revision else f"{repository}{suffix}"
-
-
 class ExperimentConfiguration(BaseModel):
     """Configuration for agent experiment execution.
 
@@ -166,39 +113,13 @@ class ExperimentConfiguration(BaseModel):
     # Plugins loaded for this experiment: "<name>@<revision>" (github) or "<name>@local"
     plugins: list[str] | None = None
 
-    pr_review_engine: RepositoryProvenance | None = None
-    bcquality: RepositoryProvenance | None = None
-
-    @computed_field
-    @property
-    def is_experiment(self) -> bool:
-        return (
-            self.mcp_servers is not None
-            or self.al_lsp_enabled
-            or self.custom_instructions
-            or self.skills_enabled
-            or self.custom_agent is not None
-            or self.plugins is not None
-            or bool(self.pr_review_engine and (self.pr_review_engine.is_variant or self.pr_review_engine.dirty))
-            or bool(self.bcquality and (self.bcquality.is_variant or self.bcquality.dirty))
-        )
-
     def is_empty(self) -> bool:
         """Check if this configuration has all default/empty values.
 
         An empty configuration means no special experiment settings were used.
         This is useful for comparing with None (no experiment) vs default experiment.
         """
-        return (
-            self.mcp_servers is None
-            and self.al_lsp_enabled is False
-            and self.custom_instructions is False
-            and self.skills_enabled is False
-            and self.custom_agent is None
-            and self.plugins is None
-            and self.pr_review_engine is None
-            and self.bcquality is None
-        )
+        return self.mcp_servers is None and self.al_lsp_enabled is False and self.custom_instructions is False and self.skills_enabled is False and self.custom_agent is None and self.plugins is None
 
 
 # Where an agent plugin comes from: local, or cloned from GitHub

--- a/tests/test_evaluation_summary.py
+++ b/tests/test_evaluation_summary.py
@@ -226,6 +226,18 @@ class TestFromResults:
         assert summary.average_ai_credits is None
         assert summary.to_dict()["average_ai_credits"] is None
 
+    def test_to_dict_preserves_exact_ai_credit_precision(self):
+        result = create_bugfix_result(
+            instance_id="test__1",
+            project="app",
+            resolved=True,
+            metrics=AgentMetrics(execution_time=100.0, ai_credits=0.123456),
+        )
+
+        summary = ExecutionBasedEvaluationResultSummary.from_results([result], run_id="test_run_123")
+
+        assert summary.to_dict()["average_ai_credits"] == pytest.approx(0.123456)
+
     def test_from_results_calculates_average_tool_usage(self):
         results = [
             create_bugfix_result(

--- a/tests/test_experiment_configuration.py
+++ b/tests/test_experiment_configuration.py
@@ -1,6 +1,6 @@
 """Test ExperimentConfiguration dataclass."""
 
-from bcbench.types import ExperimentConfiguration
+from bcbench.types import ExperimentConfiguration, RepositoryProvenance
 
 
 class TestExperimentConfiguration:
@@ -102,3 +102,38 @@ class TestExperimentConfiguration:
 
         assert config.plugins == []
         assert not config.is_empty()
+
+    def test_repository_provenance_is_preserved_and_displayable(self):
+        provenance = RepositoryProvenance(
+            repository="https://github.com/microsoft/BC-ALAgents.git",
+            ref="feature",
+            commit_sha="a" * 40,
+            dirty=True,
+            content_hash="c" * 64,
+            is_variant=True,
+        )
+        config = ExperimentConfiguration(pr_review_engine=provenance)
+
+        assert not config.is_empty()
+        assert config.is_experiment
+        assert config.model_dump(mode="json")["pr_review_engine"]["display_name"] == "microsoft/BC-ALAgents@aaaaaaaa+dirty.cccccccc"
+
+    def test_clean_pinned_provenance_remains_a_baseline(self):
+        config = ExperimentConfiguration(
+            pr_review_engine=RepositoryProvenance(
+                repository="microsoft/BC-ALAgents",
+                commit_sha="a" * 40,
+            )
+        )
+
+        assert not config.is_empty()
+        assert not config.is_experiment
+
+    def test_repository_provenance_strips_remote_credentials(self):
+        provenance = RepositoryProvenance(
+            repository="https://user:secret@github.com/microsoft/BCQuality.git?token=secret#fragment",
+            commit_sha="a" * 40,
+        )
+
+        assert provenance.repository == "github.com/microsoft/BCQuality.git"
+        assert provenance.display_name == "microsoft/BCQuality@aaaaaaaa"

--- a/tests/test_experiment_configuration.py
+++ b/tests/test_experiment_configuration.py
@@ -1,6 +1,6 @@
 """Test ExperimentConfiguration dataclass."""
 
-from bcbench.types import ExperimentConfiguration, RepositoryProvenance
+from bcbench.types import ExperimentConfiguration
 
 
 class TestExperimentConfiguration:
@@ -102,38 +102,3 @@ class TestExperimentConfiguration:
 
         assert config.plugins == []
         assert not config.is_empty()
-
-    def test_repository_provenance_is_preserved_and_displayable(self):
-        provenance = RepositoryProvenance(
-            repository="https://github.com/microsoft/BC-ALAgents.git",
-            ref="feature",
-            commit_sha="a" * 40,
-            dirty=True,
-            content_hash="c" * 64,
-            is_variant=True,
-        )
-        config = ExperimentConfiguration(pr_review_engine=provenance)
-
-        assert not config.is_empty()
-        assert config.is_experiment
-        assert config.model_dump(mode="json")["pr_review_engine"]["display_name"] == "microsoft/BC-ALAgents@aaaaaaaa+dirty.cccccccc"
-
-    def test_clean_pinned_provenance_remains_a_baseline(self):
-        config = ExperimentConfiguration(
-            pr_review_engine=RepositoryProvenance(
-                repository="microsoft/BC-ALAgents",
-                commit_sha="a" * 40,
-            )
-        )
-
-        assert not config.is_empty()
-        assert not config.is_experiment
-
-    def test_repository_provenance_strips_remote_credentials(self):
-        provenance = RepositoryProvenance(
-            repository="https://user:secret@github.com/microsoft/BCQuality.git?token=secret#fragment",
-            commit_sha="a" * 40,
-        )
-
-        assert provenance.repository == "github.com/microsoft/BCQuality.git"
-        assert provenance.display_name == "microsoft/BCQuality@aaaaaaaa"

--- a/tests/test_pr_review_agent.py
+++ b/tests/test_pr_review_agent.py
@@ -5,9 +5,9 @@ from unittest.mock import patch
 
 import pytest
 
-from bcbench.agent.pr_review.agent import _write_review_json, run_pr_review_agent
+from bcbench.agent.pr_review.agent import _dirty_content_hash, _repository_provenance, _write_review_json, run_pr_review_agent
 from bcbench.exceptions import AgentError
-from bcbench.types import EvaluationCategory
+from bcbench.types import EvaluationCategory, RepositoryProvenance
 from tests.conftest import create_codereview_entry
 
 
@@ -21,6 +21,43 @@ def _dirs(tmp_path: Path) -> tuple[Path, Path]:
 
 def _write_output(output_dir: Path, text: str) -> None:
     (output_dir / "al-code-review-findings.json").write_text(text, encoding="utf-8")
+
+
+def test_repository_provenance_resolves_checkout_identity(tmp_path: Path) -> None:
+    with (
+        patch("bcbench.agent.pr_review.agent._git_output", side_effect=["a" * 40, "https://github.com/microsoft/BC-ALAgents.git", "feature", " M file"]),
+        patch("bcbench.agent.pr_review.agent._dirty_content_hash", return_value="c" * 64),
+    ):
+        provenance = _repository_provenance(tmp_path)
+
+    assert provenance is not None
+    assert provenance.repository == "github.com/microsoft/BC-ALAgents.git"
+    assert provenance.ref == "feature"
+    assert provenance.commit_sha == "a" * 40
+    assert provenance.dirty
+    assert provenance.content_hash == "c" * 64
+    assert provenance.is_variant
+
+
+def test_dirty_content_hash_distinguishes_working_tree_content(tmp_path: Path) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    (tmp_path / "tracked.txt").write_text("base", encoding="utf-8")
+    subprocess.run(["git", "add", "tracked.txt"], cwd=tmp_path, check=True)
+    subprocess.run(
+        ["git", "-c", "user.name=BC-Bench", "-c", "user.email=bcbench@example.com", "commit", "-qm", "base"],
+        cwd=tmp_path,
+        check=True,
+    )
+
+    (tmp_path / "tracked.txt").write_text("first", encoding="utf-8")
+    first = _dirty_content_hash(tmp_path)
+    subprocess.run(["git", "config", "color.ui", "always"], cwd=tmp_path, check=True)
+    assert _dirty_content_hash(tmp_path) == first
+
+    (tmp_path / "tracked.txt").write_text("second", encoding="utf-8")
+    second = _dirty_content_hash(tmp_path)
+
+    assert first != second
 
 
 def test_valid_empty_findings_is_a_clean_review(tmp_path: Path) -> None:
@@ -90,6 +127,38 @@ def test_engine_environment_uses_target_repository_and_absolute_paths(tmp_path: 
     }
     completed = subprocess.CompletedProcess(args=["pwsh"], returncode=0, stdout="✓", stderr="")
     entry = create_codereview_entry(repo="microsoft/BCApps")
+    bcquality_root = tmp_path / "bcquality"
+    knowledge_root = bcquality_root / "microsoft" / "knowledge" / "performance"
+    knowledge_root.mkdir(parents=True)
+    (knowledge_root / "one.md").write_text("# One", encoding="utf-8")
+    (bcquality_root / "_filter-report.json").write_text('{"removed": []}', encoding="utf-8")
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    (output_dir / "_run-metrics.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "metrics_source": "copilot-cli-otel",
+                "cli_version": "1.0.81-0",
+                "wall_time_seconds": 2.4,
+                "prompt_tokens": 100,
+                "cached_tokens": 20,
+                "cache_creation_tokens": 5,
+                "completion_tokens": 10,
+                "reasoning_tokens": 4,
+                "total_tokens": 110,
+                "api_calls": 2,
+                "failed_api_calls": 0,
+                "usage_api_calls": 2,
+                "ai_credits": 0.25,
+                "premium_requests": 0.5,
+                "models": ["gpt-5.6-luna"],
+                "usage_complete": True,
+                "malformed_records": 0,
+            }
+        ),
+        encoding="utf-8",
+    )
 
     with (
         patch("bcbench.agent.pr_review.agent._load_pr_review_settings", return_value=settings),
@@ -97,7 +166,14 @@ def test_engine_environment_uses_target_repository_and_absolute_paths(tmp_path: 
         patch("bcbench.agent.pr_review.agent._resolve_pwsh", return_value="pwsh"),
         patch("bcbench.agent.pr_review.agent._commit_patch_as_head"),
         patch("bcbench.agent.pr_review.agent._init_trusted_workspace", return_value=tmp_path / "trusted"),
-        patch("bcbench.agent.pr_review.agent._prepare_bcquality_root", return_value=tmp_path / "bcquality"),
+        patch("bcbench.agent.pr_review.agent._prepare_bcquality_root", return_value=bcquality_root),
+        patch(
+            "bcbench.agent.pr_review.agent._repository_provenance",
+            side_effect=[
+                RepositoryProvenance(repository="microsoft/BC-ALAgents", commit_sha="a" * 40),
+                RepositoryProvenance(repository="microsoft/BCQuality", commit_sha="b" * 40),
+            ],
+        ),
         patch("bcbench.agent.pr_review.agent._write_review_json", return_value=0),
         patch("bcbench.agent.pr_review.agent.time.monotonic", side_effect=[10.0, 12.5]),
         patch("bcbench.agent.pr_review.agent.subprocess.run", return_value=completed) as run_process,
@@ -113,7 +189,14 @@ def test_engine_environment_uses_target_repository_and_absolute_paths(tmp_path: 
 
     assert metrics is not None
     assert metrics.execution_time == 2.5
-    assert config.is_empty()
+    assert metrics.prompt_tokens == 100
+    assert metrics.completion_tokens == 10
+    assert metrics.total_tokens == 110
+    assert metrics.ai_credits == 0.25
+    assert config.pr_review_engine is not None
+    assert config.pr_review_engine.commit_sha == "a" * 40
+    assert config.bcquality is not None
+    assert config.bcquality.commit_sha == "b" * 40
     assert run_process.call_args.kwargs["encoding"] == "utf-8"
     assert run_process.call_args.kwargs["cwd"] == str((tmp_path / "repo").resolve())
     engine_env = run_process.call_args.kwargs["env"]

--- a/tests/test_pr_review_agent.py
+++ b/tests/test_pr_review_agent.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 import pytest
 
-from bcbench.agent.pr_review.agent import _prepare_bcquality_root, _prepare_pr_review_root, _write_review_json, run_pr_review_agent
+from bcbench.agent.pr_review.agent import _prepare_bcquality_root, _resolve_pr_review_root, _write_review_json, run_pr_review_agent
 from bcbench.exceptions import AgentError
 from bcbench.types import EvaluationCategory
 from tests.conftest import create_codereview_entry
@@ -23,29 +23,9 @@ def _write_output(output_dir: Path, text: str) -> None:
     (output_dir / "al-code-review-findings.json").write_text(text, encoding="utf-8")
 
 
-def test_prepare_pr_review_root_uses_local_checkout(tmp_path: Path) -> None:
-    with patch("bcbench.agent.pr_review.agent._resolve_pr_review_root", return_value=tmp_path) as resolve:
-        root = _prepare_pr_review_root("ignored/repo", "ignored-ref", tmp_path, tmp_path / "clone")
-
-    assert root == tmp_path
-    resolve.assert_called_once_with(tmp_path)
-
-
-def test_prepare_pr_review_root_clones_configured_revision(tmp_path: Path) -> None:
-    destination = tmp_path / "clone"
-    with (
-        patch("bcbench.agent.pr_review.agent.clone_repo_at_revision") as clone,
-        patch("bcbench.agent.pr_review.agent._resolve_pr_review_root", return_value=destination),
-    ):
-        root = _prepare_pr_review_root("microsoft/BC-ALAgents", "a" * 40, None, destination)
-
-    assert root == destination
-    clone.assert_called_once_with("microsoft/BC-ALAgents", "a" * 40, destination)
-
-
-def test_prepare_pr_review_root_requires_configured_source(tmp_path: Path) -> None:
-    with pytest.raises(AgentError, match="repo and ref must be configured"):
-        _prepare_pr_review_root(None, None, None, tmp_path / "clone")
+def test_resolve_pr_review_root_requires_engine_path() -> None:
+    with pytest.raises(AgentError, match="Pass --engine-path"):
+        _resolve_pr_review_root(None)
 
 
 def test_prepare_bcquality_root_ignores_ambient_overrides(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -136,10 +116,7 @@ def test_engine_environment_uses_target_repository_and_absolute_paths(tmp_path: 
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("GITHUB_REPOSITORY", "microsoft/BC-Bench")
     monkeypatch.setenv("BCQUALITY_REF", "ambient-override")
-    settings = {
-        "min_severity": "Medium",
-        "engine": {"repo": "microsoft/BC-ALAgents", "ref": "a" * 40},
-    }
+    settings = {"min_severity": "Medium"}
     completed = subprocess.CompletedProcess(args=["pwsh"], returncode=0, stdout="✓", stderr="")
     entry = create_codereview_entry(repo="microsoft/BCApps")
     bcquality_root = tmp_path / "bcquality"
@@ -177,7 +154,7 @@ def test_engine_environment_uses_target_repository_and_absolute_paths(tmp_path: 
 
     with (
         patch("bcbench.agent.pr_review.agent._load_pr_review_settings", return_value=settings),
-        patch("bcbench.agent.pr_review.agent._prepare_pr_review_root", return_value=tmp_path / "engine") as prepare_engine,
+        patch("bcbench.agent.pr_review.agent._resolve_pr_review_root", return_value=tmp_path / "engine") as resolve_engine,
         patch("bcbench.agent.pr_review.agent._resolve_pwsh", return_value="pwsh"),
         patch("bcbench.agent.pr_review.agent._commit_patch_as_head"),
         patch("bcbench.agent.pr_review.agent._init_trusted_workspace", return_value=tmp_path / "trusted"),
@@ -192,7 +169,7 @@ def test_engine_environment_uses_target_repository_and_absolute_paths(tmp_path: 
             category=EvaluationCategory.CODE_REVIEW,
             repo_path=tmp_path / "repo",
             output_dir=Path("output"),
-            engine_local_path=tmp_path / "engine",
+            engine_path=tmp_path / "engine",
         )
 
     assert metrics is not None
@@ -202,7 +179,7 @@ def test_engine_environment_uses_target_repository_and_absolute_paths(tmp_path: 
     assert metrics.total_tokens == 110
     assert metrics.ai_credits == 0.25
     assert config.is_empty()
-    prepare_engine.assert_called_once_with("microsoft/BC-ALAgents", "a" * 40, tmp_path / "engine", (tmp_path / "output" / "bc-alagents").resolve())
+    resolve_engine.assert_called_once_with(tmp_path / "engine")
     prepare_bcquality.assert_called_once_with(tmp_path / "engine", "pwsh", (tmp_path / "output" / "bcquality").resolve())
     assert run_process.call_args.kwargs["encoding"] == "utf-8"
     assert run_process.call_args.kwargs["cwd"] == str((tmp_path / "repo").resolve())

--- a/tests/test_pr_review_agent.py
+++ b/tests/test_pr_review_agent.py
@@ -5,9 +5,9 @@ from unittest.mock import patch
 
 import pytest
 
-from bcbench.agent.pr_review.agent import _dirty_content_hash, _repository_provenance, _write_review_json, run_pr_review_agent
+from bcbench.agent.pr_review.agent import _prepare_bcquality_root, _prepare_pr_review_root, _write_review_json, run_pr_review_agent
 from bcbench.exceptions import AgentError
-from bcbench.types import EvaluationCategory, RepositoryProvenance
+from bcbench.types import EvaluationCategory
 from tests.conftest import create_codereview_entry
 
 
@@ -23,41 +23,45 @@ def _write_output(output_dir: Path, text: str) -> None:
     (output_dir / "al-code-review-findings.json").write_text(text, encoding="utf-8")
 
 
-def test_repository_provenance_resolves_checkout_identity(tmp_path: Path) -> None:
+def test_prepare_pr_review_root_uses_local_checkout(tmp_path: Path) -> None:
+    with patch("bcbench.agent.pr_review.agent._resolve_pr_review_root", return_value=tmp_path) as resolve:
+        root = _prepare_pr_review_root("ignored/repo", "ignored-ref", tmp_path, tmp_path / "clone")
+
+    assert root == tmp_path
+    resolve.assert_called_once_with(tmp_path)
+
+
+def test_prepare_pr_review_root_clones_configured_revision(tmp_path: Path) -> None:
+    destination = tmp_path / "clone"
     with (
-        patch("bcbench.agent.pr_review.agent._git_output", side_effect=["a" * 40, "https://github.com/microsoft/BC-ALAgents.git", "feature", " M file"]),
-        patch("bcbench.agent.pr_review.agent._dirty_content_hash", return_value="c" * 64),
+        patch("bcbench.agent.pr_review.agent.clone_repo_at_revision") as clone,
+        patch("bcbench.agent.pr_review.agent._resolve_pr_review_root", return_value=destination),
     ):
-        provenance = _repository_provenance(tmp_path)
+        root = _prepare_pr_review_root("microsoft/BC-ALAgents", "a" * 40, None, destination)
 
-    assert provenance is not None
-    assert provenance.repository == "github.com/microsoft/BC-ALAgents.git"
-    assert provenance.ref == "feature"
-    assert provenance.commit_sha == "a" * 40
-    assert provenance.dirty
-    assert provenance.content_hash == "c" * 64
-    assert provenance.is_variant
+    assert root == destination
+    clone.assert_called_once_with("microsoft/BC-ALAgents", "a" * 40, destination)
 
 
-def test_dirty_content_hash_distinguishes_working_tree_content(tmp_path: Path) -> None:
-    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
-    (tmp_path / "tracked.txt").write_text("base", encoding="utf-8")
-    subprocess.run(["git", "add", "tracked.txt"], cwd=tmp_path, check=True)
-    subprocess.run(
-        ["git", "-c", "user.name=BC-Bench", "-c", "user.email=bcbench@example.com", "commit", "-qm", "base"],
-        cwd=tmp_path,
-        check=True,
-    )
+def test_prepare_pr_review_root_requires_configured_source(tmp_path: Path) -> None:
+    with pytest.raises(AgentError, match="repo and ref must be configured"):
+        _prepare_pr_review_root(None, None, None, tmp_path / "clone")
 
-    (tmp_path / "tracked.txt").write_text("first", encoding="utf-8")
-    first = _dirty_content_hash(tmp_path)
-    subprocess.run(["git", "config", "color.ui", "always"], cwd=tmp_path, check=True)
-    assert _dirty_content_hash(tmp_path) == first
 
-    (tmp_path / "tracked.txt").write_text("second", encoding="utf-8")
-    second = _dirty_content_hash(tmp_path)
+def test_prepare_bcquality_root_ignores_ambient_overrides(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BCQUALITY_REPO", "contoso/BCQuality")
+    monkeypatch.setenv("BCQUALITY_REF", "feature")
+    monkeypatch.setenv("BCQUALITY_CONFIG_PATH", "custom.yaml")
+    destination = tmp_path / "bcquality"
+    destination.mkdir()
+    completed = subprocess.CompletedProcess(args=["pwsh"], returncode=0, stdout=f"root={destination}", stderr="")
 
-    assert first != second
+    with patch("bcbench.agent.pr_review.agent.subprocess.run", return_value=completed) as run:
+        root = _prepare_bcquality_root(tmp_path / "engine", "pwsh", destination)
+
+    assert root == destination
+    child_env = run.call_args.kwargs["env"]
+    assert not any(name.startswith("BCQUALITY_") for name in child_env)
 
 
 def test_valid_empty_findings_is_a_clean_review(tmp_path: Path) -> None:
@@ -121,9 +125,10 @@ def test_failed_engine_outcome_raises_instead_of_clean_review(tmp_path: Path) ->
 def test_engine_environment_uses_target_repository_and_absolute_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("GITHUB_REPOSITORY", "microsoft/BC-Bench")
+    monkeypatch.setenv("BCQUALITY_REF", "ambient-override")
     settings = {
         "min_severity": "Medium",
-        "bcquality": {"repo": None, "ref": None},
+        "engine": {"repo": "microsoft/BC-ALAgents", "ref": "a" * 40},
     }
     completed = subprocess.CompletedProcess(args=["pwsh"], returncode=0, stdout="✓", stderr="")
     entry = create_codereview_entry(repo="microsoft/BCApps")
@@ -162,18 +167,11 @@ def test_engine_environment_uses_target_repository_and_absolute_paths(tmp_path: 
 
     with (
         patch("bcbench.agent.pr_review.agent._load_pr_review_settings", return_value=settings),
-        patch("bcbench.agent.pr_review.agent._resolve_pr_review_root", return_value=tmp_path / "engine"),
+        patch("bcbench.agent.pr_review.agent._prepare_pr_review_root", return_value=tmp_path / "engine") as prepare_engine,
         patch("bcbench.agent.pr_review.agent._resolve_pwsh", return_value="pwsh"),
         patch("bcbench.agent.pr_review.agent._commit_patch_as_head"),
         patch("bcbench.agent.pr_review.agent._init_trusted_workspace", return_value=tmp_path / "trusted"),
-        patch("bcbench.agent.pr_review.agent._prepare_bcquality_root", return_value=bcquality_root),
-        patch(
-            "bcbench.agent.pr_review.agent._repository_provenance",
-            side_effect=[
-                RepositoryProvenance(repository="microsoft/BC-ALAgents", commit_sha="a" * 40),
-                RepositoryProvenance(repository="microsoft/BCQuality", commit_sha="b" * 40),
-            ],
-        ),
+        patch("bcbench.agent.pr_review.agent._prepare_bcquality_root", return_value=bcquality_root) as prepare_bcquality,
         patch("bcbench.agent.pr_review.agent._write_review_json", return_value=0),
         patch("bcbench.agent.pr_review.agent.time.monotonic", side_effect=[10.0, 12.5]),
         patch("bcbench.agent.pr_review.agent.subprocess.run", return_value=completed) as run_process,
@@ -184,7 +182,7 @@ def test_engine_environment_uses_target_repository_and_absolute_paths(tmp_path: 
             category=EvaluationCategory.CODE_REVIEW,
             repo_path=tmp_path / "repo",
             output_dir=Path("output"),
-            engine_path=tmp_path / "engine",
+            engine_local_path=tmp_path / "engine",
         )
 
     assert metrics is not None
@@ -193,10 +191,9 @@ def test_engine_environment_uses_target_repository_and_absolute_paths(tmp_path: 
     assert metrics.completion_tokens == 10
     assert metrics.total_tokens == 110
     assert metrics.ai_credits == 0.25
-    assert config.pr_review_engine is not None
-    assert config.pr_review_engine.commit_sha == "a" * 40
-    assert config.bcquality is not None
-    assert config.bcquality.commit_sha == "b" * 40
+    assert config.is_empty()
+    prepare_engine.assert_called_once_with("microsoft/BC-ALAgents", "a" * 40, tmp_path / "engine", (tmp_path / "output" / "bc-alagents").resolve())
+    prepare_bcquality.assert_called_once_with(tmp_path / "engine", "pwsh", (tmp_path / "output" / "bcquality").resolve())
     assert run_process.call_args.kwargs["encoding"] == "utf-8"
     assert run_process.call_args.kwargs["cwd"] == str((tmp_path / "repo").resolve())
     engine_env = run_process.call_args.kwargs["env"]
@@ -204,6 +201,7 @@ def test_engine_environment_uses_target_repository_and_absolute_paths(tmp_path: 
     assert engine_env["REVIEW_OUTPUT_DIR"] == str((tmp_path / "output").resolve())
     assert engine_env["REVIEW_WORKSPACE"] == str(tmp_path / "trusted")
     assert engine_env["BCQUALITY_ROOT"] == str(tmp_path / "bcquality")
+    assert "BCQUALITY_REF" not in engine_env
     assert engine_env["GITHUB_REPOSITORY"] == "microsoft/BCApps"
     assert engine_env["AGENT_MINIMUM_SEVERITY"] == "Medium"
     assert run_process.call_args.args[0][-1].endswith("Invoke-CopilotPRReview.ps1")

--- a/tests/test_pr_review_agent.py
+++ b/tests/test_pr_review_agent.py
@@ -122,6 +122,16 @@ def test_failed_engine_outcome_raises_instead_of_clean_review(tmp_path: Path) ->
     assert not (repo / "review.json").exists()
 
 
+def test_not_applicable_engine_outcome_raises_instead_of_clean_review(tmp_path: Path) -> None:
+    out, repo = _dirs(tmp_path)
+    _write_output(out, json.dumps({"outcome": "not-applicable", "outcome-reason": "No AL files.", "findings": []}))
+
+    with pytest.raises(AgentError, match="must contain AL changes"):
+        _write_review_json(out, repo)
+
+    assert not (repo / "review.json").exists()
+
+
 def test_engine_environment_uses_target_repository_and_absolute_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("GITHUB_REPOSITORY", "microsoft/BC-Bench")

--- a/tests/test_pr_review_metrics.py
+++ b/tests/test_pr_review_metrics.py
@@ -154,7 +154,7 @@ def test_missing_run_metrics_key_raises(tmp_path: Path) -> None:
         build_pr_review_metrics(tmp_path, execution_time=1.0)
 
 
-def test_not_applicable_zero_shape_is_accepted(tmp_path: Path) -> None:
+def test_not_applicable_zero_shape_fails_evaluation(tmp_path: Path) -> None:
     _write_run_metrics(
         tmp_path,
         metrics_source="not-applicable",
@@ -176,13 +176,8 @@ def test_not_applicable_zero_shape_is_accepted(tmp_path: Path) -> None:
         malformed_records=0,
     )
 
-    metrics = build_pr_review_metrics(tmp_path, execution_time=0.25)
-
-    assert metrics.execution_time == 0.25
-    assert metrics.prompt_tokens == 0
-    assert metrics.completion_tokens == 0
-    assert metrics.total_tokens == 0
-    assert metrics.ai_credits == 0.0
+    with pytest.raises(AgentError, match="must contain AL changes"):
+        build_pr_review_metrics(tmp_path, execution_time=0.25)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_pr_review_metrics.py
+++ b/tests/test_pr_review_metrics.py
@@ -1,0 +1,225 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from bcbench.agent.pr_review.metrics import RUN_METRICS_FILE_NAME, build_pr_review_metrics
+from bcbench.exceptions import AgentError
+
+
+def _run_metrics(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "schema_version": 1,
+        "metrics_source": "copilot-cli-otel",
+        "cli_version": "1.0.81-0",
+        "wall_time_seconds": 12.346,
+        "prompt_tokens": 150,
+        "cached_tokens": 60,
+        "cache_creation_tokens": 10,
+        "completion_tokens": 28,
+        "reasoning_tokens": 7,
+        "total_tokens": 178,
+        "api_calls": 2,
+        "failed_api_calls": 1,
+        "usage_api_calls": 2,
+        "ai_credits": 1.75,
+        "premium_requests": 1.75,
+        "models": ["gpt-5.4-mini", "gpt-5.6-sol"],
+        "usage_complete": True,
+        "malformed_records": 0,
+    }
+    return {**payload, **overrides}
+
+
+def _write_run_metrics(root: Path, **overrides: object) -> None:
+    (root / RUN_METRICS_FILE_NAME).write_text(json.dumps(_run_metrics(**overrides)), encoding="utf-8")
+
+
+def test_build_metrics_promotes_public_performance_metrics(tmp_path: Path) -> None:
+    _write_run_metrics(tmp_path)
+
+    metrics = build_pr_review_metrics(tmp_path, execution_time=12.5)
+
+    assert metrics.execution_time == 12.5
+    assert metrics.prompt_tokens == 150
+    assert metrics.completion_tokens == 28
+    assert metrics.total_tokens == 178
+    assert metrics.ai_credits == 1.75
+
+
+def test_legal_null_optional_fields_and_multiple_models_are_accepted(tmp_path: Path) -> None:
+    _write_run_metrics(
+        tmp_path,
+        cli_version=None,
+        wall_time_seconds=None,
+        cached_tokens=None,
+        cache_creation_tokens=None,
+        reasoning_tokens=None,
+        ai_credits=None,
+        premium_requests=None,
+        models=["gpt-5.4-mini", "gpt-5.6-sol"],
+    )
+
+    metrics = build_pr_review_metrics(tmp_path, execution_time=2.0)
+
+    assert metrics.ai_credits is None
+    assert metrics.total_tokens == 178
+
+
+def test_malformed_records_suppress_all_usage_metrics(tmp_path: Path) -> None:
+    _write_run_metrics(
+        tmp_path,
+        prompt_tokens=25,
+        cached_tokens=None,
+        cache_creation_tokens=None,
+        completion_tokens=5,
+        total_tokens=30,
+        api_calls=2,
+        failed_api_calls=1,
+        usage_api_calls=1,
+        ai_credits=0.1,
+        reasoning_tokens=None,
+        premium_requests=None,
+        usage_complete=False,
+        malformed_records=3,
+    )
+
+    metrics = build_pr_review_metrics(tmp_path, execution_time=2.0)
+
+    assert metrics.prompt_tokens is None
+    assert metrics.completion_tokens is None
+    assert metrics.total_tokens is None
+    assert metrics.ai_credits is None
+
+
+def test_incomplete_usage_suppresses_tokens_but_preserves_exact_credits(tmp_path: Path) -> None:
+    _write_run_metrics(
+        tmp_path,
+        prompt_tokens=25,
+        completion_tokens=5,
+        total_tokens=30,
+        api_calls=2,
+        ai_credits=0.1,
+        usage_complete=False,
+        malformed_records=0,
+    )
+
+    metrics = build_pr_review_metrics(tmp_path, execution_time=2.0)
+
+    assert metrics.prompt_tokens is None
+    assert metrics.completion_tokens is None
+    assert metrics.total_tokens is None
+    assert metrics.ai_credits == 0.1
+
+
+def test_missing_run_metrics_raises(tmp_path: Path) -> None:
+    with pytest.raises(AgentError, match="run metrics artifact not found"):
+        build_pr_review_metrics(tmp_path, execution_time=1.0)
+
+
+def test_invalid_run_metrics_json_raises(tmp_path: Path) -> None:
+    (tmp_path / RUN_METRICS_FILE_NAME).write_text("not json", encoding="utf-8")
+
+    with pytest.raises(AgentError, match="Could not read engine run metrics artifact"):
+        build_pr_review_metrics(tmp_path, execution_time=1.0)
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"schema_version": 2},
+        {"metrics_source": "console-transcript"},
+        {"api_calls": "2"},
+        {"usage_complete": 1},
+        {"reasoning_tokens": "5"},
+        {"premium_requests": "1.0"},
+        {"cli_version": 79},
+        {"models": ["gpt-5.6-sol", 5]},
+        {"unexpected": "field"},
+    ],
+)
+def test_invalid_run_metrics_contract_raises(tmp_path: Path, overrides: dict[str, object]) -> None:
+    _write_run_metrics(tmp_path, **overrides)
+
+    with pytest.raises(AgentError, match="does not satisfy schema version 1"):
+        build_pr_review_metrics(tmp_path, execution_time=1.0)
+
+
+def test_missing_run_metrics_key_raises(tmp_path: Path) -> None:
+    payload = _run_metrics()
+    del payload["models"]
+    (tmp_path / RUN_METRICS_FILE_NAME).write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(AgentError, match="does not satisfy schema version 1"):
+        build_pr_review_metrics(tmp_path, execution_time=1.0)
+
+
+def test_not_applicable_zero_shape_is_accepted(tmp_path: Path) -> None:
+    _write_run_metrics(
+        tmp_path,
+        metrics_source="not-applicable",
+        cli_version=None,
+        wall_time_seconds=0,
+        prompt_tokens=0,
+        cached_tokens=0,
+        cache_creation_tokens=0,
+        completion_tokens=0,
+        reasoning_tokens=None,
+        total_tokens=0,
+        api_calls=0,
+        failed_api_calls=0,
+        usage_api_calls=0,
+        ai_credits=0.0,
+        premium_requests=None,
+        models=[],
+        usage_complete=True,
+        malformed_records=0,
+    )
+
+    metrics = build_pr_review_metrics(tmp_path, execution_time=0.25)
+
+    assert metrics.execution_time == 0.25
+    assert metrics.prompt_tokens == 0
+    assert metrics.completion_tokens == 0
+    assert metrics.total_tokens == 0
+    assert metrics.ai_credits == 0.0
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("cli_version", "1.0.79"),
+        ("wall_time_seconds", 1.0),
+        ("prompt_tokens", None),
+        ("reasoning_tokens", 0),
+        ("premium_requests", 0.0),
+        ("models", ["gpt-5.6-sol"]),
+        ("usage_complete", False),
+        ("malformed_records", 1),
+    ],
+)
+def test_not_applicable_rejects_noncanonical_shape(tmp_path: Path, field: str, value: object) -> None:
+    not_applicable = {
+        "metrics_source": "not-applicable",
+        "cli_version": None,
+        "wall_time_seconds": 0,
+        "prompt_tokens": 0,
+        "cached_tokens": 0,
+        "cache_creation_tokens": 0,
+        "completion_tokens": 0,
+        "reasoning_tokens": None,
+        "total_tokens": 0,
+        "api_calls": 0,
+        "failed_api_calls": 0,
+        "usage_api_calls": 0,
+        "ai_credits": 0.0,
+        "premium_requests": None,
+        "models": [],
+        "usage_complete": True,
+        "malformed_records": 0,
+        field: value,
+    }
+    _write_run_metrics(tmp_path, **not_applicable)
+
+    with pytest.raises(AgentError, match="not-applicable metrics have invalid fields"):
+        build_pr_review_metrics(tmp_path, execution_time=1.0)

--- a/tests/test_pr_review_metrics_reporting.py
+++ b/tests/test_pr_review_metrics_reporting.py
@@ -1,0 +1,131 @@
+import json
+
+from bcbench.results.codereview import CodeReviewResultSummary
+from bcbench.results.leaderboard import CodeReviewLeaderboardAggregate
+from bcbench.types import AgentMetrics
+from tests.conftest import create_codereview_result
+
+
+def _metrics(*, duration: float, scale: int) -> AgentMetrics:
+    return AgentMetrics(
+        execution_time=duration,
+        prompt_tokens=900 * scale,
+        completion_tokens=100 * scale,
+        total_tokens=1000 * scale,
+        ai_credits=0.5 * scale,
+    )
+
+
+def test_summary_aggregates_public_pr_review_metrics() -> None:
+    summary = CodeReviewResultSummary.from_results(
+        [
+            create_codereview_result(instance_id="proj__review-1", metrics=_metrics(duration=4.0, scale=1)),
+            create_codereview_result(instance_id="proj__review-2", metrics=_metrics(duration=6.0, scale=2)),
+        ],
+        run_id="run",
+    )
+
+    assert summary.average_duration == 5
+    assert summary.average_prompt_tokens == 1350
+    assert summary.average_completion_tokens == 150
+    assert summary.average_total_tokens == 1500
+    assert summary.average_ai_credits == 0.75
+    assert summary.valid_review_output_rate == 1.0
+
+
+def test_summary_preserves_unavailable_usage_as_none() -> None:
+    summary = CodeReviewResultSummary.from_results(
+        [create_codereview_result(metrics=AgentMetrics(execution_time=4.0))],
+        run_id="run",
+    )
+
+    serialized = summary.to_dict()
+
+    assert serialized["average_prompt_tokens"] is None
+    assert serialized["average_completion_tokens"] is None
+    assert serialized["average_total_tokens"] is None
+    assert serialized["average_ai_credits"] is None
+
+
+def test_leaderboard_propagates_public_pr_review_metrics() -> None:
+    first = CodeReviewResultSummary.from_results(
+        [create_codereview_result(instance_id="proj__review-1", metrics=_metrics(duration=4.0, scale=1))],
+        run_id="one",
+    )
+    second = CodeReviewResultSummary.from_results(
+        [create_codereview_result(instance_id="proj__review-1", metrics=_metrics(duration=6.0, scale=2))],
+        run_id="two",
+    )
+
+    aggregate = CodeReviewLeaderboardAggregate.from_runs([first, second])
+
+    assert aggregate.average_duration == 5
+    assert aggregate.average_prompt_tokens == 1350
+    assert aggregate.average_completion_tokens == 150
+    assert aggregate.average_total_tokens == 1500
+    assert aggregate.average_ai_credits == 0.75
+    assert aggregate.valid_review_output_rate == 1.0
+
+
+def test_github_summary_renders_only_public_performance_metrics() -> None:
+    summary = CodeReviewResultSummary.from_results(
+        [create_codereview_result(instance_id="proj__review-1", metrics=_metrics(duration=4.0, scale=1))],
+        run_id="run",
+    )
+
+    markdown = summary.render_github_metrics_markdown()
+
+    assert "## Performance" in markdown
+    assert "Avg prompt tokens" in markdown
+    assert "Avg completion tokens" in markdown
+    assert "Avg total tokens" in markdown
+    assert "Avg AI credits" in markdown
+    for diagnostic in ("API calls", "knowledge", "cached", "reasoning", "failed API", "usage", "premium", "malformed"):
+        assert diagnostic not in markdown
+
+
+def test_result_json_excludes_raw_only_diagnostics(tmp_path) -> None:
+    result = create_codereview_result(metrics=_metrics(duration=4.0, scale=1))
+    result.save(tmp_path, "results.jsonl")
+
+    saved_metrics = json.loads((tmp_path / "results.jsonl").read_text(encoding="utf-8"))["metrics"]
+
+    assert saved_metrics["prompt_tokens"] == 900
+    assert saved_metrics["completion_tokens"] == 100
+    assert saved_metrics["total_tokens"] == 1000
+    assert saved_metrics["ai_credits"] == 0.5
+    for diagnostic in (
+        "cached_tokens",
+        "cache_creation_tokens",
+        "reasoning_tokens",
+        "failed_api_calls",
+        "usage_api_calls",
+        "premium_requests",
+        "usage_complete",
+        "malformed_records",
+    ):
+        assert diagnostic not in saved_metrics
+
+
+def test_summary_and_leaderboard_schemas_exclude_raw_only_diagnostics() -> None:
+    summary = CodeReviewResultSummary.from_results(
+        [create_codereview_result(metrics=_metrics(duration=4.0, scale=1))],
+        run_id="run",
+    )
+    aggregate = CodeReviewLeaderboardAggregate.from_runs([summary])
+
+    for payload in (summary.model_dump(), aggregate.model_dump()):
+        for diagnostic in (
+            "average_cached_tokens",
+            "average_cache_creation_tokens",
+            "average_reasoning_tokens",
+            "average_api_calls",
+            "average_failed_api_calls",
+            "average_usage_api_calls",
+            "average_premium_requests",
+            "structured_usage_complete_rate",
+            "average_malformed_records",
+            "average_knowledge_files",
+            "average_knowledge_pruned",
+        ):
+            assert diagnostic not in payload

--- a/tests/test_result_writer.py
+++ b/tests/test_result_writer.py
@@ -3,7 +3,7 @@ from unittest.mock import PropertyMock, patch
 
 from bcbench.dataset.dataset_entry import BugFixEntry, _BugFixTestGenBase
 from bcbench.results.bceval_export import write_bceval_results
-from bcbench.types import AgentMetrics, EvaluationCategory, ExperimentConfiguration, RepositoryProvenance
+from bcbench.types import AgentMetrics, EvaluationCategory, ExperimentConfiguration
 from tests.conftest import VALID_INSTANCE_ID, create_bugfix_result
 
 
@@ -293,30 +293,3 @@ class TestWriteBcevalResults:
         assert data["metadata"]["experiment"]["al_lsp_enabled"] is True
         assert data["metadata"]["experiment"]["custom_instructions"] is True
         assert data["metadata"]["git_branch"] == "feat/al-mcp"
-
-    def test_provenance_only_run_remains_baseline(self, tmp_path, sample_dataset_file, problem_statement_dir):
-        output_dir = tmp_path / "output"
-        output_dir.mkdir()
-        provenance = RepositoryProvenance(repository="microsoft/BC-ALAgents", commit_sha="a" * 40)
-        result = create_bugfix_result(
-            metrics=AgentMetrics(execution_time=1.0),
-            experiment=ExperimentConfiguration(pr_review_engine=provenance),
-        )
-
-        with (
-            patch.object(_BugFixTestGenBase, "problem_statement_dir", property(lambda self: problem_statement_dir)),
-            patch.object(EvaluationCategory, "dataset_path", new_callable=PropertyMock, return_value=sample_dataset_file),
-        ):
-            write_bceval_results(
-                results=[result],
-                out_dir=output_dir,
-                run_id="run_provenance",
-                output_filename="results.jsonl",
-                category=EvaluationCategory.BUG_FIX,
-            )
-
-        with (output_dir / "results.jsonl").open() as f:
-            data = json.loads(f.readline())
-
-        assert data["metadata"]["EvalRunType"] == "baseline"
-        assert data["metadata"]["experiment"]["pr_review_engine"]["commit_sha"] == "a" * 40

--- a/tests/test_result_writer.py
+++ b/tests/test_result_writer.py
@@ -3,7 +3,7 @@ from unittest.mock import PropertyMock, patch
 
 from bcbench.dataset.dataset_entry import BugFixEntry, _BugFixTestGenBase
 from bcbench.results.bceval_export import write_bceval_results
-from bcbench.types import AgentMetrics, EvaluationCategory, ExperimentConfiguration
+from bcbench.types import AgentMetrics, EvaluationCategory, ExperimentConfiguration, RepositoryProvenance
 from tests.conftest import VALID_INSTANCE_ID, create_bugfix_result
 
 
@@ -293,3 +293,30 @@ class TestWriteBcevalResults:
         assert data["metadata"]["experiment"]["al_lsp_enabled"] is True
         assert data["metadata"]["experiment"]["custom_instructions"] is True
         assert data["metadata"]["git_branch"] == "feat/al-mcp"
+
+    def test_provenance_only_run_remains_baseline(self, tmp_path, sample_dataset_file, problem_statement_dir):
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+        provenance = RepositoryProvenance(repository="microsoft/BC-ALAgents", commit_sha="a" * 40)
+        result = create_bugfix_result(
+            metrics=AgentMetrics(execution_time=1.0),
+            experiment=ExperimentConfiguration(pr_review_engine=provenance),
+        )
+
+        with (
+            patch.object(_BugFixTestGenBase, "problem_statement_dir", property(lambda self: problem_statement_dir)),
+            patch.object(EvaluationCategory, "dataset_path", new_callable=PropertyMock, return_value=sample_dataset_file),
+        ):
+            write_bceval_results(
+                results=[result],
+                out_dir=output_dir,
+                run_id="run_provenance",
+                output_filename="results.jsonl",
+                category=EvaluationCategory.BUG_FIX,
+            )
+
+        with (output_dir / "results.jsonl").open() as f:
+            data = json.loads(f.readline())
+
+        assert data["metadata"]["EvalRunType"] == "baseline"
+        assert data["metadata"]["experiment"]["pr_review_engine"]["commit_sha"] == "a" * 40

--- a/tests/test_review_runners.py
+++ b/tests/test_review_runners.py
@@ -77,11 +77,7 @@ def test_pr_review_evaluation_is_fixed_to_runner_and_category(tmp_path: Path) ->
                 str(tmp_path / "out"),
                 "--run-id",
                 "pr-review",
-                "--engine-repo",
-                "contoso/BC-ALAgents",
-                "--engine-ref",
-                "feature",
-                "--engine-local-path",
+                "--engine-path",
                 str(tmp_path),
             ],
         )
@@ -91,9 +87,7 @@ def test_pr_review_evaluation_is_fixed_to_runner_and_category(tmp_path: Path) ->
     assert contexts[0].agent_name is AgentHarness.PR_REVIEW
     assert contexts[0].category is EvaluationCategory.CODE_REVIEW
     assert contexts[0].model == "gpt-5.6-luna"
-    assert agent_runner.call_args.kwargs["engine_repo"] == "contoso/BC-ALAgents"
-    assert agent_runner.call_args.kwargs["engine_ref"] == "feature"
-    assert agent_runner.call_args.kwargs["engine_local_path"] == tmp_path
+    assert agent_runner.call_args.kwargs["engine_path"] == tmp_path
 
 
 def test_pr_review_run_is_fixed_to_code_review(tmp_path: Path) -> None:
@@ -113,11 +107,7 @@ def test_pr_review_run_is_fixed_to_code_review(tmp_path: Path) -> None:
                 str(tmp_path),
                 "--output-dir",
                 str(tmp_path / "out"),
-                "--engine-repo",
-                "contoso/BC-ALAgents",
-                "--engine-ref",
-                "feature",
-                "--engine-local-path",
+                "--engine-path",
                 str(tmp_path),
             ],
         )
@@ -126,9 +116,7 @@ def test_pr_review_run_is_fixed_to_code_review(tmp_path: Path) -> None:
     assert agent_runner.call_args.kwargs["entry"] is entry
     assert agent_runner.call_args.kwargs["category"] is EvaluationCategory.CODE_REVIEW
     assert agent_runner.call_args.kwargs["model"] == "gpt-5.6-luna"
-    assert agent_runner.call_args.kwargs["engine_repo"] == "contoso/BC-ALAgents"
-    assert agent_runner.call_args.kwargs["engine_ref"] == "feature"
-    assert agent_runner.call_args.kwargs["engine_local_path"] == tmp_path
+    assert agent_runner.call_args.kwargs["engine_path"] == tmp_path
 
 
 def test_pr_review_is_public_command() -> None:

--- a/tests/test_review_runners.py
+++ b/tests/test_review_runners.py
@@ -77,9 +77,11 @@ def test_pr_review_evaluation_is_fixed_to_runner_and_category(tmp_path: Path) ->
                 str(tmp_path / "out"),
                 "--run-id",
                 "pr-review",
-                "--engine-path",
-                str(tmp_path),
-                "--bcquality-local-path",
+                "--engine-repo",
+                "contoso/BC-ALAgents",
+                "--engine-ref",
+                "feature",
+                "--engine-local-path",
                 str(tmp_path),
             ],
         )
@@ -89,8 +91,9 @@ def test_pr_review_evaluation_is_fixed_to_runner_and_category(tmp_path: Path) ->
     assert contexts[0].agent_name is AgentHarness.PR_REVIEW
     assert contexts[0].category is EvaluationCategory.CODE_REVIEW
     assert contexts[0].model == "gpt-5.6-luna"
-    assert agent_runner.call_args.kwargs["engine_path"] == tmp_path
-    assert agent_runner.call_args.kwargs["bcquality_local_path"] == tmp_path
+    assert agent_runner.call_args.kwargs["engine_repo"] == "contoso/BC-ALAgents"
+    assert agent_runner.call_args.kwargs["engine_ref"] == "feature"
+    assert agent_runner.call_args.kwargs["engine_local_path"] == tmp_path
 
 
 def test_pr_review_run_is_fixed_to_code_review(tmp_path: Path) -> None:
@@ -110,9 +113,11 @@ def test_pr_review_run_is_fixed_to_code_review(tmp_path: Path) -> None:
                 str(tmp_path),
                 "--output-dir",
                 str(tmp_path / "out"),
-                "--engine-path",
-                str(tmp_path),
-                "--bcquality-local-path",
+                "--engine-repo",
+                "contoso/BC-ALAgents",
+                "--engine-ref",
+                "feature",
+                "--engine-local-path",
                 str(tmp_path),
             ],
         )
@@ -121,8 +126,9 @@ def test_pr_review_run_is_fixed_to_code_review(tmp_path: Path) -> None:
     assert agent_runner.call_args.kwargs["entry"] is entry
     assert agent_runner.call_args.kwargs["category"] is EvaluationCategory.CODE_REVIEW
     assert agent_runner.call_args.kwargs["model"] == "gpt-5.6-luna"
-    assert agent_runner.call_args.kwargs["engine_path"] == tmp_path
-    assert agent_runner.call_args.kwargs["bcquality_local_path"] == tmp_path
+    assert agent_runner.call_args.kwargs["engine_repo"] == "contoso/BC-ALAgents"
+    assert agent_runner.call_args.kwargs["engine_ref"] == "feature"
+    assert agent_runner.call_args.kwargs["engine_local_path"] == tmp_path
 
 
 def test_pr_review_is_public_command() -> None:

--- a/tests/test_review_workflows.py
+++ b/tests/test_review_workflows.py
@@ -4,6 +4,7 @@ import yaml
 
 WORKFLOWS = Path(__file__).parents[1] / ".github" / "workflows"
 ACTIONS = Path(__file__).parents[1] / ".github" / "actions"
+AGENT_CONFIG = Path(__file__).parents[1] / "src" / "bcbench" / "agent" / "shared" / "config.yaml"
 
 
 def _workflow(name: str) -> str:
@@ -32,13 +33,17 @@ def test_claude_workflow_routes_code_review_through_claude() -> None:
 
 def test_pr_review_workflow_is_fixed_to_code_review() -> None:
     workflow = _workflow("pr-review-evaluation.yml")
+    config = yaml.safe_load(AGENT_CONFIG.read_text(encoding="utf-8"))
 
     assert "category: code-review" in workflow
     assert "bcbench evaluate pr-review" in workflow
-    assert "repository: microsoft/BC-ALAgents" in workflow
-    assert "533dd39dfe29218c09e5e31c39c78bb72fa20aa2" in workflow
-    assert "ref: main" not in workflow
-    assert '--engine-path "${{ github.workspace }}/bc-alagents-engine"' in workflow
+    assert "Checkout BC-ALAgents review engine" not in workflow
+    assert "--engine-local-path" not in workflow
+    assert "GH_TOKEN: ${{ github.token }}" in workflow
+    assert config["pr_review"]["engine"] == {
+        "repo": "microsoft/BC-ALAgents",
+        "ref": "533dd39dfe29218c09e5e31c39c78bb72fa20aa2",
+    }
     assert "BC_PR_REVIEW_ROOT:" not in workflow
     assert "install-agent-harnesses" in workflow
     assert "install-eval-clis" not in workflow

--- a/tests/test_review_workflows.py
+++ b/tests/test_review_workflows.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import yaml
 
 WORKFLOWS = Path(__file__).parents[1] / ".github" / "workflows"
+ACTIONS = Path(__file__).parents[1] / ".github" / "actions"
 
 
 def _workflow(name: str) -> str:
@@ -35,7 +36,7 @@ def test_pr_review_workflow_is_fixed_to_code_review() -> None:
     assert "category: code-review" in workflow
     assert "bcbench evaluate pr-review" in workflow
     assert "repository: microsoft/BC-ALAgents" in workflow
-    assert "f2ac8704bf8d39000f8002bcf2d287f1f5b5e9ba" in workflow
+    assert "533dd39dfe29218c09e5e31c39c78bb72fa20aa2" in workflow
     assert "ref: main" not in workflow
     assert '--engine-path "${{ github.workspace }}/bc-alagents-engine"' in workflow
     assert "BC_PR_REVIEW_ROOT:" not in workflow
@@ -47,3 +48,9 @@ def test_pr_review_workflow_is_fixed_to_code_review() -> None:
     assert "mai-code-1-flash-picker" not in workflow
     for input_name in ("model:", "test-run:", "repeat:", "git-ref:"):
         assert input_name in workflow
+
+
+def test_agent_harness_action_pins_published_copilot_version() -> None:
+    action = (ACTIONS / "install-agent-harnesses" / "action.yml").read_text(encoding="utf-8")
+
+    assert "@github/copilot@1.0.80" in action

--- a/tests/test_review_workflows.py
+++ b/tests/test_review_workflows.py
@@ -38,12 +38,8 @@ def test_pr_review_workflow_is_fixed_to_code_review() -> None:
     assert "category: code-review" in workflow
     assert "bcbench evaluate pr-review" in workflow
     assert "Checkout BC-ALAgents review engine" not in workflow
-    assert "--engine-local-path" not in workflow
-    assert "GH_TOKEN: ${{ github.token }}" in workflow
-    assert config["pr_review"]["engine"] == {
-        "repo": "microsoft/BC-ALAgents",
-        "ref": "533dd39dfe29218c09e5e31c39c78bb72fa20aa2",
-    }
+    assert '--engine-path "${{ steps.install-harnesses.outputs.bc-alagents-path }}"' in workflow
+    assert config["pr_review"] == {"min_severity": "Medium"}
     assert "BC_PR_REVIEW_ROOT:" not in workflow
     assert "install-agent-harnesses" in workflow
     assert "install-eval-clis" not in workflow
@@ -59,3 +55,11 @@ def test_agent_harness_action_pins_published_copilot_version() -> None:
     action = (ACTIONS / "install-agent-harnesses" / "action.yml").read_text(encoding="utf-8")
 
     assert "@github/copilot@1.0.80" in action
+
+
+def test_agent_harness_action_pins_and_exports_bc_alagents() -> None:
+    action = (ACTIONS / "install-agent-harnesses" / "action.yml").read_text(encoding="utf-8")
+
+    assert "repository: microsoft/BC-ALAgents" in action
+    assert "ref: 533dd39dfe29218c09e5e31c39c78bb72fa20aa2" in action
+    assert "bc-alagents-path:" in action


### PR DESCRIPTION
## What & why

Adds performance telemetry for the dedicated BC PR Review evaluation runner without replacing the engine's raw diagnostic artifact.

## Changes

- Strictly validates the complete BC-ALAgents schema-v1 `_run-metrics.json` artifact, including source, field presence, types, and the canonical no-AL shape.
- Promotes the original BC-Bench performance surface: monotonic execution time, prompt/completion/total tokens, actual model API calls, exact AI credits, and BCQuality knowledge retained/pruned counts.
- Keeps producer-only diagnostics such as cache/reasoning breakdowns, failed/usage-call counts, premium requests, completeness, and malformed-record counts in the raw artifact rather than public result and leaderboard schemas.
- Suppresses all usage-derived public values when malformed records make coverage unknowable. When token usage is incomplete but structurally well formed, suppresses token totals while retaining independently exact API-call and AI-credit values.
- Aggregates the public fields in Code Review summaries and leaderboards and displays them in GitHub, console, and dashboard performance views.
- Uses the shared `AgentMetrics.ai_credits` field introduced on `main` and preserves full precision through summary persistence.
- Keeps the BC-ALAgents producer pinned to `533dd39dfe29218c09e5e31c39c78bb72fa20aa2`.
- Intentionally pins `@github/copilot` to `1.0.79`: `1.0.80` is not published to npm, and `1.0.79` is the version whose structured telemetry contract was validated.

## Validation

- Ruff format and lint
- `ty check . --ignore=unresolved-import --exclude notebooks/`
- Focused PR Review telemetry tests
- 781 tests passed, 2 skipped
- `pre-commit run --all-files`

AB#645219