### PR TITLE
experiment: ablate the al-appsource-review leaf (DO NOT MERGE)

### DIFF
--- a/.github/actions/install-agent-harnesses/action.yml
+++ b/.github/actions/install-agent-harnesses/action.yml
@@ -21,7 +21,7 @@ runs:
       uses: actions/checkout@v5
       with:
         repository: microsoft/BC-ALAgents
-        ref: 533dd39dfe29218c09e5e31c39c78bb72fa20aa2
+        ref: 7f00ccad5e99a8cbbb73306bfc6526f6ea4d21f2
         path: .agent-harnesses/bc-alagents
         persist-credentials: false
 


### PR DESCRIPTION
**Experiment arm — DO NOT MERGE.** Opened for tracking and discussion only.

## Question

Does the `al-appsource-review` leaf cost more precision than it returns on the code-review set?

## Motivation

Analysis of baseline run [33517690300](https://github.com/microsoft/BC-Bench/actions/runs/33517690300) (BC PR Review, `gpt-5.6-luna`, 145 entries, precision 0.151 / recall 0.402 / F1 0.219) attributes **169 of the 623 generated comments (27%)** to the AppSource leaf, spread across **87 of 145 entries**. The gold set expects **zero** AppSource findings.

This is not corpus dilution. Across the 11 domains the correlation between per-domain corpus size and mean entry F1 is `r = +0.02`. The two extremes run the opposite way:

| leaf | knowledge articles | comments generated | entries touched | gold expects |
| --- | ---: | ---: | ---: | ---: |
| `al-appsource-review` | 4 | **169** | 87 / 145 | 0 |
| `al-ui-review` | 28 | 8 | 8 / 145 | 4 |

What drives output volume is the leaf's applicability gate, not how much it knows.

## Why the AppSource leaf engages everywhere

Two properties of `microsoft/skills/review/al-appsource-review.md` combine:

1. Its first worklist cue fires **when no namespace declaration is present**. The synthetic fixtures are bare `src/*.al` files with no namespace, so the cue is unconditionally true.
2. Its `not-applicable` escape hatch keys on a token list that includes `field`, `key`, `control`, and `action` — tokens present in essentially every AL diff.

The leaf then asserts an affix violation on fixtures that carry no `app.json`, and therefore have no configured `mandatoryAffixes` to compare against.

## Arm definition

Engine: microsoft/BC-ALAgents@`7f00cca`, which changes only `agents/ALReviewAgent/bcquality.config.yaml`:

- `disabled-skills` → `microsoft/skills/review/al-appsource-review.md`
- `knowledge.deny` → `microsoft/knowledge/appsource/**`

Both levers are required. `al-code-review` pins its leaves in frontmatter and "does not discover sub-skills implicitly", so deleting the leaf file alone leaves the super-skill free to improvise the domain from general model knowledge. Denying the corpus removes the grounding as well.

Verified locally against the pinned BCQuality ref `712dee9`: the filter removes exactly 1 skill and 4 knowledge articles; the remaining 239 articles and 15 other review leaves are untouched.

## Control

This branch is cut from `c4b72341` — the exact commit the baseline run evaluated — so the harness pin is the only variable. The code-review dataset and scoring pipeline are byte-identical between that commit and `main`.

## Prediction

Removing all 169 comments without losing a match puts the ceiling at precision **0.207** and F1 **0.273**, against a baseline F1 of 0.219. That is an upper bound: the judge is semantic, so some AppSource-labelled comments may currently match an expected finding in another domain. The measured value is what decides whether this is worth a real fix.

## What this does and does not establish

This is an ablation, not a proposed product change. The gold set contains no AppSource entries, so part of any gain is simply removing an unmeasured domain. A positive result justifies narrowing the leaf's applicability gate in BCQuality — requiring real AppSource context such as `app.json` with `mandatoryAffixes` or an `AppSourceCop.json` — so production keeps the domain while fixtures stop triggering it.
