### PR TITLE
Bump the BC-ALAgents engine pin to 1.38.6

### DIFF
--- a/.github/actions/install-agent-harnesses/action.yml
+++ b/.github/actions/install-agent-harnesses/action.yml
@@ -21,7 +21,7 @@ runs:
       uses: actions/checkout@v5
       with:
         repository: microsoft/BC-ALAgents
-        ref: e9d9249eaa25be88388b60106b4cbf8cd7aa8a7d
+        ref: 1dbb15f793826be85959724ab82427db9452ac34
         path: .agent-harnesses/bc-alagents
         persist-credentials: false
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bcbench"
-version = "0.10.1"
+version = "0.11.0"
 description = "Benchmarking tool for Business Central (AL) ecosystem, inspired by SWE-Bench"
 readme = "README.md"
 requires-python = ">=3.13,<3.14"

--- a/tests/test_review_workflows.py
+++ b/tests/test_review_workflows.py
@@ -85,7 +85,7 @@ def test_agent_harness_action_pins_and_exports_bc_alagents() -> None:
     action = (ACTIONS / "install-agent-harnesses" / "action.yml").read_text(encoding="utf-8")
 
     assert "repository: microsoft/BC-ALAgents" in action
-    assert "ref: e9d9249eaa25be88388b60106b4cbf8cd7aa8a7d" in action
+    assert "ref: 1dbb15f793826be85959724ab82427db9452ac34" in action
     assert "bc-alagents-path:" in action
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -245,7 +245,7 @@ wheels = [
 
 [[package]]
 name = "bcbench"
-version = "0.10.1"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
Moves the pinned review engine from `e9d9249` (1.36.6) to `1dbb15f` (1.38.6).

## Knowledge corpus is unchanged

Both engine commits declare the same BCQuality revision in `agents/ALReviewAgent/bcquality.config.yaml` — `182180913e6c90b62e6c2a65f13371e53c7adb5e`, content version `1.6`. The knowledge under evaluation is therefore identical, and the `BC-Bench -> BC-ALAgents -> BCQuality` chain stays consistent: the revision a run executes is still exactly the one its engine pin declares.

## What the bump picks up

**BC-ALAgents #64 — orphaned knowledge samples are now removed with their article.** `Invoke-BCQualityFilter.ps1` deletes knowledge articles that fall outside `enabled-layers` / `knowledge.allow`, but previously left the sibling `<slug>.good.al` / `<slug>.bad.al` samples behind. This repository evaluates with `enabled-layers: microsoft` and `knowledge.allow: microsoft/knowledge/**`, so the community layer is filtered out. Measured at the pinned BCQuality revision, that left **52 orphaned `.al` files** in the clone the Copilot CLI uses as its working directory, **26 of them `.bad.al`** — anti-pattern samples stripped of the prose that identifies them as anti-patterns.

**BC-ALAgents #63 — `PATHEXT` is forwarded to the Copilot child environment.** `New-CopilotChildEnvironment` clears the child environment and re-adds an allow-list that omitted `PATHEXT`, so on Windows the child could not resolve `git` to `git.exe` and every git call returned empty output instead of an error. This does not affect this repository: `EvaluationCategory.CODE_REVIEW.runner` is `ubuntu-latest`, where `PATHEXT` does not exist. Included because it comes with the range, not as a fix for anything here.

## Version

`0.10.0 -> 0.11.0`. Per `CONTRIBUTING.md`, a tooling update that may affect results is a minor bump.

## Validation

- `uv lock --check` — consistent
- `uv run ruff format --check` / `ruff check` — clean
- `uv run ty check . --ignore=unresolved-import --exclude "notebooks/"` — 1 diagnostic, pre-existing on `main` (`src/bcbench/redteam.py:150`, unused `ty: ignore`); verified by re-running with the change stashed
- `uv run pytest -q -m "not e2e"` — 874 passed, 2 skipped
- `uv run pytest -q -m e2e` against a clean `microsoft/BCQuality` `main` checkout — 1 passed
- `git diff --stat` — 4 files, 1 line each, no formatter or line-ending noise
