### PR TITLE
Company selection should exist as long as a container is created

### DIFF
--- a/scripts/BCContainerManagement.psm1
+++ b/scripts/BCContainerManagement.psm1
@@ -419,7 +419,7 @@ function Get-BCContainerCompany {
     )
 
     $companies = @(Get-CompanyInBcContainer -containerName $ContainerName)
-    [string]$evaluationCompany = $companies | Where-Object { $_.EvaluationCompany } | Select-Object -First 1
+    $evaluationCompany = $companies | Where-Object { $_.EvaluationCompany } | Select-Object -First 1
     if (-not $evaluationCompany) {
         $evaluationCompany = $companies | Select-Object -First 1
     }

--- a/scripts/BCContainerManagement.psm1
+++ b/scripts/BCContainerManagement.psm1
@@ -403,6 +403,36 @@ function Publish-MCPConfigApp {
     }
 }
 
+<#
+    .SYNOPSIS
+    Retrieves the name of the first company in the specified BC container
+    .DESCRIPTION
+    This function retrieves the name of the first company in the specified BC container, prioritizing the evaluation company if present.
+    .PARAMETER ContainerName
+    The name of the container to query
+#>
+function Get-BCContainerCompany {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ContainerName
+    )
+
+    $companies = @(Get-CompanyInBcContainer -containerName $ContainerName)
+    [string]$evaluationCompany = $companies | Where-Object { $_.EvaluationCompany } | Select-Object -First 1
+    if (-not $evaluationCompany) {
+        $evaluationCompany = $companies | Select-Object -First 1
+    }
+
+    # BcContainerHelper has exposed the company name as either CompanyName or Name across versions.
+    [string]$company = $evaluationCompany.CompanyName
+    if (-not $company) {
+        $company = $evaluationCompany.Name
+    }
+
+    return $company
+}
+
 function Get-BCMCPConnectionInfo {
     [CmdletBinding()]
     param(
@@ -421,22 +451,10 @@ function Get-BCMCPConnectionInfo {
     # off the same base as the API endpoint the query harness already uses (base + '/mcp').
     [string]$baseUrl = "http://${ip}:7048/BC"
 
-    $companies = @(Get-CompanyInBcContainer -containerName $ContainerName)
-    $evaluationCompany = $companies | Where-Object { $_.EvaluationCompany } | Select-Object -First 1
-    if (-not $evaluationCompany) {
-        $evaluationCompany = $companies | Select-Object -First 1
-    }
-
-    # BcContainerHelper has exposed the company name as either CompanyName or Name across versions.
-    [string]$company = $evaluationCompany.CompanyName
-    if (-not $company) {
-        $company = $evaluationCompany.Name
-    }
-
     return [PSCustomObject]@{
         BaseUrl = $baseUrl
-        Company = $company
+        Company = (Get-BCContainerCompany -ContainerName $ContainerName)
     }
 }
 
-Export-ModuleMember -Function Test-Database, Set-AppVersion, Move-AppIntoDevScope, Initialize-ContainerForDevelopment, Test-ContainerExists, New-BCContainerSync, New-BCCompilerFolderSync, Publish-MCPConfigApp, Get-BCMCPConnectionInfo
+Export-ModuleMember -Function Test-Database, Set-AppVersion, Move-AppIntoDevScope, Initialize-ContainerForDevelopment, Test-ContainerExists, New-BCContainerSync, New-BCCompilerFolderSync, Publish-MCPConfigApp, Get-BCContainerCompany, Get-BCMCPConnectionInfo

--- a/scripts/Setup-ContainerAndRepository.ps1
+++ b/scripts/Setup-ContainerAndRepository.ps1
@@ -114,19 +114,20 @@ if (-not $SkipContainer) {
 
     Initialize-ContainerForDevelopment -ContainerName $ContainerName -RepoVersion ([System.Version]$Version)
 
-    # When the BC MCP server is requested (--bc-mcp), publish the install app that provisions and
-    # activates the 'BCBench' MCP configuration, then expose the endpoint and company to the agent step
-    # so it can point its MCP client at the container. Gated on the flag (not the category) so any
-    # category can opt into the BC MCP server.
+    [string] $company = Get-BCContainerCompany -ContainerName $ContainerName
+    Write-Log "BC company: '$company'" -Level Info
+
+    if ($env:GITHUB_ENV) {
+        "BC_COMPANY=$company" | Out-File -FilePath $env:GITHUB_ENV -Append
+    }
+
     if ($BcMcp) {
         Publish-MCPConfigApp -ContainerName $ContainerName -Version $Version -Credential $credential -BuildRoot $RepoPath
-
         $mcpInfo = Get-BCMCPConnectionInfo -ContainerName $ContainerName
-        Write-Log "BC MCP base URL: $($mcpInfo.BaseUrl) (company '$($mcpInfo.Company)')" -Level Info
+        Write-Log "BC MCP base URL: $($mcpInfo.BaseUrl)" -Level Info
 
         if ($env:GITHUB_ENV) {
             "BC_MCP_URL=$($mcpInfo.BaseUrl)" | Out-File -FilePath $env:GITHUB_ENV -Append
-            "BC_MCP_COMPANY=$($mcpInfo.Company)" | Out-File -FilePath $env:GITHUB_ENV -Append
         }
     }
 }

--- a/src/bcbench/agent/shared/env.py
+++ b/src/bcbench/agent/shared/env.py
@@ -9,7 +9,7 @@ import os
 # so the agent's MCP config stays credential-free), so withholding these from the agent process closes
 # the direct-API/direct-DB side-doors without breaking MCP connectivity.
 _WITHHELD_ENV_PREFIXES = ("BC_SERVER_", "BC_MCP_")
-_WITHHELD_ENV_VARS = frozenset({"BC_CONTAINER_NAME"})
+_WITHHELD_ENV_VARS = frozenset({"BC_COMPANY", "BC_CONTAINER_NAME"})
 
 
 def agent_subprocess_env(overrides: dict[str, str] | None = None, *, pass_bc_credentials: bool = False) -> dict[str, str]:

--- a/src/bcbench/cli_options.py
+++ b/src/bcbench/cli_options.py
@@ -40,7 +40,7 @@ ContainerServerInstance = Annotated[str, typer.Option(envvar="BC_SERVER_INSTANCE
 
 ContainerMcpUrl = Annotated[str | None, typer.Option(envvar="BC_MCP_URL", help="BC MCP upstream URL")]
 
-ContainerCompany = Annotated[str | None, typer.Option(envvar="BC_MCP_COMPANY", help="BC company name")]
+ContainerCompany = Annotated[str | None, typer.Option(envvar="BC_COMPANY", help="BC company name")]
 
 EvaluationCategoryOption = Annotated[EvaluationCategory, typer.Option(help="Category of evaluation to perform")]
 

--- a/src/bcbench/exceptions.py
+++ b/src/bcbench/exceptions.py
@@ -102,7 +102,7 @@ class EmptyGoldResultError(BCBenchError):
         message = (
             f"Gold query for {instance_id} returned 0 rows. A data-query gold must be non-empty; an "
             "empty result indicates a harness/environment problem (degraded BC container, wrong "
-            "BC_MCP_COMPANY, or a broken gold_query), not a valid expected answer."
+            "BC_COMPANY, or a broken gold_query), not a valid expected answer."
         )
         super().__init__(message)
 

--- a/tests/test_agent_env.py
+++ b/tests/test_agent_env.py
@@ -6,12 +6,13 @@ def test_scrubs_bc_connection_vars(monkeypatch):
     monkeypatch.setenv("BC_SERVER_USERNAME", "admin")
     monkeypatch.setenv("BC_SERVER_PASSWORD", "secret")
     monkeypatch.setenv("BC_MCP_URL", "http://172.17.0.2:7048/BC")
-    monkeypatch.setenv("BC_MCP_COMPANY", "CRONUS")
+    monkeypatch.setenv("BC_COMPANY", "CRONUS")
     monkeypatch.setenv("BC_CONTAINER_NAME", "bcbench-sales")
 
     env = agent_subprocess_env()
 
     assert not any(k.startswith(("BC_SERVER_", "BC_MCP_")) for k in env)
+    assert "BC_COMPANY" not in env
     assert "BC_CONTAINER_NAME" not in env
 
 
@@ -28,12 +29,14 @@ def test_preserves_other_vars(monkeypatch):
 def test_preserves_bc_connection_vars_when_allowed(monkeypatch):
     monkeypatch.setenv("BC_SERVER_USERNAME", "admin")
     monkeypatch.setenv("BC_SERVER_PASSWORD", "secret")
+    monkeypatch.setenv("BC_COMPANY", "CRONUS")
     monkeypatch.setenv("BC_CONTAINER_NAME", "bcbench-sales")
 
     env = agent_subprocess_env(pass_bc_credentials=True)
 
     assert env["BC_SERVER_USERNAME"] == "admin"
     assert env["BC_SERVER_PASSWORD"] == "secret"
+    assert env["BC_COMPANY"] == "CRONUS"
     assert env["BC_CONTAINER_NAME"] == "bcbench-sales"
 
 


### PR DESCRIPTION
Company must exist even if BC MCP is not selected, this is needed for the baseline scenario (container provisioned, no BC MCP).

Making company name category agnostic for future categories.