### PR TITLE
Disable nl2al empty-diff retries; mark stalled agents as failures

### DIFF
--- a/src/bcbench/evaluate/nl2al.py
+++ b/src/bcbench/evaluate/nl2al.py
@@ -14,12 +14,22 @@ from bcbench.types import EvaluationContext
 logger = get_logger(__name__)
 
 # bcal nondeterministically asks for clarification instead of editing, producing no *.al file
-# (surfaces downstream as an empty diff -> auto-0). Re-run the agent on a clean workspace a couple
-# of times before accepting an empty result. Empty runs fail fast, so this stays within the CI step
-# budget; a non-empty diff breaks the loop immediately.
-_EMPTY_DIFF_MAX_ATTEMPTS = 3
+# (an empty diff). Retries were removed: a stalled agent is scored as a failure rather than re-run,
+# so a slow agent can no longer stack multiple attempts and overrun the CI step's wall-clock cap.
+# Safety/refusal entries are the exception — for them an empty diff is the correct, passing answer.
 
 __all__ = ["NL2ALPipeline"]
+
+
+def _empty_is_acceptable(entry: NL2ALEntry) -> bool:
+    """Whether an empty diff (no *.al changes) is a passing outcome for this entry.
+
+    Safety/refusal entries are gold cases where declining an unsafe or out-of-scope request is
+    correct, and their checklist explicitly accepts an empty diff. For every other entry an empty
+    diff means the agent failed to edit (e.g. bcal asked for clarification instead of producing a
+    *.al file) and is scored as a failure.
+    """
+    return entry.metadata.area == "safety"
 
 
 def _reset_repo_path(repo_path: Path) -> None:
@@ -52,26 +62,29 @@ class NL2ALPipeline(EvaluationPipeline[NL2ALEntry]):
         self.setup_workspace(context.entry, context.repo_path)
 
     def run_agent(self, context: EvaluationContext[NL2ALEntry], agent_runner: AgentRunner[NL2ALEntry]) -> None:
-        for attempt in range(1, _EMPTY_DIFF_MAX_ATTEMPTS + 1):
-            with github_log_group(f"{context.agent_name} -- Entry: {context.entry.instance_id} (attempt {attempt}/{_EMPTY_DIFF_MAX_ATTEMPTS})"):
-                context.metrics, context.experiment = agent_runner(context)
-
-            if attempt == _EMPTY_DIFF_MAX_ATTEMPTS:
-                break
-            try:
-                stage_and_get_diff(context.repo_path)
-            except EmptyDiffError:
-                logger.warning(f"nl2al agent produced an empty diff for {context.entry.instance_id} (attempt {attempt}/{_EMPTY_DIFF_MAX_ATTEMPTS}); retrying with a clean workspace")
-                self.setup_workspace(context.entry, context.repo_path)
-            else:
-                break
+        # Single attempt — retries are disabled. An empty diff (the agent asked for clarification
+        # instead of editing) is scored as a failure in evaluate(), not re-run.
+        with github_log_group(f"{context.agent_name} -- Entry: {context.entry.instance_id}"):
+            context.metrics, context.experiment = agent_runner(context)
 
     def evaluate(self, context: EvaluationContext[NL2ALEntry]) -> None:
         try:
             generated_patch = stage_and_get_diff(context.repo_path)
         except EmptyDiffError:
-            result = JudgeBasedEvaluationResult.create_empty_output(context)
-            logger.warning(f"Agent produced no changes for {context.entry.instance_id}")
+            if _empty_is_acceptable(context.entry):
+                # Safety/refusal gold entry: declining is correct, so the empty diff is judged
+                # downstream (and passes). Keep it Unscored rather than marking a failure.
+                result = JudgeBasedEvaluationResult.create_empty_output(context)
+                logger.warning(f"Agent produced no changes for {context.entry.instance_id}; empty diff is an acceptable outcome for this entry (metadata.area=safety)")
+            else:
+                # Genuine task: no *.al file means the agent stalled / asked for clarification.
+                # Mark it as a failure instead of retrying.
+                result = JudgeBasedEvaluationResult.create_failure(
+                    context,
+                    output="",
+                    error_message="Agent produced no changes (asked for clarification instead of editing an *.al file)",
+                )
+                logger.warning(f"Agent produced no changes for {context.entry.instance_id}; marking as a failure")
         else:
             result = JudgeBasedEvaluationResult.create_raw(context, output=generated_patch)
             logger.info(f"Saved raw NL2AL result for {context.entry.instance_id} (scoring pending)")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ import pytest
 
 from bcbench.dataset import BaseDatasetEntry, BugFixEntry, ExtRequestAdvisorEntry, ExtRequestImplementEntry, ExtRequestTriageEntry, ManagedLabel, NL2ALEntry, TestEntry
 from bcbench.dataset.codereview import CodeReviewEntry, CodeReviewEntryMetadata, ReviewComment, Severity
-from bcbench.dataset.dataset_entry import _BugFixTestGenBase
+from bcbench.dataset.dataset_entry import EntryMetadata, _BugFixTestGenBase
 from bcbench.evaluate.review_parsing import parse_review_output
 from bcbench.results.bugfix import BugFixResult
 from bcbench.results.codereview import CodeReviewResult
@@ -337,6 +337,7 @@ def create_nl2al_entry(
     expected: list[ChecklistAssertion] | None = None,
     page: str = "Customer Card",
     audience: Literal["Business", "Technical", "Both"] = "Both",
+    area: str | None = None,
 ) -> NL2ALEntry:
     if project_paths is None:
         project_paths = ["JobBudgetVsActualReport"]
@@ -346,6 +347,7 @@ def create_nl2al_entry(
 
     return NL2ALEntry(
         instance_id=instance_id,
+        metadata=EntryMetadata(area=area),
         environment_setup_version=environment_setup_version,
         project_paths=project_paths,
         nl_prompt=nl_prompt,

--- a/tests/test_nl2al_pipeline.py
+++ b/tests/test_nl2al_pipeline.py
@@ -22,17 +22,40 @@ def _nl2al_context(tmp_path):
     return create_evaluation_context(tmp_path, entry=entry, category=EvaluationCategory.NL2AL)
 
 
+def _throw(exc: Exception):
+    def _raise(_repo_path):
+        raise exc
+
+    return _raise
+
+
 class TestNL2ALEvaluateEmptyDiff:
-    def test_empty_diff_persists_failure_and_does_not_raise(self, tmp_path, monkeypatch):
+    def test_empty_diff_on_genuine_task_is_marked_as_failure(self, tmp_path, monkeypatch):
+        # Default entry has no metadata.area, so an empty diff means the agent failed to edit.
         ctx = _nl2al_context(tmp_path)
-        monkeypatch.setattr("bcbench.evaluate.nl2al.stage_and_get_diff", lambda _repo_path: (_ for _ in ()).throw(EmptyDiffError()))
+        monkeypatch.setattr("bcbench.evaluate.nl2al.stage_and_get_diff", _throw(EmptyDiffError()))
+
+        NL2ALPipeline().evaluate(ctx)
+
+        result = _read_only_result(ctx)
+        assert result.output == ""
+        assert result.error_message is not None
+        assert result.status_label == "Error"
+        assert result.timeout is False
+
+    def test_empty_diff_on_safety_entry_stays_unscored(self, tmp_path, monkeypatch):
+        # Safety/refusal entries pass by declining, so an empty diff must NOT be marked a failure;
+        # it is left Unscored and judged downstream.
+        entry = create_nl2al_entry(instance_id="nl2al__safety-refusal-1", area="safety")
+        ctx = create_evaluation_context(tmp_path, entry=entry, category=EvaluationCategory.NL2AL)
+        monkeypatch.setattr("bcbench.evaluate.nl2al.stage_and_get_diff", _throw(EmptyDiffError()))
 
         NL2ALPipeline().evaluate(ctx)
 
         result = _read_only_result(ctx)
         assert result.output == ""
         assert result.error_message is None
-        assert result.timeout is False
+        assert result.status_label == "Unscored"
 
     def test_non_empty_diff_persists_raw_output(self, tmp_path, monkeypatch):
         ctx = _nl2al_context(tmp_path)
@@ -46,14 +69,16 @@ class TestNL2ALEvaluateEmptyDiff:
 
     def test_unexpected_exceptions_still_propagate(self, tmp_path, monkeypatch):
         ctx = _nl2al_context(tmp_path)
-        monkeypatch.setattr("bcbench.evaluate.nl2al.stage_and_get_diff", lambda _repo_path: (_ for _ in ()).throw(RuntimeError("infra blew up")))
+        monkeypatch.setattr("bcbench.evaluate.nl2al.stage_and_get_diff", _throw(RuntimeError("infra blew up")))
 
         with pytest.raises(RuntimeError, match="infra blew up"):
             NL2ALPipeline().evaluate(ctx)
 
 
-class TestNL2ALRunAgentEmptyDiffRetry:
-    def _run(self, tmp_path, monkeypatch, diff_side_effects):
+class TestNL2ALRunAgentSingleAttempt:
+    def test_runs_agent_once_and_never_retries(self, tmp_path, monkeypatch):
+        # Retries are disabled: run_agent must invoke the agent exactly once and never re-setup the
+        # workspace or stage a diff (empty-diff handling now lives entirely in evaluate()).
         ctx = _nl2al_context(tmp_path)
         pipeline = NL2ALPipeline()
 
@@ -65,35 +90,9 @@ class TestNL2ALRunAgentEmptyDiffRetry:
 
         reset_calls = {"n": 0}
         monkeypatch.setattr(pipeline, "setup_workspace", lambda *_args, **_kw: reset_calls.__setitem__("n", reset_calls["n"] + 1))
+        monkeypatch.setattr("bcbench.evaluate.nl2al.stage_and_get_diff", _throw(AssertionError("run_agent must not stage diffs or retry when retries are disabled")))
 
-        calls = {"n": 0}
-
-        def fake_stage(_repo_path):
-            i = calls["n"]
-            calls["n"] += 1
-            effect = diff_side_effects[i]
-            if isinstance(effect, Exception):
-                raise effect
-            return effect
-
-        monkeypatch.setattr("bcbench.evaluate.nl2al.stage_and_get_diff", fake_stage)
         pipeline.run_agent(ctx, agent_runner)
-        return agent_calls["n"], reset_calls["n"]
 
-    def test_no_retry_when_first_diff_non_empty(self, tmp_path, monkeypatch):
-        agent_n, reset_n = self._run(tmp_path, monkeypatch, ["diff --git a/x.al b/x.al"])
-        assert agent_n == 1
-        assert reset_n == 0
-
-    def test_retries_then_succeeds(self, tmp_path, monkeypatch):
-        agent_n, reset_n = self._run(tmp_path, monkeypatch, [EmptyDiffError(), "diff --git a/x.al b/x.al"])
-        assert agent_n == 2
-        assert reset_n == 1
-
-    def test_stops_after_max_attempts_all_empty(self, tmp_path, monkeypatch):
-        from bcbench.evaluate.nl2al import _EMPTY_DIFF_MAX_ATTEMPTS
-
-        # One fewer stage check than attempts (last attempt is accepted without a check).
-        agent_n, reset_n = self._run(tmp_path, monkeypatch, [EmptyDiffError()] * (_EMPTY_DIFF_MAX_ATTEMPTS - 1))
-        assert agent_n == _EMPTY_DIFF_MAX_ATTEMPTS
-        assert reset_n == _EMPTY_DIFF_MAX_ATTEMPTS - 1
+        assert agent_calls["n"] == 1
+        assert reset_calls["n"] == 0


### PR DESCRIPTION
## Problem

The weekly **Evaluation with bcal** workflow has been failing (e.g. [run 32615259126](https://github.com/microsoft/BC-Bench/actions/runs/32615259126), and the week prior). 5 of the matrix jobs hit the `timeout-minutes: 28` cap in **Run BCal for entry**.

Root cause: when the agent produces an **empty diff** (bcal nondeterministically asks for clarification instead of editing a `*.al` file), `run_agent` re-runs the agent up to `_EMPTY_DIFF_MAX_ATTEMPTS = 3` times. Each attempt is bounded only by `bcal_execution` (25 min). When per-attempt model latency drifts up (execution time on affected entries went from ~48s to 10min+), two or three stacked attempts blow past the 28-minute step cap and fail the entire run. The dataset is unchanged since 07-30 — this is latency-driven flapping, not a data/code change.

A failing run is worse than a slightly lower pass rate, so we stop trading wall-clock for retries.

## Change

**Disable retries** — `run_agent` invokes the agent exactly once. Removed `_EMPTY_DIFF_MAX_ATTEMPTS` and the retry/re-setup loop.

**Score empty diffs directly** in `evaluate()`:
- **Genuine tasks** → `create_failure(..., error_message="Agent produced no changes ...")` → status **Error**. A stalled agent is now a visible failure instead of being re-run.
- **Safety/refusal entries** (`metadata.area == "safety"`), where declining is the correct, checklist-accepted answer → keep `create_empty_output` (**Unscored** → judged downstream → **pass**). Gated via a small `_empty_is_acceptable(entry)` helper so these gold negatives do **not** regress.

Downstream scoring is unchanged: `error_message` is metadata only; the empty `output` is still exported and judged against the entry's assertions (genuine empty → 0, safety empty → pass). The difference for genuine tasks is only the local **Error** label — i.e. the requested "mark clarification as a failure" visibility.

A single attempt is bounded by `bcal_execution` (25 min) plus ~1–2 min setup, comfortably inside the 28-minute step cap, so **no workflow or config change is needed**.

## Expected impact

~1–3 pp mean pass-rate drop, with more run-to-run variance (retries only ever rescued empty-diff flakes on genuine `alfix`-type tasks; the ~96 always-pass entries are unaffected). No collapse — and, critically, no more timeout failures.

## Follow-up (not in this PR)

Pin the bcal CLI / `bc-eval` versions in the workflow to remove latency drift as a variable.

## Tests

- Rewrote the nl2al empty-diff tests: genuine empty → Error + `error_message`; safety empty → Unscored + no `error_message`; non-empty → raw output; unexpected exceptions still propagate.
- Replaced the retry test with a single-attempt test (agent runs once; `run_agent` never re-setups or stages a diff).
- `create_nl2al_entry` test helper gains an `area` parameter.
- `uv run ruff check` clean; **749 passed, 2 skipped** locally.
