### PR TITLE
Emit parsed Content-Length when relaying MCP gateway responses

### DIFF
--- a/src/bcbench/agent/shared/mcp_gateway.py
+++ b/src/bcbench/agent/shared/mcp_gateway.py
@@ -368,9 +368,11 @@ def _build_handler(gateway: BcMcpGateway) -> type[BaseHTTPRequestHandler]:
                 self.send_header(key, value)
 
             if content_length is not None:
-                self.send_header("Content-Length", content_length)
-                self.end_headers()
+                # Parse first, then emit the re-serialised int: the raw value skips the _header_safe
+                # check above, and an unparsable length must fail before any bytes reach the client.
                 remaining = int(content_length)
+                self.send_header("Content-Length", str(remaining))
+                self.end_headers()
                 while remaining > 0:
                     chunk = response.read(min(_STREAM_CHUNK_BYTES, remaining))
                     if not chunk:


### PR DESCRIPTION
Replaces #831, which is being dropped.

## Problem

In `_relay`, the upstream `Content-Length` is captured and `continue`d out of the header loop *before* the `_header_safe` check runs, so it was the one relayed header never validated for CR/LF. CodeQL flagged it as `py/http-response-splitting`.

There was also a latent inconsistency: the header was emitted from the raw string while the body read loop used `int(content_length)`, so the two could disagree for values like `"007"` or `"+5"`.

## Change

Parse first, then emit the re-serialised int:

```python
remaining = int(content_length)
self.send_header("Content-Length", str(remaining))
self.end_headers()
```

- The emitted header and the length used to read the body can no longer diverge.
- A malformed value now raises before `end_headers()` flushes, so the client gets a clean failure instead of a corrupt header block followed by a dangling connection. (`int()` already raised here — only the ordering changes.)
- `str(int(...))` is a sanitizer CodeQL recognizes, so the alert clears without a second mitigation layer.

## Why not the other four alerts

The key/value flows in `_relay` and `_relay_initialize` are already guarded by `_header_safe`, which checks both key and value for `\r` and `\n` and drops the header rather than flattening it. Those are false positives — CodeQL just doesn't model the guard. #831 added a `_strip_crlf()` pass on top of them, which is a provable no-op on every path and leaves two contradictory mitigations in the file. Dismissing those alerts is the more honest resolution.

## Validation

- `uv run pytest tests/test_mcp_gateway.py -q` — 17 passed. The `do_POST` upstream fixture returns a real `Content-Length` response, so the happy path is covered.
- ruff check / format clean; pre-commit (incl. `ty check`) passed.
