### PR TITLE
Let a pr-review run target a candidate BCQuality revision

### DIFF
--- a/src/bcbench/agent/pr_review/scripts/Prepare-BCQualityRoot.ps1
+++ b/src/bcbench/agent/pr_review/scripts/Prepare-BCQualityRoot.ps1
@@ -8,12 +8,20 @@
     does: read the engine's pinned repo/ref via Get-BCQualityConfig.ps1, shallow
     fetch that ref, then run Invoke-BCQualityFilter.ps1 over the checkout.
 
-    Emits the resolved root as `root=<path>` on stdout for the Python caller.
+    CandidateRepo/CandidateRef redirect only the fetch, so an unmerged BCQuality
+    revision can be evaluated without editing the engine pin. The filter still
+    runs from the engine's own configuration, so a candidate is evaluated under
+    baseline rules rather than rules it supplied itself.
+
+    Emits `root=<path>` plus the baseline and executed coordinates on stdout, so
+    the caller can record what actually ran instead of assuming the pin.
 #>
 [CmdletBinding()]
 param(
     [Parameter(Mandatory)] [string] $EngineRoot,
-    [Parameter(Mandatory)] [string] $Root
+    [Parameter(Mandatory)] [string] $Root,
+    [string] $CandidateRepo,
+    [string] $CandidateRef
 )
 
 Set-StrictMode -Version Latest
@@ -31,10 +39,16 @@ if (-not (Get-Module -ListAvailable -Name powershell-yaml)) {
 
 # The engine configuration drives both the BCQuality fetch and filter.
 $cfg = & $getConfig
-$repo = $cfg.bcquality.repo
-$ref = $cfg.bcquality.ref
+$baselineRepo = $cfg.bcquality.repo
+$baselineRef = $cfg.bcquality.ref
+
+$repo = if ($CandidateRepo) { $CandidateRepo } else { $baselineRepo }
+$ref = if ($CandidateRef) { $CandidateRef } else { $baselineRef }
 
 Write-Host "Fetching BCQuality from $repo@$ref into $Root"
+if ($repo -ne $baselineRepo -or $ref -ne $baselineRef) {
+    Write-Host "Candidate override in effect; baseline is $baselineRepo@$baselineRef"
+}
 if (Test-Path -LiteralPath $Root) { Remove-Item -LiteralPath $Root -Recurse -Force }
 New-Item -ItemType Directory -Force -Path $Root | Out-Null
 git -C $Root init -q
@@ -44,6 +58,14 @@ if ($LASTEXITCODE -ne 0) { throw "git fetch of BCQuality ref '$ref' failed (exit
 git -C $Root checkout -q FETCH_HEAD
 if ($LASTEXITCODE -ne 0) { throw "git checkout of BCQuality ref '$ref' failed (exit $LASTEXITCODE)" }
 
+# A ref is mutable, so report the commit the fetch actually landed on.
+$resolvedCommit = "$(git -C $Root rev-parse HEAD)".Trim()
+
 & $filter -BCQualityRoot $Root -Config $cfg | Out-Null
 
 "root=$Root"
+"baseline-repo=$baselineRepo"
+"baseline-ref=$baselineRef"
+"resolved-repo=$repo"
+"resolved-ref=$ref"
+"resolved-commit=$resolvedCommit"

--- a/tests/test_pr_review_agent.py
+++ b/tests/test_pr_review_agent.py
@@ -10,6 +10,8 @@ from bcbench.exceptions import AgentError
 from bcbench.types import EvaluationCategory
 from tests.conftest import create_codereview_entry
 
+_PREPARE_SCRIPT = Path(__file__).parents[1] / "src" / "bcbench" / "agent" / "pr_review" / "scripts" / "Prepare-BCQualityRoot.ps1"
+
 
 def _dirs(tmp_path: Path) -> tuple[Path, Path]:
     out = tmp_path / "out"
@@ -42,6 +44,33 @@ def test_prepare_bcquality_root_ignores_ambient_overrides(tmp_path: Path, monkey
     assert root == destination
     child_env = run.call_args.kwargs["env"]
     assert not any(name.startswith("BCQUALITY_") for name in child_env)
+
+
+def test_prepare_script_defaults_to_the_engine_pin() -> None:
+    script = _PREPARE_SCRIPT.read_text(encoding="utf-8")
+
+    assert "[string] $CandidateRepo" in script
+    assert "[string] $CandidateRef" in script
+    assert "$repo = if ($CandidateRepo) { $CandidateRepo } else { $baselineRepo }" in script
+    assert "$ref = if ($CandidateRef) { $CandidateRef } else { $baselineRef }" in script
+
+
+def test_prepare_script_filters_a_candidate_under_baseline_rules() -> None:
+    """A candidate redirects only the fetch.
+
+    The filter keeps running from the engine's own configuration, so a candidate
+    revision cannot widen ``enabled-layers`` or ``knowledge.allow`` to smuggle
+    content it supplied itself past the filter.
+    """
+    assert "$filter -BCQualityRoot $Root -Config $cfg" in _PREPARE_SCRIPT.read_text(encoding="utf-8")
+
+
+def test_prepare_script_reports_what_actually_ran() -> None:
+    script = _PREPARE_SCRIPT.read_text(encoding="utf-8")
+
+    # A ref is mutable, so the resolved commit is what makes two runs comparable.
+    for key in ("root=", "baseline-repo=", "baseline-ref=", "resolved-repo=", "resolved-ref=", "resolved-commit="):
+        assert f'"{key}' in script
 
 
 def test_valid_empty_findings_is_a_clean_review(tmp_path: Path) -> None:


### PR DESCRIPTION
## Why

`Prepare-BCQualityRoot.ps1` resolves the BCQuality repository and ref solely from the pinned engine's own `bcquality.config.yaml`. A run can therefore only ever exercise whatever BCQuality content that engine pin happens to point at, which makes it impossible to answer the question the offline eval gate needs answered: *does this proposed BCQuality change move the score?*

There are two independent pins involved, and it is worth being explicit about which one this touches:

```
BC-Bench .github/actions/install-agent-harnesses/action.yml
  └─ ref: 533dd39d…                          <- pin 1: the engine. BC-Bench owns it.
       └─ BC-ALAgents/agents/ALReviewAgent/bcquality.config.yaml
            └─ ref: 18218091…                <- pin 2: BCQuality. Transitive.
                 └─ read at run time by this script.
```

The gate needs pin 2. Pin 1 stays exactly where it is: it is the reproducibility anchor and must not move per run. An earlier attempt at this went after pin 1 instead and was withdrawn.

## What changed

`Prepare-BCQualityRoot.ps1` takes two new optional parameters, `-CandidateRepo` and `-CandidateRef`, which redirect the fetch. Omitting both reproduces today's behaviour exactly.

The script also now reports the baseline coordinates, the coordinates it actually used, and the resolved commit:

```
root=<path>
baseline-repo=… baseline-ref=…
resolved-repo=… resolved-ref=… resolved-commit=…
```

A ref is mutable — `refs/pull/N/head` moves on every force-push — so recording the commit is what makes a baseline run and a candidate run comparable after the fact. `root=` is still emitted first and is unchanged, so the existing caller keeps working.

## A candidate cannot widen its own filter

The filter still runs from the engine's configuration, not the candidate's:

```powershell
& $filter -BCQualityRoot $Root -Config $cfg   # $cfg is the engine's, always
```

So a candidate revision cannot edit its own `enabled-layers` or `knowledge.allow` to smuggle in content the filter would otherwise strip. This is a security property of the ordering, not an implementation detail, and it is asserted by a test.

## Verification

Both modes were run end to end against a real engine checkout.

| Mode | Result |
| --- | --- |
| Baseline (no candidate arguments) | Identical to today. Filter removed 27 files. `resolved-*` equals `baseline-*`. |
| Candidate (`-CandidateRef refs/pull/152/head`) | Fetch succeeded, filter removed 51 files, and `resolved-commit=eaef922a8a1cfbe17fa14d670e089966dc27b2d1` matches `gh pr view 152 --json headRefOid` exactly. |

The candidate run also demonstrates the filter property above rather than merely asserting it. BCQuality PR 152 adds an article under `community/knowledge/events/`, and the engine baseline enables only the `microsoft` layer — the article was correctly removed with `reason=layer-disabled`.

`ruff format`, `ruff check`, `ty check` and `pytest` are all clean (877 passed, 2 skipped). The one `ty` diagnostic that appears is present on an unmodified `origin/main` as well.

## Scope

Nothing wires the new parameters up yet — this change is inert until a caller passes them. That caller change belongs in `agent.py` alongside the experiment-configuration work in #851 and lands after it, so this PR deliberately touches neither `agent.py` nor `action.yml` and does not conflict with #851.
