### PR TITLE
Add common workspace handling and reproducibility guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,6 +140,8 @@ Keep evaluation tools pinned so benchmark runs remain reproducible. For example,
 3. Bump the BC-Bench version following the Versioning Policy
 4. Include the exact BC-ALAgents commit SHA in the BC-Bench release notes
 
+Comparison runs must use clean commits that can be fetched from the recorded remote. Local or dirty checkouts are for smoke tests only; a local SHA or content hash cannot recover their contents. Commit and push dependency changes before a full run.
+
 ### Create a new release
 
 After you bump the version in [pyproject.toml](https://github.com/microsoft/BC-Bench/blob/main/pyproject.toml#L7) following the Versioning Policy, use the repository's [`create-release` skill](.github/skills/create-release/SKILL.md) to prepare release notes after pushing your changes. The skill screens merged PRs since the previous version tag and returns Markdown covering only changes that may affect evaluation results, without creating the tag or release.

--- a/scripts/Setup-ContainerAndRepository.ps1
+++ b/scripts/Setup-ContainerAndRepository.ps1
@@ -72,7 +72,10 @@ if (-not $SkipRepo) {
     Invoke-GitCloneWithRetry -RepoUrl $cloneInfo.Url -Token $cloneInfo.Token -ClonePath $RepoPath -CommitSha $commitSha -SparseCheckoutPaths $cloneInfo.SparseCheckoutPaths
 }
 else {
-    Write-Log "Skipping repository clone (SkipRepo flag set)" -Level Info
+    # Categories that scaffold their own workspace still need the folder to exist: it is shared into
+    # the container below, and Compile-AppInBcContainer throws for any path not shared with it.
+    Write-Log "Skipping repository clone (SkipRepo flag set); creating empty workspace at $RepoPath" -Level Info
+    New-Item -ItemType Directory -Path $RepoPath -Force | Out-Null
 }
 
 if (-not $SkipContainer) {

--- a/src/bcbench/agent/shared/config.yaml
+++ b/src/bcbench/agent/shared/config.yaml
@@ -197,7 +197,8 @@ mcp:
 # the production orchestrator's complete local, non-posting path to measure BC PR Review
 # + BCQuality on the code-review category, including production parsing and filtering.
 # Generic Copilot and Claude runners use code-review-template above on the same category.
-# Engine and local BCQuality checkout paths are machine inputs supplied through CLI flags.
+# Dirty engine checkouts and local BCQuality paths are for smoke tests only.
+# Full comparison runs require clean commits available remotely.
 # BCQuality repo/ref remain experiment settings; repo supports testing forks while null values
 # use the engine's pinned content source. CLI flags override these values.
 pr_review:

--- a/src/bcbench/operations/__init__.py
+++ b/src/bcbench/operations/__init__.py
@@ -9,7 +9,7 @@ from bcbench.operations.bc_operations import (
     resolve_artifact_version_root,
     run_tests,
 )
-from bcbench.operations.filesystem_operations import remove_tree
+from bcbench.operations.filesystem_operations import clear_directory, remove_tree
 from bcbench.operations.git_operations import (
     apply_patch,
     checkout_commit,
@@ -40,6 +40,7 @@ __all__ = [
     "checkout_commit",
     "clean_project_paths",
     "clean_repo",
+    "clear_directory",
     "clone_repo_at_revision",
     "commit_changes",
     "copy_problem_statement_folder",

--- a/src/bcbench/operations/filesystem_operations.py
+++ b/src/bcbench/operations/filesystem_operations.py
@@ -18,3 +18,18 @@ def remove_tree(path: Path) -> None:
     Use when `shutil.rmtree` fails due to read-only files, which usually occur in secondary runs on Windows.
     """
     shutil.rmtree(path, onexc=_force_remove_readonly)
+
+
+def clear_directory(path: Path) -> None:
+    """
+    Remove everything inside a directory, leaving the directory itself in place.
+
+    Use instead of `remove_tree` when the directory should survive.
+    """
+    path.mkdir(parents=True, exist_ok=True)
+    for child in path.iterdir():
+        if child.is_dir():
+            remove_tree(child)
+        else:
+            child.chmod(stat.S_IWRITE)
+            child.unlink()

--- a/src/bcbench/types.py
+++ b/src/bcbench/types.py
@@ -52,6 +52,7 @@ class Checklist(TypedDict):
 type ExpectedOutput = str | Checklist
 
 # A full git commit SHA: branches and tags move, so only a SHA pins content reproducibly
+# Reproducible only when fetchable from the recorded remote
 type CommitSha = Annotated[str, StringConstraints(pattern=r"^[0-9a-fA-F]{40}$")]
 
 # A GitHub repository in "owner/repo" form

--- a/tests/test_filesystem_operations.py
+++ b/tests/test_filesystem_operations.py
@@ -1,0 +1,25 @@
+import stat
+
+from bcbench.operations import clear_directory
+
+
+def test_clear_directory_removes_contents_and_preserves_directory(tmp_path):
+    nested_directory = tmp_path / "nested"
+    nested_directory.mkdir()
+    (nested_directory / "nested.txt").write_text("nested", encoding="utf-8")
+    read_only_file = tmp_path / "read-only.txt"
+    read_only_file.write_text("content", encoding="utf-8")
+    read_only_file.chmod(stat.S_IREAD)
+
+    clear_directory(tmp_path)
+
+    assert tmp_path.is_dir()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_clear_directory_creates_missing_directory(tmp_path):
+    missing_directory = tmp_path / "missing"
+
+    clear_directory(missing_directory)
+
+    assert missing_directory.is_dir()


### PR DESCRIPTION
Identified some generic changes from #740 , ported them here so that PR is more focused

* Add reusable workspace cleanup and ensure skipped clones still create a shared directory

Improved documentation regarding commit sha now we bump into similar problems 2 times in a row
* Clarify that comparison runs require clean, remotely fetchable commits.
