### PR TITLE
Handle judge-scored evaluation timeouts

### DIFF
--- a/src/bcbench/evaluate/base.py
+++ b/src/bcbench/evaluate/base.py
@@ -96,7 +96,7 @@ class EvaluationPipeline[E: BaseDatasetEntry](ABC):
         except AgentTimeoutError as e:
             context.metrics = e.metrics
             context.experiment = e.config
-            result = BaseEvaluationResult.create_agent_timeout_failure(context)
+            result = context.category.result_class.create_agent_timeout_failure(context)
             self.save_result(context, result)
             logger.info("Agent timed out during execution, counting as failure.")
             return

--- a/src/bcbench/results/base.py
+++ b/src/bcbench/results/base.py
@@ -2,9 +2,9 @@
 
 import json
 from pathlib import Path
-from typing import Any, Self
+from typing import Any, Self, cast
 
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 
 from bcbench.logger import get_logger
 from bcbench.types import AgentMetrics, EvaluationCategory, EvaluationContext, ExperimentConfiguration
@@ -130,6 +130,22 @@ class JudgeScoredEvaluationResult(BaseEvaluationResult):
     """Result for categories whose scoring involves an LLM judge, recording which judge model was pinned for the run."""
 
     judge_model: str
+
+    @model_validator(mode="before")
+    @classmethod
+    def restore_missing_timeout_judge_model(cls, payload: object) -> object:
+        if not isinstance(payload, dict):
+            return payload
+
+        payload = cast(dict[str, object], payload)
+        if payload.get("timeout") is not True or "judge_model" in payload:
+            return payload
+
+        category = EvaluationCategory(payload["category"])
+        if (judge_model := category.judge_model) is None:
+            return payload
+
+        return {**payload, "judge_model": judge_model}
 
     @classmethod
     def _base_fields(cls, context: "EvaluationContext") -> dict[str, Any]:

--- a/tests/test_evaluate_pipeline.py
+++ b/tests/test_evaluate_pipeline.py
@@ -8,15 +8,15 @@ import pytest
 
 from bcbench.commands.evaluate import MockEvaluationPipeline
 from bcbench.config import get_config
-from bcbench.dataset import BaseDatasetEntry, BugFixEntry
+from bcbench.dataset import BaseDatasetEntry, BugFixEntry, NL2ALEntry
 from bcbench.evaluate.base import AgentRunner, EvaluationPipeline
 from bcbench.exceptions import AgentTimeoutError
-from bcbench.results.base import BaseEvaluationResult
+from bcbench.results.base import BaseEvaluationResult, JudgeBasedEvaluationResult
 from bcbench.types import AgentMetrics, EvaluationCategory, EvaluationContext, ExperimentConfiguration
 from tests.conftest import create_codereview_entry, create_dataset_entry, create_evaluation_context, create_ext_advisor_entry, create_nl2al_entry
 
 
-class _StubPipeline(EvaluationPipeline[BugFixEntry]):
+class _StubPipeline[E: BaseDatasetEntry](EvaluationPipeline[E]):
     def __init__(self, *, raise_in_evaluate: Exception | None = None, raise_in_run_agent: Exception | None = None) -> None:
         self.raise_in_evaluate = raise_in_evaluate
         self.raise_in_run_agent = raise_in_run_agent
@@ -24,19 +24,19 @@ class _StubPipeline(EvaluationPipeline[BugFixEntry]):
         self.run_agent_called = False
         self.evaluate_called = False
 
-    def setup_workspace(self, entry: BugFixEntry, repo_path: Path) -> None:
+    def setup_workspace(self, entry: E, repo_path: Path) -> None:
         pass
 
-    def setup(self, context: EvaluationContext[BugFixEntry]) -> None:
+    def setup(self, context: EvaluationContext[E]) -> None:
         self.setup_called = True
 
-    def run_agent(self, context: EvaluationContext[BugFixEntry], agent_runner: AgentRunner[BugFixEntry]) -> None:
+    def run_agent(self, context: EvaluationContext[E], agent_runner: AgentRunner[E]) -> None:
         self.run_agent_called = True
         if self.raise_in_run_agent is not None:
             raise self.raise_in_run_agent
         context.metrics, context.experiment = agent_runner(context)
 
-    def evaluate(self, context: EvaluationContext[BugFixEntry]) -> None:
+    def evaluate(self, context: EvaluationContext[E]) -> None:
         self.evaluate_called = True
         if self.raise_in_evaluate is not None:
             raise self.raise_in_evaluate
@@ -46,7 +46,7 @@ def _noop_runner(_ctx: EvaluationContext[BugFixEntry]) -> tuple[AgentMetrics | N
     return AgentMetrics(execution_time=1.0), ExperimentConfiguration()
 
 
-def _read_only_result(ctx: EvaluationContext[BugFixEntry]) -> BaseEvaluationResult:
+def _read_only_result[E: BaseDatasetEntry](ctx: EvaluationContext[E]) -> BaseEvaluationResult:
     result_file = ctx.result_dir / f"{ctx.entry.instance_id}{get_config().file_patterns.result_pattern}"
     payload = result_file.read_text(encoding="utf-8").strip().splitlines()
     assert len(payload) == 1, f"Expected one persisted result, got {len(payload)}: {payload}"
@@ -57,7 +57,7 @@ def _read_only_result(ctx: EvaluationContext[BugFixEntry]) -> BaseEvaluationResu
 class TestExecuteHappyPath:
     def test_runs_setup_then_agent_then_evaluate(self, tmp_path):
         ctx = create_evaluation_context(tmp_path)
-        pipeline = _StubPipeline()
+        pipeline = _StubPipeline[BugFixEntry]()
 
         pipeline.execute(ctx, _noop_runner)
 
@@ -71,7 +71,7 @@ class TestExecuteAgentTimeout:
         ctx = create_evaluation_context(tmp_path)
         timeout_metrics = AgentMetrics(execution_time=600.0)
         timeout_config = ExperimentConfiguration(custom_instructions=True)
-        pipeline = _StubPipeline(raise_in_run_agent=AgentTimeoutError("test timeout", metrics=timeout_metrics, config=timeout_config))
+        pipeline = _StubPipeline[BugFixEntry](raise_in_run_agent=AgentTimeoutError("test timeout", metrics=timeout_metrics, config=timeout_config))
 
         pipeline.execute(ctx, _noop_runner)
 
@@ -82,11 +82,26 @@ class TestExecuteAgentTimeout:
         assert result.metrics == timeout_metrics
         assert result.experiment == timeout_config
 
+    def test_persists_category_specific_timeout_result(self, tmp_path):
+        entry = create_nl2al_entry()
+        ctx = create_evaluation_context(tmp_path, entry=entry, category=EvaluationCategory.NL2AL)
+        pipeline = _StubPipeline[NL2ALEntry](raise_in_run_agent=AgentTimeoutError("test timeout"))
+
+        pipeline.execute(ctx, lambda _: (None, None))
+
+        result_file = ctx.result_dir / f"{entry.instance_id}{get_config().file_patterns.result_pattern}"
+        payload = json.loads(result_file.read_text(encoding="utf-8"))
+        assert payload["judge_model"] == EvaluationCategory.NL2AL.judge_model
+
+        result = _read_only_result(ctx)
+        assert isinstance(result, JudgeBasedEvaluationResult)
+        assert result.judge_model == EvaluationCategory.NL2AL.judge_model
+
 
 class TestExecuteEvaluateError:
     def test_unexpected_exceptions_still_propagate(self, tmp_path):
         ctx = create_evaluation_context(tmp_path)
-        pipeline = _StubPipeline(raise_in_evaluate=RuntimeError("infra blew up"))
+        pipeline = _StubPipeline[BugFixEntry](raise_in_evaluate=RuntimeError("infra blew up"))
 
         with pytest.raises(RuntimeError, match="infra blew up"):
             pipeline.execute(ctx, _noop_runner)

--- a/tests/test_result_hierarchy.py
+++ b/tests/test_result_hierarchy.py
@@ -13,8 +13,9 @@ Covers:
 from datetime import UTC, datetime
 
 import pytest
+from pydantic import ValidationError
 
-from bcbench.results.base import BaseEvaluationResult, ExecutionBasedEvaluationResult
+from bcbench.results.base import BaseEvaluationResult, ExecutionBasedEvaluationResult, JudgeBasedEvaluationResult
 from bcbench.results.bugfix import BugFixResult
 from bcbench.results.display import create_console_summary, create_github_job_summary
 from bcbench.results.summary import (
@@ -24,7 +25,7 @@ from bcbench.results.summary import (
 )
 from bcbench.results.testgeneration import TestGenerationResult
 from bcbench.types import AgentMetrics, EvaluationCategory, ExperimentConfiguration
-from tests.conftest import create_bugfix_result, create_evaluation_context, create_testgen_result
+from tests.conftest import create_bugfix_result, create_evaluation_context, create_nl2al_entry, create_testgen_result
 
 
 def _make_config_with_summary(summary_path: str):
@@ -171,6 +172,25 @@ class TestFromJsonDispatch:
         payload["category"] = "nonexistent"
         with pytest.raises(ValueError, match="nonexistent"):
             BaseEvaluationResult.from_json(payload)
+
+
+class TestJudgeScoredValidation:
+    def test_restores_missing_judge_model_for_timeout(self, tmp_path):
+        ctx = create_evaluation_context(tmp_path, entry=create_nl2al_entry(), category=EvaluationCategory.NL2AL)
+        payload = BaseEvaluationResult.create_agent_timeout_failure(ctx).model_dump(mode="json")
+
+        loaded = JudgeBasedEvaluationResult.model_validate(payload)
+
+        assert isinstance(loaded, JudgeBasedEvaluationResult)
+        assert loaded.judge_model == EvaluationCategory.NL2AL.judge_model
+
+    def test_rejects_missing_judge_model_for_non_timeout(self, tmp_path):
+        ctx = create_evaluation_context(tmp_path, entry=create_nl2al_entry(), category=EvaluationCategory.NL2AL)
+        payload = JudgeBasedEvaluationResult.create_raw(ctx, "output").model_dump(mode="json")
+        del payload["judge_model"]
+
+        with pytest.raises(ValidationError, match="judge_model"):
+            JudgeBasedEvaluationResult.model_validate(payload)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
As part of #816 , we start to record agent timeouts instead of failing the job completely, this is a good move.

The downstream validation logic didn't take this scenario into account, we now preserve category-specific metadata when evaluation jobs time out, and repair legacy timeout artifacts during Pydantic validation.

Non-timeout validation remains strict.