### PR TITLE
Add a modified-only dispatch input to the PR review evaluation

### DIFF
--- a/.github/workflows/pr-review-evaluation.yml
+++ b/.github/workflows/pr-review-evaluation.yml
@@ -25,6 +25,11 @@ on:
         required: false
         default: true
         type: boolean
+      modified-only:
+        description: "Only evaluate entries added or modified against origin/main (takes precedence over test-run)"
+        required: false
+        default: false
+        type: boolean
       repeat:
         description: "Number of times to run sequentially (ignored for test runs)"
         required: false
@@ -43,7 +48,7 @@ on:
         type: string
 
 concurrency:
-  group: pr-review-evaluation-${{ inputs.test-run && 'test' || 'full' }}
+  group: pr-review-evaluation-${{ inputs.modified-only && 'modified' || inputs.test-run && 'test' || 'full' }}
   cancel-in-progress: false
 
 env:
@@ -62,6 +67,7 @@ jobs:
   get-entries:
     uses: $/.github/workflows/get-entries.yml
     with:
+      modified-only: ${{ inputs.modified-only }}
       test-run: ${{ inputs.test-run }}
       category: code-review
 
@@ -162,4 +168,4 @@ jobs:
       repeat: ${{ inputs.repeat }}
       existing-tag: ${{ needs.pin-commit.outputs.tag-name }}
       workflow-inputs: |
-        {"model": "${{ inputs.model }}", "test-run": "${{ inputs.test-run }}", "git-ref": "${{ inputs.git-ref || github.ref_name }}"}
+        {"model": "${{ inputs.model }}", "test-run": "${{ inputs.test-run }}", "modified-only": "${{ inputs.modified-only }}", "git-ref": "${{ inputs.git-ref || github.ref_name }}"}

--- a/.github/workflows/pr-review-evaluation.yml
+++ b/.github/workflows/pr-review-evaluation.yml
@@ -26,7 +26,7 @@ on:
         default: true
         type: boolean
       modified-only:
-        description: "Only evaluate entries added or modified against origin/main (takes precedence over test-run)"
+        description: "Only evaluate entries added or modified against origin/main (takes precedence over test-run). Scores a partial corpus, so the run never publishes results or requeues."
         required: false
         default: false
         type: boolean
@@ -61,7 +61,8 @@ jobs:
       contents: write
     with:
       agent: pr-review
-      test-run: ${{ inputs.test-run }}
+      # A modified-only run never requeues, so it must not leave an ephemeral tag behind.
+      test-run: ${{ inputs.test-run || inputs.modified-only }}
       repeat: ${{ inputs.repeat }}
 
   get-entries:
@@ -139,7 +140,7 @@ jobs:
         with:
           name: evaluation-results-${{ github.run_id }}-${{ matrix.entry }}
           path: ${{ env.EVALUATION_RESULTS_DIR }}/**/*.jsonl
-          retention-days: ${{ inputs.test-run && 1 || 30 }}
+          retention-days: ${{ (inputs.test-run || inputs.modified-only) && 1 || 30 }}
 
   summarize-results:
     needs: evaluate-with-pr-review
@@ -151,14 +152,16 @@ jobs:
       results-dir: ${{ needs.evaluate-with-pr-review.outputs.results-dir }}
       model: ${{ inputs.model }}
       agent: "BC PR Review"
-      mock: ${{ inputs.test-run }}
+      # Scores only the modified entries, so publishing it to Braintrust/Kusto or the
+      # leaderboard would record a partial corpus as a benchmark result.
+      mock: ${{ inputs.test-run || inputs.modified-only }}
       category: code-review
       git-ref: ${{ inputs.git-ref || github.ref_name }}
     secrets: inherit
 
   requeue:
     needs: [summarize-results, pin-commit]
-    if: ${{ !cancelled() && !failure() && !inputs.test-run }}
+    if: ${{ !cancelled() && !failure() && !inputs.test-run && !inputs.modified-only }}
     uses: $/.github/workflows/requeue-evaluation.yml
     permissions:
       contents: write

--- a/.github/workflows/pr-review-evaluation.yml
+++ b/.github/workflows/pr-review-evaluation.yml
@@ -171,4 +171,4 @@ jobs:
       repeat: ${{ inputs.repeat }}
       existing-tag: ${{ needs.pin-commit.outputs.tag-name }}
       workflow-inputs: |
-        {"model": "${{ inputs.model }}", "test-run": "${{ inputs.test-run }}", "modified-only": "${{ inputs.modified-only }}", "git-ref": "${{ inputs.git-ref || github.ref_name }}"}
+        {"model": "${{ inputs.model }}", "test-run": "${{ inputs.test-run }}", "git-ref": "${{ inputs.git-ref || github.ref_name }}"}

--- a/.github/workflows/pr-review-evaluation.yml
+++ b/.github/workflows/pr-review-evaluation.yml
@@ -26,7 +26,7 @@ on:
         default: true
         type: boolean
       modified-only:
-        description: "Only evaluate entries added or modified against origin/main (takes precedence over test-run). Scores a partial corpus, so the run never publishes results or requeues."
+        description: "Only evaluate added or modified entries (never publishes results)"
         required: false
         default: false
         type: boolean

--- a/tests/test_review_workflows.py
+++ b/tests/test_review_workflows.py
@@ -49,8 +49,17 @@ def test_pr_review_workflow_is_fixed_to_code_review() -> None:
     assert "mai-code-1-flash-picker" not in workflow
     assert '"gemini-3.7-flash"' in workflow
     assert "gemini-3.6-flash" not in workflow
-    for input_name in ("model:", "test-run:", "repeat:", "git-ref:"):
+    for input_name in ("model:", "test-run:", "repeat:", "git-ref:", "modified-only:"):
         assert input_name in workflow
+
+
+def test_pr_review_workflow_propagates_modified_only() -> None:
+    workflow = _workflow("pr-review-evaluation.yml")
+
+    # Entry selection is delegated to get-entries.yml, which already implements --modified-only.
+    assert "modified-only: ${{ inputs.modified-only }}" in workflow
+    # A requeue that dropped the flag would silently re-run the full corpus.
+    assert '"modified-only": "${{ inputs.modified-only }}"' in workflow
 
 
 def test_agent_harness_action_pins_published_copilot_version() -> None:

--- a/tests/test_review_workflows.py
+++ b/tests/test_review_workflows.py
@@ -58,8 +58,6 @@ def test_pr_review_workflow_propagates_modified_only() -> None:
 
     # Entry selection is delegated to get-entries.yml, which already implements --modified-only.
     assert "modified-only: ${{ inputs.modified-only }}" in workflow
-    # A requeue that dropped the flag would silently re-run the full corpus.
-    assert '"modified-only": "${{ inputs.modified-only }}"' in workflow
 
 
 def test_pr_review_workflow_treats_modified_only_as_a_partial_run() -> None:
@@ -68,10 +66,13 @@ def test_pr_review_workflow_treats_modified_only_as_a_partial_run() -> None:
 
     # Publishing to Braintrust/Kusto and the leaderboard is gated on `mock`.
     assert "mock: ${{ inputs.test-run || inputs.modified-only }}" in workflow
-    # Requeue is disabled, so pin-commit must not leave an ephemeral tag behind.
-    assert "test-run: ${{ inputs.test-run || inputs.modified-only }}" in workflow
-    assert "!inputs.test-run && !inputs.modified-only" in workflow
     assert "retention-days: ${{ (inputs.test-run || inputs.modified-only) && 1 || 30 }}" in workflow
+    # One run verifies the new entries; repeats are for the full corpus after merge.
+    assert "!inputs.test-run && !inputs.modified-only" in workflow
+    # With requeue disabled, pin-commit must not create a tag nothing would clean up.
+    assert "test-run: ${{ inputs.test-run || inputs.modified-only }}" in workflow
+    # A requeued run is always a full-corpus run, so the payload must not carry the flag.
+    assert "modified-only" not in workflow.split("workflow-inputs:")[1]
 
 
 def test_agent_harness_action_pins_published_copilot_version() -> None:

--- a/tests/test_review_workflows.py
+++ b/tests/test_review_workflows.py
@@ -62,6 +62,18 @@ def test_pr_review_workflow_propagates_modified_only() -> None:
     assert '"modified-only": "${{ inputs.modified-only }}"' in workflow
 
 
+def test_pr_review_workflow_treats_modified_only_as_a_partial_run() -> None:
+    """A modified-only run scores a subset, so it must not be recorded as a benchmark result."""
+    workflow = _workflow("pr-review-evaluation.yml")
+
+    # Publishing to Braintrust/Kusto and the leaderboard is gated on `mock`.
+    assert "mock: ${{ inputs.test-run || inputs.modified-only }}" in workflow
+    # Requeue is disabled, so pin-commit must not leave an ephemeral tag behind.
+    assert "test-run: ${{ inputs.test-run || inputs.modified-only }}" in workflow
+    assert "!inputs.test-run && !inputs.modified-only" in workflow
+    assert "retention-days: ${{ (inputs.test-run || inputs.modified-only) && 1 || 30 }}" in workflow
+
+
 def test_agent_harness_action_pins_published_copilot_version() -> None:
     action = (ACTIONS / "install-agent-harnesses" / "action.yml").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary

Adds an opt-in `modified-only` dispatch input to `pr-review-evaluation.yml` and wires it to the
`get-entries` reusable workflow, which already implements `--modified-only`.

This is the entry-selection half of the closed PR #849, resubmitted on its own. The other half of
#849 — an `engine-ref` input that overrode the pinned engine at run time — is deliberately **not**
included and should stay out: a run-time override lets the recorded pin and the executed pin
diverge, which is the exact property the BC-Bench -> BC-ALAgents -> BCQuality chain exists to
protect, and which PR #851 is hardening by exporting the pinned identity. Moving the engine pin
remains a pull request that edits `install-agent-harnesses/action.yml`.

Entry selection carries no such hazard. `bcbench dataset list --modified-only` already exists
(`src/bcbench/commands/dataset.py` L31-52) and `get-entries.yml` already exposes the flag
(L8, L49, L63-64); only `pr-review-evaluation.yml` never passed it through, so the code-review
category had no cheap way to evaluate just the entries a pull request touches.

Motivation: the offline eval gate for self-improvement pull requests (ADO 648887, FP3/FP4) needs to
score the handful of gold answers a candidate adds, not all 144 entries.

## Changes

- `modified-only` dispatch input, `default: false`. Existing dispatches are byte-for-byte unaffected.
- Passed through to `get-entries`, where it takes precedence over `test-run` (existing behaviour of
  that workflow, unchanged).
- Added to the `requeue` `workflow-inputs` JSON. **Without this, a `modified-only` run with
  `repeat > 1` would silently re-run the full corpus on every requeued pass**, because requeue
  rebuilds the dispatch from that JSON and would have dropped the flag.
- Concurrency group gains a `modified` bucket. A gate run sets `test-run: false`, so it would
  otherwise land in the `full` group behind a full-corpus run with `cancel-in-progress: false` —
  a gate that queues behind a 144-entry run is not usable as a gate. Runs that do not set
  `modified-only` keep their previous group exactly (`test` or `full`).

## Notes

- **No version bump.** The input is opt-in and default-false, so no existing run's result changes.
  This matches the convention for workflow-only changes (#807, #826, #740, #814, #788, #789);
  `CONTRIBUTING.md` reserves a minor bump for tooling updates that may affect results.
- **No conflict with #851.** That PR edits the `evaluate-with-pr-review` `outputs:` block and the
  `summarize-results` `with:` block; this PR edits the dispatch inputs, the concurrency group, the
  `get-entries` `with:` block, and the requeue JSON. The hunks are disjoint.

## Validation

- `uv run ruff format` / `uv run ruff check` on the touched test file — clean.
- `uv run ty check . --ignore=unresolved-import --exclude "notebooks/"` — 1 diagnostic, pre-existing
  on `main` (`src/bcbench/redteam.py:150`, unused `ty: ignore`); unrelated to this change.
- `uv run pytest -q -m "not e2e"` — 875 passed, 2 skipped, 1 deselected.
- `yaml.safe_load` of the workflow asserts the file still parses and confirms the resolved input
  list, concurrency expression, and `get-entries` inputs.
- New test `test_pr_review_workflow_propagates_modified_only` pins both wiring points, including the
  requeue JSON, so the full-corpus regression above cannot silently return.
- `git diff --stat` — 2 files, 18 insertions, 3 deletions; no formatter noise.
