### PR TITLE
Allow evaluating an engine branch and only modified entries

### DIFF
--- a/.github/actions/install-agent-harnesses/action.yml
+++ b/.github/actions/install-agent-harnesses/action.yml
@@ -1,6 +1,15 @@
 name: Install Agent Harnesses
 description: Install the agent harnesses used by the evaluation workflows
 
+inputs:
+  bc-alagents-ref:
+    description: >-
+      BC-ALAgents ref to evaluate. Leave empty to use the pinned baseline.
+      Override it to score an engine branch before it merges - for example a
+      branch whose bcquality.config.yaml points at an unmerged BCQuality PR.
+    required: false
+    default: ""
+
 outputs:
   bc-alagents-path:
     description: Path to the pinned BC-ALAgents checkout
@@ -21,7 +30,7 @@ runs:
       uses: actions/checkout@v5
       with:
         repository: microsoft/BC-ALAgents
-        ref: e9d9249eaa25be88388b60106b4cbf8cd7aa8a7d
+        ref: ${{ inputs.bc-alagents-ref || 'e9d9249eaa25be88388b60106b4cbf8cd7aa8a7d' }}
         path: .agent-harnesses/bc-alagents
         persist-credentials: false
 

--- a/.github/workflows/pr-review-evaluation.yml
+++ b/.github/workflows/pr-review-evaluation.yml
@@ -41,9 +41,19 @@ on:
         required: false
         default: ""
         type: string
+      engine-ref:
+        description: "BC-ALAgents ref to evaluate (branch, tag, or SHA). Leave blank to use the pinned baseline engine."
+        required: false
+        default: ""
+        type: string
+      modified-only:
+        description: "Only evaluate dataset entries changed versus origin/main"
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
-  group: pr-review-evaluation-${{ inputs.test-run && 'test' || 'full' }}
+  group: pr-review-evaluation-${{ inputs.test-run && 'test' || inputs.modified-only && 'modified' || 'full' }}
   cancel-in-progress: false
 
 env:
@@ -62,6 +72,7 @@ jobs:
   get-entries:
     uses: $/.github/workflows/get-entries.yml
     with:
+      modified-only: ${{ inputs.modified-only }}
       test-run: ${{ inputs.test-run }}
       category: code-review
 
@@ -111,6 +122,8 @@ jobs:
       - name: Install evaluation CLIs
         id: install-harnesses
         uses: $/.github/actions/install-agent-harnesses
+        with:
+          bc-alagents-ref: ${{ inputs.engine-ref }}
 
       - name: Run BC PR Review for entry ${{ matrix.entry }}
         timeout-minutes: 120
@@ -148,11 +161,12 @@ jobs:
       mock: ${{ inputs.test-run }}
       category: code-review
       git-ref: ${{ inputs.git-ref || github.ref_name }}
+      skip-leaderboard: ${{ inputs.modified-only }}
     secrets: inherit
 
   requeue:
     needs: [summarize-results, pin-commit]
-    if: ${{ !cancelled() && !failure() && !inputs.test-run }}
+    if: ${{ !cancelled() && !failure() && !inputs.test-run && !inputs.modified-only }}
     uses: $/.github/workflows/requeue-evaluation.yml
     permissions:
       contents: write
@@ -162,4 +176,4 @@ jobs:
       repeat: ${{ inputs.repeat }}
       existing-tag: ${{ needs.pin-commit.outputs.tag-name }}
       workflow-inputs: |
-        {"model": "${{ inputs.model }}", "test-run": "${{ inputs.test-run }}", "git-ref": "${{ inputs.git-ref || github.ref_name }}"}
+        {"model": "${{ inputs.model }}", "test-run": "${{ inputs.test-run }}", "git-ref": "${{ inputs.git-ref || github.ref_name }}", "engine-ref": "${{ inputs.engine-ref }}"}

--- a/tests/test_review_workflows.py
+++ b/tests/test_review_workflows.py
@@ -49,7 +49,7 @@ def test_pr_review_workflow_is_fixed_to_code_review() -> None:
     assert "mai-code-1-flash-picker" not in workflow
     assert '"gemini-3.7-flash"' in workflow
     assert "gemini-3.6-flash" not in workflow
-    for input_name in ("model:", "test-run:", "repeat:", "git-ref:"):
+    for input_name in ("model:", "test-run:", "repeat:", "git-ref:", "engine-ref:", "modified-only:"):
         assert input_name in workflow
 
 
@@ -63,5 +63,5 @@ def test_agent_harness_action_pins_and_exports_bc_alagents() -> None:
     action = (ACTIONS / "install-agent-harnesses" / "action.yml").read_text(encoding="utf-8")
 
     assert "repository: microsoft/BC-ALAgents" in action
-    assert "ref: e9d9249eaa25be88388b60106b4cbf8cd7aa8a7d" in action
+    assert "inputs.bc-alagents-ref || 'e9d9249eaa25be88388b60106b4cbf8cd7aa8a7d'" in action
     assert "bc-alagents-path:" in action


### PR DESCRIPTION
## Why

Today `pr-review-evaluation.yml` can only score the engine commit hard-coded in
`install-agent-harnesses`, over the whole `codereview.jsonl` dataset.

That makes it impossible to answer the question the self-improvement loop keeps
asking: *does this not-yet-merged BCQuality article actually suppress the false
positive we wrote a gold answer for?* The article only takes effect once
`bcquality.config.yaml` points at it, and that file lives in BC-ALAgents - so
you need to evaluate an engine **branch**, not the pinned baseline.

BC-Bench deliberately isolates BCQuality (`_environment_without_bcquality_overrides`
in `agent/pr_review/agent.py` strips every `BCQUALITY_*` variable, and
`Prepare-BCQualityRoot.ps1` reads the ref only from the engine's own config).
That isolation is correct and is left untouched here. Instead this PR makes the
*engine* selectable, so the normal engine -> BCQuality chain does the rest:

1. open the BCQuality PR with the new article,
2. push a BC-ALAgents branch whose `bcquality.config.yaml` `ref` points at that PR head,
3. run this workflow with `engine-ref` set to that branch.

## What

Two optional `workflow_dispatch` inputs, both defaulting to today's behaviour:

- **`engine-ref`** - BC-ALAgents ref to evaluate. Blank keeps the pinned
  baseline commit. Plumbed through a new `bc-alagents-ref` input on the
  `install-agent-harnesses` composite action, which falls back to the same
  pinned SHA when the value is empty (a composite action's `default` does not
  apply to an explicitly-passed empty string, hence the `||` fallback).
  It is also forwarded through `requeue-evaluation` so repeated runs stay on the
  same engine.

- **`modified-only`** - forwarded to `get-entries.yml`, which already supports
  it but was never given the value. Scores only the dataset entries changed
  versus `origin/main`, which is what you want when validating a handful of new
  gold answers instead of burning credits on all 251.

Because a `modified-only` run is a biased subset, it is excluded from anything
that would treat it as a baseline: `skip-leaderboard` is set, `requeue` is
skipped, and it gets its own concurrency group so it does not queue behind a
full run.

## Validation

- `uv run ruff format` / `ruff check` clean
- `uv run pytest -q` - 871 passed, 2 skipped
- `test_review_workflows.py` updated: the harness test now asserts the baseline
  SHA is still pinned *and* that the override input exists.
- YAML of both changed files parses.

No behaviour change when both inputs are left blank, which is every scheduled
and requeued run today.
