### PR TITLE
Stream Copilot transcript to job logs

### DIFF
--- a/src/bcbench/agent/copilot/cli.py
+++ b/src/bcbench/agent/copilot/cli.py
@@ -73,5 +73,9 @@ def invoke_copilot(
         sys.stderr.write(result.stderr)
         sys.stderr.flush()
 
+    if result.stdout:
+        sys.stdout.write(result.stdout)
+        sys.stdout.flush()
+
     metrics, final_response = parse_output(result.stdout.splitlines())
     return metrics, final_response or ""

--- a/tests/test_copilot_agent.py
+++ b/tests/test_copilot_agent.py
@@ -50,6 +50,21 @@ def test_invoke_copilot_can_enable_custom_instructions(tmp_path: Path):
     assert "--no-custom-instructions" not in mock_run.call_args.args[0]
 
 
+def test_invoke_copilot_writes_json_output_to_stdout(tmp_path: Path, capsys):
+    output = '{"type":"assistant.message","data":{"content":"working"}}\n{"type":"result"}\n'
+    with (
+        patch("bcbench.agent.copilot.cli._find_copilot", return_value="copilot"),
+        patch("bcbench.agent.copilot.cli.parse_output", return_value=(None, None)),
+        patch(
+            "bcbench.agent.copilot.cli.subprocess.run",
+            return_value=subprocess.CompletedProcess(args=[], returncode=0, stdout=output, stderr=""),
+        ),
+    ):
+        invoke_copilot(prompt="do the task", model="test-model", work_dir=tmp_path, timeout=60)
+
+    assert capsys.readouterr().out == output
+
+
 def test_copilot_does_not_enable_hooks_memory_or_unrestricted_urls(tmp_path: Path, monkeypatch):
     repo_path = tmp_path / "repo"
     output_dir = tmp_path / "output"


### PR DESCRIPTION
Echo Copilot JSONL output to Actions logs before metrics parsing, restoring transcripts without additional artifacts.