### PR TITLE
Log readable agent transcripts

### DIFF
--- a/src/bcbench/agent/claude/agent.py
+++ b/src/bcbench/agent/claude/agent.py
@@ -130,9 +130,7 @@ def run_claude_code(
         stdout: str = result.stdout.decode("utf-8", errors="replace") if result.stdout else ""
         logger.debug(f"Claude Code raw output: {stdout}")
 
-        metrics, final_response = parse_stream_output(stdout.splitlines())
-        if final_response:
-            logger.info(final_response)
+        metrics, _ = parse_stream_output(stdout.splitlines(), log_transcript=True)
     except subprocess.TimeoutExpired:
         logger.exception(f"Claude Code timed out after {_config.timeout.agent_execution} seconds")
         metrics = AgentMetrics(execution_time=_config.timeout.agent_execution)

--- a/src/bcbench/agent/claude/metrics.py
+++ b/src/bcbench/agent/claude/metrics.py
@@ -36,7 +36,7 @@ def _tool_label(block: dict) -> str | None:
     return tool_name
 
 
-def parse_stream_output(output_lines: Sequence[str]) -> tuple[AgentMetrics | None, str | None]:
+def parse_stream_output(output_lines: Sequence[str], *, log_transcript: bool = False) -> tuple[AgentMetrics | None, str | None]:
     execution_time: float | None = None
     llm_duration: float | None = None
     turn_count: int | None = None
@@ -44,6 +44,9 @@ def parse_stream_output(output_lines: Sequence[str]) -> tuple[AgentMetrics | Non
     completion_tokens: int | None = None
     tool_usage: Counter[str] = Counter()
     final_response: str | None = None
+    # The final text is emitted in both AssistantMessage and ResultMessage:
+    # https://code.claude.com/docs/en/agent-sdk/agent-loop#the-loop-at-a-glance
+    last_assistant_message: str | None = None
 
     for line_number, line in enumerate(output_lines, start=1):
         if not line.strip():
@@ -67,8 +70,19 @@ def parse_stream_output(output_lines: Sequence[str]) -> tuple[AgentMetrics | Non
                     if not isinstance(content, list):
                         continue
                     for block in content:
-                        if isinstance(block, dict) and block.get("type") == "tool_use" and (label := _tool_label(block)):
-                            tool_usage[label] += 1
+                        if not isinstance(block, dict):
+                            continue
+                        match block.get("type"):
+                            case "text":
+                                text = block.get("text")
+                                if log_transcript and isinstance(text, str) and text.strip():
+                                    last_assistant_message = text.strip()
+                                    logger.info("Claude Code: %s", last_assistant_message)
+                            case "tool_use":
+                                if label := _tool_label(block):
+                                    tool_usage[label] += 1
+                                    if log_transcript:
+                                        logger.info("Claude Code tool: %s", label)
             case "result":
                 execution_time = _milliseconds_to_seconds(event.get("duration_ms"))
                 llm_duration = _milliseconds_to_seconds(event.get("duration_api_ms"))
@@ -88,6 +102,8 @@ def parse_stream_output(output_lines: Sequence[str]) -> tuple[AgentMetrics | Non
                 result_text = event.get("result")
                 if isinstance(result_text, str) and result_text:
                     final_response = result_text
+                    if log_transcript and result_text.strip() != last_assistant_message:
+                        logger.info("Claude Code: %s", result_text.strip())
 
     metrics = None
     if execution_time is not None or llm_duration is not None or turn_count is not None or prompt_tokens is not None or completion_tokens is not None or tool_usage:

--- a/src/bcbench/agent/copilot/agent.py
+++ b/src/bcbench/agent/copilot/agent.py
@@ -87,7 +87,7 @@ def run_copilot_agent(
         if custom_agent:
             extra_args.append(f"--agent={custom_agent}")
 
-        metrics, final_response = invoke_copilot(
+        metrics, _ = invoke_copilot(
             prompt=prompt,
             model=model,
             work_dir=repo_path,
@@ -103,9 +103,6 @@ def run_copilot_agent(
             ),
         )
         logger.info(f"Copilot CLI run complete for: {entry.instance_id}")
-
-        if final_response:
-            logger.info(final_response)
     except subprocess.TimeoutExpired:
         logger.exception(f"Copilot CLI timed out after {_config.timeout.agent_execution} seconds")
         metrics = AgentMetrics(execution_time=_config.timeout.agent_execution)

--- a/src/bcbench/agent/copilot/cli.py
+++ b/src/bcbench/agent/copilot/cli.py
@@ -73,9 +73,5 @@ def invoke_copilot(
         sys.stderr.write(result.stderr)
         sys.stderr.flush()
 
-    if result.stdout:
-        sys.stdout.write(result.stdout)
-        sys.stdout.flush()
-
-    metrics, final_response = parse_output(result.stdout.splitlines())
+    metrics, final_response = parse_output(result.stdout.splitlines(), log_transcript=True)
     return metrics, final_response or ""

--- a/src/bcbench/agent/copilot/metrics.py
+++ b/src/bcbench/agent/copilot/metrics.py
@@ -33,7 +33,7 @@ def _tool_label(data: dict) -> str | None:
     return tool_name
 
 
-def parse_output(output_lines: Sequence[str]) -> tuple[AgentMetrics | None, str | None]:
+def parse_output(output_lines: Sequence[str], *, log_transcript: bool = False) -> tuple[AgentMetrics | None, str | None]:
     """Parse metrics and the agent's final response from `copilot --output-format=json` (JSONL) stdout.
 
     Relevant events (CLI 1.0.82):
@@ -74,6 +74,8 @@ def parse_output(output_lines: Sequence[str]) -> tuple[AgentMetrics | None, str 
                 data = event.get("data")
                 if isinstance(data, dict) and (label := _tool_label(data)):
                     tool_usage[label] += 1
+                    if log_transcript:
+                        logger.info("Copilot tool: %s", label)
             case "assistant.message":
                 data = event.get("data")
                 if not isinstance(data, dict):
@@ -82,6 +84,8 @@ def parse_output(output_lines: Sequence[str]) -> tuple[AgentMetrics | None, str 
                 content = data.get("content")
                 if isinstance(content, str) and content:
                     response = content
+                    if log_transcript and content.strip():
+                        logger.info("Copilot: %s", content.strip())
                     if data.get("phase") == "final_answer":
                         final_response = content
             case "session.usage_checkpoint":

--- a/tests/test_claude_code_metrics.py
+++ b/tests/test_claude_code_metrics.py
@@ -198,3 +198,37 @@ class TestClaudeStreamParsing:
         assert final_response == "ok"
         assert metrics is not None
         assert metrics.execution_time == 1.0
+
+    def test_logs_readable_transcript(self, caplog: pytest.LogCaptureFixture):
+        caplog.set_level("INFO")
+
+        parse_stream_output(
+            self._lines(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "content": [
+                            {"type": "text", "text": "Inspecting the implementation."},
+                            {"type": "tool_use", "id": "tool-1", "name": "Read", "input": {}},
+                        ]
+                    },
+                },
+                {"type": "assistant", "message": {"content": [{"type": "text", "text": "Done."}]}},
+                {"type": "result", "result": "Done."},
+            ),
+            log_transcript=True,
+        )
+
+        assert "Claude Code: Inspecting the implementation." in caplog.messages
+        assert "Claude Code tool: Read" in caplog.messages
+        assert caplog.messages.count("Claude Code: Done.") == 1
+
+    def test_logs_final_result_without_assistant_message(self, caplog: pytest.LogCaptureFixture):
+        caplog.set_level("INFO")
+
+        parse_stream_output(
+            self._lines({"type": "result", "duration_ms": 1000, "result": "Done."}),
+            log_transcript=True,
+        )
+
+        assert "Claude Code: Done." in caplog.messages

--- a/tests/test_copilot_agent.py
+++ b/tests/test_copilot_agent.py
@@ -50,11 +50,11 @@ def test_invoke_copilot_can_enable_custom_instructions(tmp_path: Path):
     assert "--no-custom-instructions" not in mock_run.call_args.args[0]
 
 
-def test_invoke_copilot_writes_json_output_to_stdout(tmp_path: Path, capsys):
-    output = '{"type":"assistant.message","data":{"content":"working"}}\n{"type":"result"}\n'
+def test_invoke_copilot_logs_readable_transcript(tmp_path: Path, caplog):
+    output = '{"type":"model.call_start","data":{"turnId":"0"}}\n{"type":"assistant.message","data":{"content":"working"}}\n{"type":"result"}\n'
+    caplog.set_level("INFO")
     with (
         patch("bcbench.agent.copilot.cli._find_copilot", return_value="copilot"),
-        patch("bcbench.agent.copilot.cli.parse_output", return_value=(None, None)),
         patch(
             "bcbench.agent.copilot.cli.subprocess.run",
             return_value=subprocess.CompletedProcess(args=[], returncode=0, stdout=output, stderr=""),
@@ -62,7 +62,8 @@ def test_invoke_copilot_writes_json_output_to_stdout(tmp_path: Path, capsys):
     ):
         invoke_copilot(prompt="do the task", model="test-model", work_dir=tmp_path, timeout=60)
 
-    assert capsys.readouterr().out == output
+    assert "Copilot: working" in caplog.messages
+    assert output not in caplog.text
 
 
 def test_copilot_does_not_enable_hooks_memory_or_unrestricted_urls(tmp_path: Path, monkeypatch):
@@ -113,4 +114,4 @@ def test_copilot_does_not_enable_hooks_memory_or_unrestricted_urls(tmp_path: Pat
     assert "GITHUB_COPILOT_PROMPT_MODE_REPO_HOOKS" not in mock_run.call_args.kwargs["env"]
     assert mock_run.call_args.kwargs["env"]["BC_SERVER_USERNAME"] == "admin"
     assert mock_run.call_args.kwargs["env"]["BC_SERVER_PASSWORD"] == "secret"
-    mock_parse_output.assert_called_once_with(['{"type":"result"}'])
+    mock_parse_output.assert_called_once_with(['{"type":"result"}'], log_transcript=True)

--- a/tests/test_copilot_metrics_parsing.py
+++ b/tests/test_copilot_metrics_parsing.py
@@ -157,3 +157,20 @@ def test_parse_output_tool_usage_none_when_no_tools():
 
     assert metrics is not None
     assert metrics.tool_usage is None
+
+
+def test_parse_output_logs_readable_transcript(caplog: pytest.LogCaptureFixture):
+    caplog.set_level("INFO")
+
+    parse_output(
+        [
+            _json_line({"type": "assistant.message", "data": {"content": "Inspecting the implementation."}}),
+            _json_line({"type": "tool.execution_start", "data": {"toolCallId": "call-1", "toolName": "rg"}}),
+            _json_line({"type": "assistant.message", "data": {"content": "Done.", "phase": "final_answer"}}),
+        ],
+        log_transcript=True,
+    )
+
+    assert "Copilot: Inspecting the implementation." in caplog.messages
+    assert "Copilot tool: rg" in caplog.messages
+    assert "Copilot: Done." in caplog.messages


### PR DESCRIPTION
Previously, we only log the final response for Claude Code and json format output for Copilot CLI.

One of them is not enough to get insights on what happened during the run, and the other is very hard to read for human.

This PR will make both agent's transcript easier to read:
- log readable assistant messages and tool names from Copilot and Claude output
- avoid duplicate Claude final responses while preserving result-only output
- keep existing subprocess and Copilot debug logging behavior