### PR TITLE
Keep the requeue chain alive when an evaluation entry fails

### DIFF
--- a/.github/workflows/claude-evaluation.yml
+++ b/.github/workflows/claude-evaluation.yml
@@ -187,7 +187,10 @@ jobs:
 
   requeue:
     needs: [summarize-results, pin-commit]
-    if: ${{ !cancelled() && !failure() && !inputs.test-run }}
+    # Only a failed pin-commit blocks the chain: without its tag there is
+    # nothing to requeue. A flaky evaluation entry must not, since the matrix
+    # is fail-fast: false and every entry uploads its artifact regardless.
+    if: ${{ !cancelled() && !inputs.test-run && needs.pin-commit.result != 'failure' }}
     uses: $/.github/workflows/requeue-evaluation.yml
     permissions:
       contents: write

--- a/.github/workflows/copilot-evaluation.yml
+++ b/.github/workflows/copilot-evaluation.yml
@@ -190,7 +190,10 @@ jobs:
 
   requeue:
     needs: [summarize-results, pin-commit]
-    if: ${{ !cancelled() && !failure() && !inputs.test-run }}
+    # Only a failed pin-commit blocks the chain: without its tag there is
+    # nothing to requeue. A flaky evaluation entry must not, since the matrix
+    # is fail-fast: false and every entry uploads its artifact regardless.
+    if: ${{ !cancelled() && !inputs.test-run && needs.pin-commit.result != 'failure' }}
     uses: $/.github/workflows/requeue-evaluation.yml
     permissions:
       contents: write

--- a/.github/workflows/pr-review-evaluation.yml
+++ b/.github/workflows/pr-review-evaluation.yml
@@ -152,7 +152,10 @@ jobs:
 
   requeue:
     needs: [summarize-results, pin-commit]
-    if: ${{ !cancelled() && !failure() && !inputs.test-run }}
+    # Only a failed pin-commit blocks the chain: without its tag there is
+    # nothing to requeue. A flaky evaluation entry must not, since the matrix
+    # is fail-fast: false and every entry uploads its artifact regardless.
+    if: ${{ !cancelled() && !inputs.test-run && needs.pin-commit.result != 'failure' }}
     uses: $/.github/workflows/requeue-evaluation.yml
     permissions:
       contents: write


### PR DESCRIPTION
## Problem

A `repeat=N` evaluation chain dies as soon as a **single** matrix entry fails.

`requeue` is gated on `!failure()`. In GitHub Actions that expression is true only when no **ancestor** job failed - not merely the job's direct `needs`. Because `requeue` transitively depends on the whole `evaluate-*` matrix, one flaky entry out of ~150 skips `requeue` and silently ends the chain with rounds still outstanding.

This contradicts the surrounding design. The matrix sets `fail-fast: false` and every entry uploads its artifact with `if: always()`, so a run is explicitly built to tolerate partial entry failure. Only the downstream gating disagrees.

## Observed

Two consecutive rounds of the BC PR Review baseline chain died this way today:

| Run | Entries | Failed | Result |
| --- | --- | --- | --- |
| [33848814493](https://github.com/microsoft/BC-Bench/actions/runs/33848814493) | 149 | 3 | `summarize-results` + `requeue` skipped; chain ended (later rescued by manually re-running the failed jobs) |
| [33853574933](https://github.com/microsoft/BC-Bench/actions/runs/33853574933) | 146 | 1 | `summarize-results` + `requeue` skipped; chain ended again |

The second one lost the round to a single entry (`synthetic__security-011`) out of 146.

## Fix

Gate on the one dependency that genuinely blocks requeuing. Without a pin-commit tag there is nothing to requeue, so a failed `pin-commit` is fatal; a failed evaluation entry is not.

```yaml
if: ${{ !cancelled() && !inputs.test-run && needs.pin-commit.result != 'failure' }}
```

The check is `!= 'failure'` rather than `== 'success'` on purpose: `pin-commit` is legitimately `skipped` on rounds 2+, because the chain is already running from the ephemeral tag it created in round 1. An `== 'success'` version was tried first and breaks every round after the first.

The identical gate is used by the copilot and claude evaluation workflows, so all three are fixed together.

## Scope: `summarize-results` is deliberately left alone

`summarize-results` has no `if:` at all, so it is still skipped whenever any entry fails, and a partial round still publishes nothing. That is intentional, and this PR does not change it.

Letting a partial round through would break leaderboard aggregation. `LeaderboardAggregate._validate_consistent_runs` rejects runs of unequal size:

```python
totals = {run.total for run in runs}
if len(totals) > 1:
    raise ValueError(f"Cannot aggregate runs with different totals: {totals}")
```

`total` is `len(results)`, so a 145-entry round and a 146-entry round of the same chain share a `combination_key` and cannot be aggregated. The skip is therefore load-bearing: it is what keeps mixed-size rounds out of the leaderboard.

So the behaviour after this PR is: a round that loses entries produces no summary and no leaderboard entry (unchanged), but the chain continues and the remaining rounds still run (fixed). Results for the degraded round remain available as artifacts.

Making partial rounds publishable would need a real decision about aggregation semantics - intersect on common entries, or carry per-run entry sets - which is out of scope here.

## Validation

Ran a 6-round `pr-review-evaluation` chain on an experiment branch carrying this change. Rounds that lost a single entry continued to requeue and the chain completed, whereas the unpatched chain stopped at the first such round.
