### PR TITLE
Fail loud on empty data-query gold (prevent false-positive passes)

### DIFF
--- a/src/bcbench/evaluate/dataquery.py
+++ b/src/bcbench/evaluate/dataquery.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from bcbench.dataset import DataQueryEntry
 from bcbench.evaluate.base import EvaluationPipeline
+from bcbench.exceptions import EmptyGoldResultError
 from bcbench.github_actions import github_log_group
 from bcbench.logger import get_logger
 from bcbench.operations import clear_directory
@@ -142,8 +143,10 @@ class DataQueryPipeline(EvaluationPipeline[DataQueryEntry]):
         """The expected rows: run the entry's gold query live against the container's fixed dataset.
 
         Computing the gold on demand keeps it resilient to demo-data changes (no stale baked rows). A
-        gold query that doesn't compile/run is a harness/dataset bug, not the agent's fault, so this
-        deliberately does NOT catch its failure — it must fail the run loudly.
+        gold query that doesn't compile/run — or that returns zero rows — is a harness/dataset bug, not
+        the agent's fault, so this deliberately does NOT catch those failures: it must fail the run
+        loudly. In particular an empty gold is rejected (see EmptyGoldResultError) so an agent that
+        retrieved nothing cannot spuriously match it.
         """
         from bcbench.operations import execute_al_query
 
@@ -154,4 +157,10 @@ class DataQueryPipeline(EvaluationPipeline[DataQueryEntry]):
         company = os.environ.get("BC_MCP_COMPANY")
         if not company:
             raise OSError("BC_MCP_COMPANY is not set; container setup must export the company the gold query runs against.")
-        return execute_al_query(context.entry.gold_query, context.get_container(), context.entry.environment_setup_version, context.repo_path, "gold", company=company)
+        rows = execute_al_query(context.entry.gold_query, context.get_container(), context.entry.environment_setup_version, context.repo_path, "gold", company=company)
+        if not rows:
+            # An empty gold would make an empty agent answer spuriously "match" (result_sets_match([],
+            # []) is True), scoring a run that retrieved nothing as resolved. Every question has a
+            # non-empty answer, so treat this as a harness/environment failure and fail loudly.
+            raise EmptyGoldResultError(context.entry.instance_id)
+        return rows

--- a/src/bcbench/exceptions.py
+++ b/src/bcbench/exceptions.py
@@ -15,6 +15,7 @@ __all__ = [
     "ConfigurationError",
     "DatasetError",
     "EmptyDiffError",
+    "EmptyGoldResultError",
     "EntryNotFoundError",
     "GitOperationError",
     "InvalidEntryFormatError",
@@ -84,6 +85,25 @@ class EmptyDiffError(GitOperationError):
 
     def __init__(self) -> None:
         message = "Generated diff is empty. Agent did not make any changes."
+        super().__init__(message)
+
+
+class EmptyGoldResultError(BCBenchError):
+    """A data-query gold query returned zero rows.
+
+    Every data-query question is an aggregation with a determinate, non-empty answer, so an empty gold
+    means the harness/environment is broken (BC cold-start/degraded, wrong company, or a bad gold
+    query) — never a legitimate expected result. It must fail loudly: otherwise an agent that
+    retrieved nothing (empty answer.json) would spuriously match an empty gold and score as resolved.
+    """
+
+    def __init__(self, instance_id: str) -> None:
+        self.instance_id = instance_id
+        message = (
+            f"Gold query for {instance_id} returned 0 rows. A data-query gold must be non-empty; an "
+            "empty result indicates a harness/environment problem (degraded BC container, wrong "
+            "BC_MCP_COMPANY, or a broken gold_query), not a valid expected answer."
+        )
         super().__init__(message)
 
 

--- a/tests/test_dataquery_evaluation.py
+++ b/tests/test_dataquery_evaluation.py
@@ -1,9 +1,11 @@
 import json
+from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
-from bcbench.evaluate.dataquery import _load_answer_rows, result_sets_match
-from bcbench.exceptions import BuildError
+from bcbench.evaluate.dataquery import DataQueryPipeline, _load_answer_rows, result_sets_match
+from bcbench.exceptions import BuildError, EmptyGoldResultError
 from bcbench.operations import bc_operations, wrap_query_as_api
 from bcbench.types import ContainerConfig
 
@@ -64,6 +66,43 @@ class TestResultSetsMatch:
     def test_numeric_string_not_coerced_to_number(self):
         # A code that happens to look like a scaled number must not match the numeric value 1.
         assert not result_sets_match([{"Key": "1.0"}], [{"Key": 1}])
+
+    def test_two_empty_sets_match(self):
+        # Documents the pitfall the empty-gold guard defends against: empty-vs-empty compares equal,
+        # so an agent that retrieved nothing would spuriously "resolve" against an empty gold.
+        assert result_sets_match([], [])
+
+
+class TestGoldRowsEmptyGuard:
+    def _context(self):
+        context = MagicMock()
+        context.entry.instance_id = "dataquery__customer-count-by-country-1"
+        context.entry.gold_query = "query 50101 Q { elements { } }"
+        context.entry.environment_setup_version = "29.0.0.0"
+        context.repo_path = Path("/tmp/bcbench-test")
+        return context
+
+    def test_empty_gold_raises(self, monkeypatch):
+        # An empty gold means the environment/harness is broken, not a valid expected answer. It must
+        # fail loudly so a run that retrieved nothing can't score as resolved via empty-vs-empty.
+        monkeypatch.setenv("BC_MCP_COMPANY", "CRONUS")
+        monkeypatch.setattr("bcbench.operations.execute_al_query", lambda *args, **kwargs: [])
+
+        with pytest.raises(EmptyGoldResultError):
+            DataQueryPipeline()._gold_rows(self._context())
+
+    def test_non_empty_gold_returned(self, monkeypatch):
+        monkeypatch.setenv("BC_MCP_COMPANY", "CRONUS")
+        rows = [{"CountryRegionCode": "US", "CustomerCount": 3}]
+        monkeypatch.setattr("bcbench.operations.execute_al_query", lambda *args, **kwargs: rows)
+
+        assert DataQueryPipeline()._gold_rows(self._context()) == rows
+
+    def test_missing_company_raises(self, monkeypatch):
+        monkeypatch.delenv("BC_MCP_COMPANY", raising=False)
+
+        with pytest.raises(OSError, match="BC_MCP_COMPANY"):
+            DataQueryPipeline()._gold_rows(self._context())
 
 
 class TestLoadAnswerRows:


### PR DESCRIPTION
## Problem

An empty gold result silently produced **false-positive passes**: `result_sets_match([], [])` is `True`, so an agent that retrieved **no data** (empty `answer.json`) scored as `resolved` whenever the gold query also returned 0 rows.

This surfaced in Copilot run [33374930537](https://github.com/microsoft/BC-Bench/actions/runs/33374930537) (on `main`), which reported **3/4 resolved (75%) despite 0 MCP tool calls on every entry**:

| entry | agent rows | gold rows | scored |
|---|---|---|---|
| total-purchase-amount-by-vendor | 0 (MCP blocked) | 7 (BC healthy) | ❌ fail — correct |
| customer-count-by-country | 0 | 0 (BC degraded) | ✅ "pass" — **false positive** |
| outstanding-sales-value-by-customer | 0 | 0 (BC degraded) | ✅ "pass" — **false positive** |
| outstanding-purchase-value-by-vendor | 0 | 0 | ✅ "pass" — **false positive** |

Root cause of the 0 MCP calls: it was a **GitHub Copilot** run, and Copilot CLI cannot load custom MCP servers without the `COPILOT_CLI_TOKEN` PAT (github/copilot-cli#4346 registry 403). The agent reported the BC tool "unavailable" and wrote empty answers. On the entries where the same BC cold-start also left the gold query returning 0 rows, empty-vs-empty scored green. (Claude Code is unaffected and gets a real ~82%.)

## Fix

Every data-query question is an aggregation with a determinate, **non-empty** answer, so a 0-row gold means a broken harness/environment — never a valid expected result. `_gold_rows` now raises `EmptyGoldResultError` on an empty gold, failing the entry **loudly** (consistent with the existing gold compile/publish fail-loud contract). With this, run 33374930537 would have correctly shown ~0% instead of a fake 75%.

A healthy non-empty gold vs an empty agent answer already fails correctly, so this empty-gold check is the only gap.

## Tests
- `test_empty_gold_raises`, `test_non_empty_gold_returned`, `test_missing_company_raises`
- `test_two_empty_sets_match` documents the empty-vs-empty pitfall the guard defends against.
- Full suite green (821 passed).