### PR TITLE
Fix contamination output regex parsing

### DIFF
--- a/src/bcbench/commands/contamination.py
+++ b/src/bcbench/commands/contamination.py
@@ -69,7 +69,9 @@ def _build_markdown_report(results: list[FilePathIdentificationResult]) -> str:
         [
             "## File-path identification",
             "",
-            f"Model: **{first_result.model}** · category: **{first_result.category.value}** · one-shot bug localization without repository access.",
+            f"- Model: **{first_result.model}**",
+            f"- Category: **{first_result.category.value}**",
+            "- One-shot bug localization without repository access.",
             "",
             "| Results | Matches any gold path |",
             "| --- | --- |",

--- a/src/bcbench/contamination/filepath_identification.py
+++ b/src/bcbench/contamination/filepath_identification.py
@@ -49,8 +49,6 @@ def parse_prediction(raw_text: str) -> list[str]:
         raw_text,
     )
     if response is None:
-        response = re.search(r"(?i)\bRESPONSE\b[ \t]*:?[ \t]*(?=```)", raw_text)
-    if response is None:
         raise ValueError("Expected the answer in a fenced code block after RESPONSE")
 
     block = re.search(r"```(?:(?:[A-Za-z0-9_+-]+)?[ \t]*\r?\n)?(.*?)```", raw_text[response.end() :], re.DOTALL)

--- a/src/bcbench/contamination/filepath_identification.py
+++ b/src/bcbench/contamination/filepath_identification.py
@@ -45,7 +45,7 @@ def parse_prediction(raw_text: str) -> list[str]:
             rather than quietly count as a miss.
     """
     response = re.search(
-        r"(?im)^[ \t*_#>`]*RESPONSE\b[ \t]*:?[ \t*_`]*(?=\r?$|```)",
+        r"(?im)^[ \t*_#>`]*RESPONSE\b[ \t]*:?[ \t*_`]*?(?=\r?$|```)",
         raw_text,
     )
     if response is None:

--- a/src/bcbench/contamination/filepath_identification.py
+++ b/src/bcbench/contamination/filepath_identification.py
@@ -44,7 +44,12 @@ def parse_prediction(raw_text: str) -> list[str]:
             The probe is new, so unanswerable output should surface loudly
             rather than quietly count as a miss.
     """
-    response = re.search(r"(?im)^[ \t*_#>`]*RESPONSE[ \t]*:?[ \t*_`]*$", raw_text)
+    response = re.search(
+        r"(?im)^[ \t*_#>`]*RESPONSE\b[ \t]*:?[ \t*_`]*(?=\r?$|```)",
+        raw_text,
+    )
+    if response is None:
+        response = re.search(r"(?i)\bRESPONSE\b[ \t]*:?[ \t]*(?=```)", raw_text)
     if response is None:
         raise ValueError("Expected the answer in a fenced code block after RESPONSE")
 

--- a/tests/test_filepath_identification.py
+++ b/tests/test_filepath_identification.py
@@ -75,9 +75,10 @@ BaseApp/Source/Base Application/Warehouse/Activity/CreateInventoryPickMovement.C
         response = "DISCUSSION Found the table.\nRESPONSE ```text\nApp/A.al\n```"
         assert parse_prediction(response) == ["App/A.al"]
 
-    def test_tolerates_response_after_discussion_on_same_line(self):
+    def test_rejects_response_after_discussion_on_same_line(self):
         response = "DISCUSSION Found the table. RESPONSE ```App/A.al```"
-        assert parse_prediction(response) == ["App/A.al"]
+        with pytest.raises(ValueError, match="fenced code block"):
+            parse_prediction(response)
 
     def test_uses_first_fenced_block_after_response(self):
         response = """RESPONSE
@@ -114,9 +115,10 @@ App/B.al
         with pytest.raises(ValueError, match="exactly one path"):
             parse_prediction(response)
 
-    def test_answer_without_fenced_block_raises(self):
+    @pytest.mark.parametrize("answer", ["App/A.al", "`App/A.al`"])
+    def test_answer_without_fenced_block_raises(self, answer):
         with pytest.raises(ValueError, match="fenced code block"):
-            parse_prediction("DISCUSSION\nFound it.\nRESPONSE\nApp/A.al")
+            parse_prediction(f"DISCUSSION\nFound it.\nRESPONSE\n{answer}")
 
     def test_empty_output_raises(self):
         with pytest.raises(ValueError, match="fenced code block"):

--- a/tests/test_filepath_identification.py
+++ b/tests/test_filepath_identification.py
@@ -64,6 +64,13 @@ App/A.al
         response = "DISCUSSION Found the table.\nRESPONSE ```App/A.al```"
         assert parse_prediction(response) == ["App/A.al"]
 
+    def test_tolerates_multiline_fence_on_response_line(self):
+        response = """DISCUSSION Traced the failing call stack to Codeunit 7322.
+RESPONSE ```
+BaseApp/Source/Base Application/Warehouse/Activity/CreateInventoryPickMovement.Codeunit.al
+```"""
+        assert parse_prediction(response) == ["BaseApp/Source/Base Application/Warehouse/Activity/CreateInventoryPickMovement.Codeunit.al"]
+
     def test_tolerates_tagged_fence_on_response_line(self):
         response = "DISCUSSION Found the table.\nRESPONSE ```text\nApp/A.al\n```"
         assert parse_prediction(response) == ["App/A.al"]

--- a/tests/test_filepath_identification.py
+++ b/tests/test_filepath_identification.py
@@ -60,6 +60,18 @@ App/A.al
     def test_extracts_path_from_inline_fence(self):
         assert parse_prediction("RESPONSE\n```App/A.al```") == ["App/A.al"]
 
+    def test_tolerates_inline_fence_on_response_line(self):
+        response = "DISCUSSION Found the table.\nRESPONSE ```App/A.al```"
+        assert parse_prediction(response) == ["App/A.al"]
+
+    def test_tolerates_tagged_fence_on_response_line(self):
+        response = "DISCUSSION Found the table.\nRESPONSE ```text\nApp/A.al\n```"
+        assert parse_prediction(response) == ["App/A.al"]
+
+    def test_tolerates_response_after_discussion_on_same_line(self):
+        response = "DISCUSSION Found the table. RESPONSE ```App/A.al```"
+        assert parse_prediction(response) == ["App/A.al"]
+
     def test_uses_first_fenced_block_after_response(self):
         response = """RESPONSE
 ```


### PR DESCRIPTION
First [full run](https://github.com/microsoft/BC-Bench/actions/runs/33246784832} has 29 failed jobs.

Valid model responses placed the opening fence on the same line as `RESPONSE`, which the parser rejected.


## What changed

*  Accept inline fenced responses: `RESPONSE ```path````
* Accept language-tagged fences starting on the `RESPONSE` line
* Accept `RESPONSE` after discussion text on the same line
* Add regression tests for all three observed formats