### PR TITLE
Add typed PR review metrics

### DIFF
--- a/src/bcbench/agent/pr_review/agent.py
+++ b/src/bcbench/agent/pr_review/agent.py
@@ -29,7 +29,7 @@ from bcbench.dataset.codereview import CodeReviewEntry
 from bcbench.exceptions import AgentError, AgentTimeoutError
 from bcbench.logger import get_logger
 from bcbench.operations import commit_changes, has_changes, init_repo
-from bcbench.types import AgentMetrics, EvaluationCategory, ExperimentConfiguration, PrReviewMetrics
+from bcbench.types import AgentMetrics, EvaluationCategory, ExperimentConfiguration, PRReviewMetrics
 
 logger = get_logger(__name__)
 _config = get_config()
@@ -226,7 +226,7 @@ def run_pr_review_agent(
         logger.info(f"Engine review complete for {entry.instance_id}: wrote {count} comment(s) to {_REVIEW_OUTPUT_FILE}")
     except subprocess.TimeoutExpired:
         logger.exception(f"Engine review timed out after {_config.timeout.agent_execution} seconds")
-        metrics = PrReviewMetrics(execution_time=_config.timeout.agent_execution)
+        metrics = PRReviewMetrics(execution_time=_config.timeout.agent_execution)
         raise AgentTimeoutError("Engine review timed out", metrics=metrics, config=config) from None
     except subprocess.CalledProcessError as e:
         logger.exception(f"Engine review failed (exit {e.returncode}):\n{e.stdout}\n{e.stderr}")

--- a/src/bcbench/agent/pr_review/agent.py
+++ b/src/bcbench/agent/pr_review/agent.py
@@ -29,7 +29,7 @@ from bcbench.dataset.codereview import CodeReviewEntry
 from bcbench.exceptions import AgentError, AgentTimeoutError
 from bcbench.logger import get_logger
 from bcbench.operations import commit_changes, has_changes, init_repo
-from bcbench.types import AgentMetrics, EvaluationCategory, ExperimentConfiguration
+from bcbench.types import AgentMetrics, EvaluationCategory, ExperimentConfiguration, PrReviewMetrics
 
 logger = get_logger(__name__)
 _config = get_config()
@@ -226,7 +226,7 @@ def run_pr_review_agent(
         logger.info(f"Engine review complete for {entry.instance_id}: wrote {count} comment(s) to {_REVIEW_OUTPUT_FILE}")
     except subprocess.TimeoutExpired:
         logger.exception(f"Engine review timed out after {_config.timeout.agent_execution} seconds")
-        metrics = AgentMetrics(execution_time=_config.timeout.agent_execution)
+        metrics = PrReviewMetrics(execution_time=_config.timeout.agent_execution)
         raise AgentTimeoutError("Engine review timed out", metrics=metrics, config=config) from None
     except subprocess.CalledProcessError as e:
         logger.exception(f"Engine review failed (exit {e.returncode}):\n{e.stdout}\n{e.stderr}")

--- a/src/bcbench/agent/pr_review/agent.py
+++ b/src/bcbench/agent/pr_review/agent.py
@@ -29,7 +29,7 @@ from bcbench.dataset.codereview import CodeReviewEntry
 from bcbench.exceptions import AgentError, AgentTimeoutError
 from bcbench.logger import get_logger
 from bcbench.operations import commit_changes, has_changes, init_repo
-from bcbench.types import AgentMetrics, EvaluationCategory, ExperimentConfiguration, PRReviewMetrics
+from bcbench.types import EvaluationCategory, ExperimentConfiguration, PRReviewMetrics
 
 logger = get_logger(__name__)
 _config = get_config()
@@ -161,7 +161,7 @@ def run_pr_review_agent(
     output_dir: Path,
     engine_path: Path | None = None,
     min_severity: str | None = None,
-) -> tuple[AgentMetrics | None, ExperimentConfiguration]:
+) -> tuple[PRReviewMetrics, ExperimentConfiguration]:
     """Run the engine's complete local review pipeline and write review.json.
 
     Separate from run_copilot_agent by design: this spawns the PROD BC-ALAgents
@@ -170,7 +170,7 @@ def run_pr_review_agent(
     inputs (BC-ALAgents source, min severity) for the code-review category only.
 
     Returns:
-        Tuple of (AgentMetrics, ExperimentConfiguration).
+        Tuple of (PRReviewMetrics, ExperimentConfiguration).
     """
     if category is not EvaluationCategory.CODE_REVIEW:
         raise AgentError(f"The engine agent only supports the code-review category, got {category.value}.")

--- a/src/bcbench/agent/pr_review/metrics.py
+++ b/src/bcbench/agent/pr_review/metrics.py
@@ -30,6 +30,7 @@ class _RunMetrics(BaseModel):
     failed_api_calls: _NonNegativeInt | None
     usage_api_calls: _NonNegativeInt | None
     ai_credits: _NonNegativeFloat | None
+    # Retained in the engine artifact schema, but intentionally excluded from persisted benchmark metrics.
     premium_requests: _NonNegativeFloat | None
     models: list[str]
     usage_complete: bool

--- a/src/bcbench/agent/pr_review/metrics.py
+++ b/src/bcbench/agent/pr_review/metrics.py
@@ -5,7 +5,7 @@ from typing import Annotated, Literal
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
 from bcbench.exceptions import AgentError
-from bcbench.types import AgentMetrics
+from bcbench.types import PrReviewMetrics
 
 RUN_METRICS_FILE_NAME = "_run-metrics.json"
 _NonNegativeInt = Annotated[int, Field(ge=0)]
@@ -76,16 +76,26 @@ def _load_run_metrics(path: Path) -> _RunMetrics:
         raise AgentError(f"Engine run metrics artifact {path} does not satisfy schema version 1: {exc}") from exc
 
 
-def build_pr_review_metrics(output_dir: Path, execution_time: float) -> AgentMetrics:
+def build_pr_review_metrics(output_dir: Path, execution_time: float) -> PrReviewMetrics:
     run = _load_run_metrics(output_dir / RUN_METRICS_FILE_NAME)
     if run.metrics_source == "not-applicable":
         raise AgentError("Engine metrics were not applicable. BC-Bench code-review entries must contain AL changes.")
     usage_values_available = run.malformed_records == 0
     token_values_available = usage_values_available and run.usage_complete
-    return AgentMetrics(
+    return PrReviewMetrics(
         execution_time=execution_time,
         prompt_tokens=run.prompt_tokens if token_values_available else None,
         completion_tokens=run.completion_tokens if token_values_available else None,
         total_tokens=run.total_tokens if token_values_available else None,
         ai_credits=run.ai_credits if usage_values_available else None,
+        cached_tokens=run.cached_tokens,
+        cache_creation_tokens=run.cache_creation_tokens,
+        reasoning_tokens=run.reasoning_tokens,
+        api_calls=run.api_calls,
+        failed_api_calls=run.failed_api_calls,
+        usage_api_calls=run.usage_api_calls,
+        premium_requests=run.premium_requests,
+        usage_complete=run.usage_complete,
+        malformed_records=run.malformed_records,
+        copilot_cli_version=run.cli_version,
     )

--- a/src/bcbench/agent/pr_review/metrics.py
+++ b/src/bcbench/agent/pr_review/metrics.py
@@ -94,7 +94,6 @@ def build_pr_review_metrics(output_dir: Path, execution_time: float) -> PRReview
         api_calls=run.api_calls,
         failed_api_calls=run.failed_api_calls,
         usage_api_calls=run.usage_api_calls,
-        premium_requests=run.premium_requests,
         usage_complete=run.usage_complete,
         malformed_records=run.malformed_records,
         copilot_cli_version=run.cli_version,

--- a/src/bcbench/agent/pr_review/metrics.py
+++ b/src/bcbench/agent/pr_review/metrics.py
@@ -30,7 +30,6 @@ class _RunMetrics(BaseModel):
     failed_api_calls: _NonNegativeInt | None
     usage_api_calls: _NonNegativeInt | None
     ai_credits: _NonNegativeFloat | None
-    # Retained in the engine artifact schema, but intentionally excluded from persisted benchmark metrics.
     premium_requests: _NonNegativeFloat | None
     models: list[str]
     usage_complete: bool

--- a/src/bcbench/agent/pr_review/metrics.py
+++ b/src/bcbench/agent/pr_review/metrics.py
@@ -5,7 +5,7 @@ from typing import Annotated, Literal
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
 from bcbench.exceptions import AgentError
-from bcbench.types import PrReviewMetrics
+from bcbench.types import PRReviewMetrics
 
 RUN_METRICS_FILE_NAME = "_run-metrics.json"
 _NonNegativeInt = Annotated[int, Field(ge=0)]
@@ -76,13 +76,13 @@ def _load_run_metrics(path: Path) -> _RunMetrics:
         raise AgentError(f"Engine run metrics artifact {path} does not satisfy schema version 1: {exc}") from exc
 
 
-def build_pr_review_metrics(output_dir: Path, execution_time: float) -> PrReviewMetrics:
+def build_pr_review_metrics(output_dir: Path, execution_time: float) -> PRReviewMetrics:
     run = _load_run_metrics(output_dir / RUN_METRICS_FILE_NAME)
     if run.metrics_source == "not-applicable":
         raise AgentError("Engine metrics were not applicable. BC-Bench code-review entries must contain AL changes.")
     usage_values_available = run.malformed_records == 0
     token_values_available = usage_values_available and run.usage_complete
-    return PrReviewMetrics(
+    return PRReviewMetrics(
         execution_time=execution_time,
         prompt_tokens=run.prompt_tokens if token_values_available else None,
         completion_tokens=run.completion_tokens if token_values_available else None,

--- a/src/bcbench/results/base.py
+++ b/src/bcbench/results/base.py
@@ -32,9 +32,12 @@ class BaseEvaluationResult(BaseModel):
 
     @classmethod
     def _base_fields(cls, context: "EvaluationContext") -> dict[str, Any]:
+        metrics_contract = context.agent_name.metrics_contract
         if not context.metrics:
             logger.warning(f"Creating result for {context.entry.instance_id} with no agent metrics - performance data will be unavailable")
-        elif missing_metrics := sorted(name for name in context.agent_name.expected_metrics if getattr(context.metrics, name) is None):
+        elif type(context.metrics) is not metrics_contract.metrics_type:
+            raise TypeError(f"{context.agent_name} must use {metrics_contract.metrics_type.__name__}, got {type(context.metrics).__name__}")
+        elif missing_metrics := sorted(name for name in metrics_contract.required_fields if getattr(context.metrics, name) is None):
             logger.warning(f"Result for {context.entry.instance_id} missing metrics: {', '.join(missing_metrics)}")
 
         return {

--- a/src/bcbench/results/base.py
+++ b/src/bcbench/results/base.py
@@ -7,7 +7,7 @@ from typing import Any, Self, cast
 from pydantic import BaseModel, model_validator
 
 from bcbench.logger import get_logger
-from bcbench.types import AnyAgentMetrics, EvaluationCategory, EvaluationContext, ExperimentConfiguration
+from bcbench.types import AgentHarness, AnyAgentMetrics, EvaluationCategory, EvaluationContext, ExperimentConfiguration
 
 logger = get_logger(__name__)
 
@@ -29,6 +29,21 @@ class BaseEvaluationResult(BaseModel):
 
     metrics: AnyAgentMetrics | None = None
     experiment: ExperimentConfiguration | None = None
+
+    @model_validator(mode="after")
+    def validate_metrics_contract(self) -> Self:
+        if self.metrics is None:
+            return self
+
+        try:
+            metrics_contract = AgentHarness(self.agent_name).metrics_contract
+        except ValueError:
+            return self
+
+        if type(self.metrics) is not metrics_contract.metrics_type:
+            raise ValueError(f"{self.agent_name} must use {metrics_contract.metrics_type.__name__}, got {type(self.metrics).__name__}")
+
+        return self
 
     @classmethod
     def _base_fields(cls, context: "EvaluationContext") -> dict[str, Any]:

--- a/src/bcbench/results/base.py
+++ b/src/bcbench/results/base.py
@@ -7,7 +7,7 @@ from typing import Any, Self, cast
 from pydantic import BaseModel, model_validator
 
 from bcbench.logger import get_logger
-from bcbench.types import AgentMetrics, EvaluationCategory, EvaluationContext, ExperimentConfiguration
+from bcbench.types import AnyAgentMetrics, EvaluationCategory, EvaluationContext, ExperimentConfiguration
 
 logger = get_logger(__name__)
 
@@ -27,7 +27,7 @@ class BaseEvaluationResult(BaseModel):
     output: str = ""
     error_message: str | None = None
 
-    metrics: AgentMetrics | None = None
+    metrics: AnyAgentMetrics | None = None
     experiment: ExperimentConfiguration | None = None
 
     @classmethod

--- a/src/bcbench/results/base.py
+++ b/src/bcbench/results/base.py
@@ -7,7 +7,7 @@ from typing import Any, Self, cast
 from pydantic import BaseModel, model_validator
 
 from bcbench.logger import get_logger
-from bcbench.types import AgentHarness, AnyAgentMetrics, EvaluationCategory, EvaluationContext, ExperimentConfiguration
+from bcbench.types import AnyAgentMetrics, EvaluationCategory, EvaluationContext, ExperimentConfiguration
 
 logger = get_logger(__name__)
 
@@ -29,21 +29,6 @@ class BaseEvaluationResult(BaseModel):
 
     metrics: AnyAgentMetrics | None = None
     experiment: ExperimentConfiguration | None = None
-
-    @model_validator(mode="after")
-    def validate_metrics_contract(self) -> Self:
-        if self.metrics is None:
-            return self
-
-        try:
-            metrics_contract = AgentHarness(self.agent_name).metrics_contract
-        except ValueError:
-            return self
-
-        if type(self.metrics) is not metrics_contract.metrics_type:
-            raise ValueError(f"{self.agent_name} must use {metrics_contract.metrics_type.__name__}, got {type(self.metrics).__name__}")
-
-        return self
 
     @classmethod
     def _base_fields(cls, context: "EvaluationContext") -> dict[str, Any]:

--- a/src/bcbench/types.py
+++ b/src/bcbench/types.py
@@ -7,7 +7,7 @@ from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Literal, TypedDict
 
-from pydantic import BaseModel, ConfigDict, StringConstraints, model_validator
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints, model_validator
 
 if TYPE_CHECKING:
     from bcbench.dataset import BaseDatasetEntry
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
 __all__ = [
     "AgentHarness",
     "AgentMetrics",
+    "AnyAgentMetrics",
     "BCalLLMBackend",
     "Checklist",
     "ChecklistAssertion",
@@ -31,6 +32,7 @@ __all__ = [
     "ExperimentConfiguration",
     "JudgeCalibrationReport",
     "PluginConfig",
+    "PrReviewMetrics",
     "RepoSlug",
 ]
 
@@ -67,6 +69,8 @@ class AgentMetrics(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
+    kind: Literal["generic"] = "generic"
+
     # Total execution time in seconds
     execution_time: float | None = None
     llm_duration: float | None = None
@@ -84,6 +88,24 @@ class AgentMetrics(BaseModel):
 
     # Tool usage statistics from agent logs
     tool_usage: dict[str, int] | None = None
+
+
+class PrReviewMetrics(AgentMetrics):
+    kind: Literal["pr-review"] = "pr-review"
+
+    cached_tokens: int | None = Field(default=None, ge=0)
+    cache_creation_tokens: int | None = Field(default=None, ge=0)
+    reasoning_tokens: int | None = Field(default=None, ge=0)
+    api_calls: int | None = Field(default=None, ge=0)
+    failed_api_calls: int | None = Field(default=None, ge=0)
+    usage_api_calls: int | None = Field(default=None, ge=0)
+    premium_requests: float | None = Field(default=None, ge=0)
+    usage_complete: bool | None = None
+    malformed_records: int | None = Field(default=None, ge=0)
+    copilot_cli_version: str | None = None
+
+
+type AnyAgentMetrics = Annotated[AgentMetrics | PrReviewMetrics, Field(discriminator="kind")]
 
 
 class ExperimentConfiguration(BaseModel):
@@ -203,7 +225,7 @@ class AgentHarness(StrEnum):
             case AgentHarness.BCAL:
                 expected = AgentMetrics(execution_time=None)
             case AgentHarness.PR_REVIEW:
-                expected = AgentMetrics(
+                expected = PrReviewMetrics(
                     execution_time=None,
                     prompt_tokens=None,
                     completion_tokens=None,

--- a/src/bcbench/types.py
+++ b/src/bcbench/types.py
@@ -100,7 +100,6 @@ class PRReviewMetrics(AgentMetrics):
     api_calls: int | None = Field(default=None, ge=0)
     failed_api_calls: int | None = Field(default=None, ge=0)
     usage_api_calls: int | None = Field(default=None, ge=0)
-    premium_requests: float | None = Field(default=None, ge=0)
     usage_complete: bool | None = None
     malformed_records: int | None = Field(default=None, ge=0)
     copilot_cli_version: str | None = None

--- a/src/bcbench/types.py
+++ b/src/bcbench/types.py
@@ -31,8 +31,8 @@ __all__ = [
     "ExpectedOutput",
     "ExperimentConfiguration",
     "JudgeCalibrationReport",
+    "PRReviewMetrics",
     "PluginConfig",
-    "PrReviewMetrics",
     "RepoSlug",
 ]
 
@@ -90,7 +90,7 @@ class AgentMetrics(BaseModel):
     tool_usage: dict[str, int] | None = None
 
 
-class PrReviewMetrics(AgentMetrics):
+class PRReviewMetrics(AgentMetrics):
     kind: Literal["pr-review"] = "pr-review"
 
     cached_tokens: int | None = Field(default=None, ge=0)
@@ -105,7 +105,7 @@ class PrReviewMetrics(AgentMetrics):
     copilot_cli_version: str | None = None
 
 
-type AnyAgentMetrics = Annotated[AgentMetrics | PrReviewMetrics, Field(discriminator="kind")]
+type AnyAgentMetrics = Annotated[AgentMetrics | PRReviewMetrics, Field(discriminator="kind")]
 
 
 class ExperimentConfiguration(BaseModel):
@@ -199,9 +199,10 @@ class AgentHarness(StrEnum):
 
     @property
     def expected_metrics(self) -> frozenset[str]:
-        """Metrics this agent should always report.
+        """Metrics this harness should always populate.
 
-        Only these are warned about when missing, so agents that never collect a metric don't emit a warning for every single instance of a run.
+        Metric models define which fields may be reported. This separate harness
+        capability contract controls which missing values produce warnings.
         """
 
         match self:
@@ -225,7 +226,7 @@ class AgentHarness(StrEnum):
             case AgentHarness.BCAL:
                 expected = AgentMetrics(execution_time=None)
             case AgentHarness.PR_REVIEW:
-                expected = PrReviewMetrics(
+                expected = PRReviewMetrics(
                     execution_time=None,
                     prompt_tokens=None,
                     completion_tokens=None,

--- a/src/bcbench/types.py
+++ b/src/bcbench/types.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
 __all__ = [
     "AgentHarness",
     "AgentMetrics",
+    "AgentMetricsContract",
     "AnyAgentMetrics",
     "BCalLLMBackend",
     "Checklist",
@@ -106,6 +107,16 @@ class PRReviewMetrics(AgentMetrics):
 
 
 type AnyAgentMetrics = Annotated[AgentMetrics | PRReviewMetrics, Field(discriminator="kind")]
+
+
+@dataclass(frozen=True)
+class AgentMetricsContract:
+    metrics_type: type[AgentMetrics]
+    required_fields: frozenset[str]
+
+    def __post_init__(self) -> None:
+        if unknown_fields := self.required_fields - self.metrics_type.model_fields.keys():
+            raise ValueError(f"{self.metrics_type.__name__} does not define required fields: {sorted(unknown_fields)}")
 
 
 class ExperimentConfiguration(BaseModel):
@@ -198,16 +209,16 @@ class AgentHarness(StrEnum):
     PR_REVIEW = "BC PR Review"
 
     @property
-    def expected_metrics(self) -> frozenset[str]:
-        """Metrics this harness should always populate.
+    def metrics_contract(self) -> AgentMetricsContract:
+        """Metrics schema and fields this harness must populate.
 
-        Metric models define which fields may be reported. This separate harness
-        capability contract controls which missing values produce warnings.
+        The model defines which fields may be reported. The required subset
+        controls which missing values produce warnings.
         """
 
         match self:
             case AgentHarness.COPILOT:
-                expected = AgentMetrics(
+                metrics = AgentMetrics(
                     execution_time=None,
                     llm_duration=None,
                     ai_credits=None,
@@ -215,7 +226,7 @@ class AgentHarness(StrEnum):
                     tool_usage=None,
                 )
             case AgentHarness.CLAUDE | AgentHarness.MOCK:
-                expected = AgentMetrics(
+                metrics = AgentMetrics(
                     execution_time=None,
                     llm_duration=None,
                     turn_count=None,
@@ -224,9 +235,9 @@ class AgentHarness(StrEnum):
                     tool_usage=None,
                 )
             case AgentHarness.BCAL:
-                expected = AgentMetrics(execution_time=None)
+                metrics = AgentMetrics(execution_time=None)
             case AgentHarness.PR_REVIEW:
-                expected = PRReviewMetrics(
+                metrics = PRReviewMetrics(
                     execution_time=None,
                     prompt_tokens=None,
                     completion_tokens=None,
@@ -236,7 +247,7 @@ class AgentHarness(StrEnum):
             case _:
                 raise ValueError(f"Unknown AgentHarness: {self}")
 
-        return frozenset(expected.model_fields_set)
+        return AgentMetricsContract(type(metrics), frozenset(metrics.model_fields_set))
 
     @property
     def instruction_filename(self) -> str:

--- a/tests/test_expected_metrics_warning.py
+++ b/tests/test_expected_metrics_warning.py
@@ -1,7 +1,7 @@
 import logging
 
 from bcbench.results.bugfix import BugFixResult
-from bcbench.types import AgentHarness, AgentMetrics
+from bcbench.types import AgentHarness, AgentMetrics, PRReviewMetrics
 from tests.conftest import create_evaluation_context
 
 
@@ -36,6 +36,21 @@ class TestExpectedMetricsWarning:
             BugFixResult.create_success(context, "patch")
 
         assert _missing_metric_warnings(caplog) == [f"Result for {context.entry.instance_id} missing metrics: turn_count"]
+
+    def test_optional_pr_review_diagnostics_do_not_warn(self, tmp_path, caplog):
+        context = create_evaluation_context(tmp_path, agent_name=AgentHarness.PR_REVIEW)
+        context.metrics = PRReviewMetrics(
+            execution_time=12.0,
+            prompt_tokens=100,
+            completion_tokens=10,
+            total_tokens=110,
+            ai_credits=0.25,
+        )
+
+        with caplog.at_level(logging.WARNING):
+            BugFixResult.create_success(context, "patch")
+
+        assert _missing_metric_warnings(caplog) == []
 
     def test_warns_when_no_metrics_at_all(self, tmp_path, caplog):
         context = create_evaluation_context(tmp_path, agent_name=AgentHarness.BCAL)

--- a/tests/test_expected_metrics_warning.py
+++ b/tests/test_expected_metrics_warning.py
@@ -1,5 +1,7 @@
 import logging
 
+import pytest
+
 from bcbench.results.bugfix import BugFixResult
 from bcbench.types import AgentHarness, AgentMetrics, PRReviewMetrics
 from tests.conftest import create_evaluation_context
@@ -51,6 +53,13 @@ class TestExpectedMetricsWarning:
             BugFixResult.create_success(context, "patch")
 
         assert _missing_metric_warnings(caplog) == []
+
+    def test_rejects_metrics_type_not_registered_for_harness(self, tmp_path):
+        context = create_evaluation_context(tmp_path, agent_name=AgentHarness.PR_REVIEW)
+        context.metrics = AgentMetrics(execution_time=12.0)
+
+        with pytest.raises(TypeError, match="BC PR Review must use PRReviewMetrics"):
+            BugFixResult.create_success(context, "patch")
 
     def test_warns_when_no_metrics_at_all(self, tmp_path, caplog):
         context = create_evaluation_context(tmp_path, agent_name=AgentHarness.BCAL)

--- a/tests/test_pr_review_agent.py
+++ b/tests/test_pr_review_agent.py
@@ -7,7 +7,7 @@ import pytest
 
 from bcbench.agent.pr_review.agent import _prepare_bcquality_root, _resolve_pr_review_root, _write_review_json, run_pr_review_agent
 from bcbench.exceptions import AgentError
-from bcbench.types import EvaluationCategory
+from bcbench.types import EvaluationCategory, PrReviewMetrics
 from tests.conftest import create_codereview_entry
 
 
@@ -172,12 +172,14 @@ def test_engine_environment_uses_target_repository_and_absolute_paths(tmp_path: 
             engine_path=tmp_path / "engine",
         )
 
-    assert metrics is not None
+    assert isinstance(metrics, PrReviewMetrics)
     assert metrics.execution_time == 2.5
     assert metrics.prompt_tokens == 100
     assert metrics.completion_tokens == 10
     assert metrics.total_tokens == 110
     assert metrics.ai_credits == 0.25
+    assert metrics.api_calls == 2
+    assert metrics.copilot_cli_version == "1.0.81-0"
     assert config.is_empty()
     resolve_engine.assert_called_once_with(tmp_path / "engine")
     prepare_bcquality.assert_called_once_with(tmp_path / "engine", "pwsh", (tmp_path / "output" / "bcquality").resolve())

--- a/tests/test_pr_review_agent.py
+++ b/tests/test_pr_review_agent.py
@@ -7,7 +7,7 @@ import pytest
 
 from bcbench.agent.pr_review.agent import _prepare_bcquality_root, _resolve_pr_review_root, _write_review_json, run_pr_review_agent
 from bcbench.exceptions import AgentError
-from bcbench.types import EvaluationCategory, PrReviewMetrics
+from bcbench.types import EvaluationCategory, PRReviewMetrics
 from tests.conftest import create_codereview_entry
 
 
@@ -172,7 +172,7 @@ def test_engine_environment_uses_target_repository_and_absolute_paths(tmp_path: 
             engine_path=tmp_path / "engine",
         )
 
-    assert isinstance(metrics, PrReviewMetrics)
+    assert isinstance(metrics, PRReviewMetrics)
     assert metrics.execution_time == 2.5
     assert metrics.prompt_tokens == 100
     assert metrics.completion_tokens == 10

--- a/tests/test_pr_review_metrics.py
+++ b/tests/test_pr_review_metrics.py
@@ -58,7 +58,6 @@ def test_build_metrics_promotes_public_performance_metrics(tmp_path: Path) -> No
     assert metrics.api_calls == 2
     assert metrics.failed_api_calls == 1
     assert metrics.usage_api_calls == 2
-    assert metrics.premium_requests == 1.75
     assert metrics.usage_complete is True
     assert metrics.malformed_records == 0
     assert metrics.copilot_cli_version == "1.0.81-0"

--- a/tests/test_pr_review_metrics.py
+++ b/tests/test_pr_review_metrics.py
@@ -8,7 +8,7 @@ from bcbench.agent.pr_review.metrics import RUN_METRICS_FILE_NAME, build_pr_revi
 from bcbench.dataset.codereview import CodeReviewEntry
 from bcbench.exceptions import AgentError
 from bcbench.results.bceval_export import write_bceval_results
-from bcbench.types import AgentHarness, EvaluationCategory
+from bcbench.types import AgentHarness, EvaluationCategory, PrReviewMetrics
 from tests.conftest import create_codereview_entry, create_codereview_result
 
 
@@ -45,11 +45,23 @@ def test_build_metrics_promotes_public_performance_metrics(tmp_path: Path) -> No
 
     metrics = build_pr_review_metrics(tmp_path, execution_time=12.5)
 
+    assert isinstance(metrics, PrReviewMetrics)
+    assert metrics.kind == "pr-review"
     assert metrics.execution_time == 12.5
     assert metrics.prompt_tokens == 150
     assert metrics.completion_tokens == 28
     assert metrics.total_tokens == 178
     assert metrics.ai_credits == 1.75
+    assert metrics.cached_tokens == 60
+    assert metrics.cache_creation_tokens == 10
+    assert metrics.reasoning_tokens == 7
+    assert metrics.api_calls == 2
+    assert metrics.failed_api_calls == 1
+    assert metrics.usage_api_calls == 2
+    assert metrics.premium_requests == 1.75
+    assert metrics.usage_complete is True
+    assert metrics.malformed_records == 0
+    assert metrics.copilot_cli_version == "1.0.81-0"
 
 
 def test_legal_null_optional_fields_and_multiple_models_are_accepted(tmp_path: Path) -> None:

--- a/tests/test_pr_review_metrics.py
+++ b/tests/test_pr_review_metrics.py
@@ -8,7 +8,7 @@ from bcbench.agent.pr_review.metrics import RUN_METRICS_FILE_NAME, build_pr_revi
 from bcbench.dataset.codereview import CodeReviewEntry
 from bcbench.exceptions import AgentError
 from bcbench.results.bceval_export import write_bceval_results
-from bcbench.types import AgentHarness, EvaluationCategory, PrReviewMetrics
+from bcbench.types import AgentHarness, EvaluationCategory, PRReviewMetrics
 from tests.conftest import create_codereview_entry, create_codereview_result
 
 
@@ -45,7 +45,7 @@ def test_build_metrics_promotes_public_performance_metrics(tmp_path: Path) -> No
 
     metrics = build_pr_review_metrics(tmp_path, execution_time=12.5)
 
-    assert isinstance(metrics, PrReviewMetrics)
+    assert isinstance(metrics, PRReviewMetrics)
     assert metrics.kind == "pr-review"
     assert metrics.execution_time == 12.5
     assert metrics.prompt_tokens == 150

--- a/tests/test_result_serialization.py
+++ b/tests/test_result_serialization.py
@@ -4,7 +4,7 @@ import pytest
 
 from bcbench.results.base import BaseEvaluationResult
 from bcbench.results.summary import EvaluationResultSummary
-from bcbench.types import AgentHarness, AgentMetrics, EvaluationCategory, ExperimentConfiguration, PrReviewMetrics
+from bcbench.types import AgentHarness, AgentMetrics, EvaluationCategory, ExperimentConfiguration, PRReviewMetrics
 from tests.conftest import create_bugfix_result, create_codereview_result, create_testgen_result
 
 
@@ -232,7 +232,7 @@ class TestCategorySerialization:
     def test_pr_review_metrics_round_trip(self, tmp_path):
         original = create_codereview_result(
             agent_name=AgentHarness.PR_REVIEW,
-            metrics=PrReviewMetrics(
+            metrics=PRReviewMetrics(
                 execution_time=10.0,
                 api_calls=2,
                 usage_complete=True,
@@ -245,7 +245,7 @@ class TestCategorySerialization:
         loaded = BaseEvaluationResult.from_json(payload)
 
         assert payload["metrics"]["kind"] == "pr-review"
-        assert isinstance(loaded.metrics, PrReviewMetrics)
+        assert isinstance(loaded.metrics, PRReviewMetrics)
         assert loaded.metrics.api_calls == 2
         assert loaded.metrics.copilot_cli_version == "1.0.82"
 

--- a/tests/test_result_serialization.py
+++ b/tests/test_result_serialization.py
@@ -4,8 +4,8 @@ import pytest
 
 from bcbench.results.base import BaseEvaluationResult
 from bcbench.results.summary import EvaluationResultSummary
-from bcbench.types import AgentMetrics, EvaluationCategory, ExperimentConfiguration
-from tests.conftest import create_bugfix_result, create_testgen_result
+from bcbench.types import AgentHarness, AgentMetrics, EvaluationCategory, ExperimentConfiguration, PrReviewMetrics
+from tests.conftest import create_bugfix_result, create_codereview_result, create_testgen_result
 
 
 class TestCategorySerialization:
@@ -214,6 +214,7 @@ class TestCategorySerialization:
             "build": True,
             "output": "patch",
             "metrics": {
+                "kind": "generic",
                 "execution_time": 100.0,
                 "prompt_tokens": 5000,
                 "completion_tokens": 1000,
@@ -227,6 +228,26 @@ class TestCategorySerialization:
         assert result.metrics.tool_usage is not None
         assert result.metrics.tool_usage["bash"] == 5
         assert result.metrics.tool_usage["view"] == 3
+
+    def test_pr_review_metrics_round_trip(self, tmp_path):
+        original = create_codereview_result(
+            agent_name=AgentHarness.PR_REVIEW,
+            metrics=PrReviewMetrics(
+                execution_time=10.0,
+                api_calls=2,
+                usage_complete=True,
+                copilot_cli_version="1.0.82",
+            ),
+        )
+        original.save(tmp_path, "result.jsonl")
+
+        payload = json.loads((tmp_path / "result.jsonl").read_text(encoding="utf-8"))
+        loaded = BaseEvaluationResult.from_json(payload)
+
+        assert payload["metrics"]["kind"] == "pr-review"
+        assert isinstance(loaded.metrics, PrReviewMetrics)
+        assert loaded.metrics.api_calls == 2
+        assert loaded.metrics.copilot_cli_version == "1.0.82"
 
     def test_tool_usage_round_trip(self, tmp_path):
         tool_usage = {"bash": 10, "view": 5}

--- a/tests/test_result_serialization.py
+++ b/tests/test_result_serialization.py
@@ -249,6 +249,16 @@ class TestCategorySerialization:
         assert loaded.metrics.api_calls == 2
         assert loaded.metrics.copilot_cli_version == "1.0.82"
 
+    def test_rejects_pr_review_result_with_generic_metrics(self):
+        payload = create_codereview_result(
+            agent_name=AgentHarness.PR_REVIEW,
+            metrics=PRReviewMetrics(execution_time=10.0),
+        ).model_dump(mode="json")
+        payload["metrics"] = AgentMetrics(execution_time=10.0).model_dump(mode="json")
+
+        with pytest.raises(ValueError, match="BC PR Review must use PRReviewMetrics, got AgentMetrics"):
+            BaseEvaluationResult.from_json(payload)
+
     def test_tool_usage_round_trip(self, tmp_path):
         tool_usage = {"bash": 10, "view": 5}
         original = create_bugfix_result(

--- a/tests/test_result_serialization.py
+++ b/tests/test_result_serialization.py
@@ -249,16 +249,6 @@ class TestCategorySerialization:
         assert loaded.metrics.api_calls == 2
         assert loaded.metrics.copilot_cli_version == "1.0.82"
 
-    def test_rejects_pr_review_result_with_generic_metrics(self):
-        payload = create_codereview_result(
-            agent_name=AgentHarness.PR_REVIEW,
-            metrics=PRReviewMetrics(execution_time=10.0),
-        ).model_dump(mode="json")
-        payload["metrics"] = AgentMetrics(execution_time=10.0).model_dump(mode="json")
-
-        with pytest.raises(ValueError, match="BC PR Review must use PRReviewMetrics, got AgentMetrics"):
-            BaseEvaluationResult.from_json(payload)
-
     def test_tool_usage_round_trip(self, tmp_path):
         tool_usage = {"bash": 10, "view": 5}
         original = create_bugfix_result(

--- a/tests/test_result_writer.py
+++ b/tests/test_result_writer.py
@@ -6,7 +6,7 @@ import pytest
 from bcbench.dataset.codereview import CodeReviewEntry
 from bcbench.dataset.dataset_entry import BugFixEntry, _BugFixTestGenBase
 from bcbench.results.bceval_export import write_bceval_results
-from bcbench.types import AgentHarness, AgentMetrics, EvaluationCategory, ExperimentConfiguration
+from bcbench.types import AgentHarness, AgentMetrics, EvaluationCategory, ExperimentConfiguration, PRReviewMetrics
 from tests.conftest import VALID_INSTANCE_ID, create_bugfix_result, create_codereview_entry, create_codereview_result
 
 
@@ -15,13 +15,13 @@ class TestWriteBcevalResults:
         "metrics",
         [
             None,
-            AgentMetrics(execution_time=232.257560403),
-            AgentMetrics(prompt_tokens=0, completion_tokens=0, total_tokens=0, ai_credits=0.0),
-            AgentMetrics(prompt_tokens=150, completion_tokens=28, total_tokens=178, ai_credits=1.75),
-            AgentMetrics(prompt_tokens=150, completion_tokens=28, total_tokens=178),
-            AgentMetrics(ai_credits=1.75),
-            AgentMetrics(prompt_tokens=150),
-            AgentMetrics(completion_tokens=28),
+            PRReviewMetrics(execution_time=232.257560403),
+            PRReviewMetrics(prompt_tokens=0, completion_tokens=0, total_tokens=0, ai_credits=0.0),
+            PRReviewMetrics(prompt_tokens=150, completion_tokens=28, total_tokens=178, ai_credits=1.75),
+            PRReviewMetrics(prompt_tokens=150, completion_tokens=28, total_tokens=178),
+            PRReviewMetrics(ai_credits=1.75),
+            PRReviewMetrics(prompt_tokens=150),
+            PRReviewMetrics(completion_tokens=28),
         ],
     )
     def test_pr_review_credits_preserve_missing_zero_and_observed_values(self, tmp_path, metrics):

--- a/tests/test_type_exhaustiveness.py
+++ b/tests/test_type_exhaustiveness.py
@@ -4,7 +4,7 @@ import pytest
 
 from bcbench.dataset import BugFixEntry, CodeReviewEntry, DataQueryEntry, ExtRequestAdvisorEntry, ExtRequestImplementEntry, ExtRequestTriageEntry, NL2ALEntry
 from bcbench.dataset.codereview import ReviewComment, Severity
-from bcbench.types import AgentHarness, AgentMetrics, EvaluationCategory
+from bcbench.types import AgentHarness, AgentMetrics, EvaluationCategory, PrReviewMetrics
 
 
 def test_repository_harnesses_have_target_dir():
@@ -35,6 +35,12 @@ def test_all_agent_names_have_expected_metrics():
         expected = agent_name.expected_metrics
         assert expected
         assert expected <= AgentMetrics.model_fields.keys()
+
+
+def test_pr_review_metrics_extend_generic_metrics():
+    assert issubclass(PrReviewMetrics, AgentMetrics)
+    assert PrReviewMetrics().kind == "pr-review"
+    assert "api_calls" not in AgentMetrics.model_fields
 
 
 def test_all_categories_have_pipelines():

--- a/tests/test_type_exhaustiveness.py
+++ b/tests/test_type_exhaustiveness.py
@@ -4,7 +4,7 @@ import pytest
 
 from bcbench.dataset import BugFixEntry, CodeReviewEntry, DataQueryEntry, ExtRequestAdvisorEntry, ExtRequestImplementEntry, ExtRequestTriageEntry, NL2ALEntry
 from bcbench.dataset.codereview import ReviewComment, Severity
-from bcbench.types import AgentHarness, AgentMetrics, EvaluationCategory, PRReviewMetrics
+from bcbench.types import AgentHarness, AgentMetrics, AgentMetricsContract, EvaluationCategory, PRReviewMetrics
 
 
 def test_repository_harnesses_have_target_dir():
@@ -30,17 +30,23 @@ def test_other_harnesses_reject_repository_setup(harness: AgentHarness):
         assert harness.instruction_filename
 
 
-def test_all_agent_names_have_expected_metrics():
+def test_all_agent_names_have_metrics_contracts():
     for agent_name in AgentHarness:
-        expected = agent_name.expected_metrics
-        assert expected
-        assert expected <= AgentMetrics.model_fields.keys()
+        contract = agent_name.metrics_contract
+        assert contract.required_fields
+        assert contract.required_fields <= contract.metrics_type.model_fields.keys()
+
+
+def test_agent_metrics_contract_rejects_unknown_required_fields():
+    with pytest.raises(ValueError, match="does not define required fields"):
+        AgentMetricsContract(AgentMetrics, frozenset({"unknown"}))
 
 
 def test_pr_review_metrics_extend_generic_metrics():
     assert issubclass(PRReviewMetrics, AgentMetrics)
     assert PRReviewMetrics().kind == "pr-review"
     assert "api_calls" not in AgentMetrics.model_fields
+    assert AgentHarness.PR_REVIEW.metrics_contract.metrics_type is PRReviewMetrics
 
 
 def test_all_categories_have_pipelines():

--- a/tests/test_type_exhaustiveness.py
+++ b/tests/test_type_exhaustiveness.py
@@ -1,10 +1,11 @@
 from pathlib import Path
 
 import pytest
+from pydantic import TypeAdapter
 
 from bcbench.dataset import BugFixEntry, CodeReviewEntry, DataQueryEntry, ExtRequestAdvisorEntry, ExtRequestImplementEntry, ExtRequestTriageEntry, NL2ALEntry
 from bcbench.dataset.codereview import ReviewComment, Severity
-from bcbench.types import AgentHarness, AgentMetrics, AgentMetricsContract, EvaluationCategory, PRReviewMetrics
+from bcbench.types import AgentHarness, AgentMetrics, AgentMetricsContract, AnyAgentMetrics, EvaluationCategory, PRReviewMetrics
 
 
 def test_repository_harnesses_have_target_dir():
@@ -40,6 +41,17 @@ def test_all_agent_names_have_metrics_contracts():
 def test_agent_metrics_contract_rejects_unknown_required_fields():
     with pytest.raises(ValueError, match="does not define required fields"):
         AgentMetricsContract(AgentMetrics, frozenset({"unknown"}))
+
+
+def test_every_harness_metrics_type_round_trips_through_the_union():
+    # Results are persisted and read back through AnyAgentMetrics, so a metrics type missing from that
+    # union, or a subclass that forgot to override `kind`, would serialize fine and then fail to load or
+    # silently downcast and drop its extra fields.
+    adapter = TypeAdapter(AnyAgentMetrics)
+    for agent_name in AgentHarness:
+        metrics_type = agent_name.metrics_contract.metrics_type
+        restored = adapter.validate_python(metrics_type().model_dump(mode="json"))
+        assert type(restored) is metrics_type, f"{metrics_type.__name__} needs a unique `kind` and a place in AnyAgentMetrics"
 
 
 def test_pr_review_metrics_extend_generic_metrics():

--- a/tests/test_type_exhaustiveness.py
+++ b/tests/test_type_exhaustiveness.py
@@ -4,7 +4,7 @@ import pytest
 
 from bcbench.dataset import BugFixEntry, CodeReviewEntry, DataQueryEntry, ExtRequestAdvisorEntry, ExtRequestImplementEntry, ExtRequestTriageEntry, NL2ALEntry
 from bcbench.dataset.codereview import ReviewComment, Severity
-from bcbench.types import AgentHarness, AgentMetrics, EvaluationCategory, PrReviewMetrics
+from bcbench.types import AgentHarness, AgentMetrics, EvaluationCategory, PRReviewMetrics
 
 
 def test_repository_harnesses_have_target_dir():
@@ -38,8 +38,8 @@ def test_all_agent_names_have_expected_metrics():
 
 
 def test_pr_review_metrics_extend_generic_metrics():
-    assert issubclass(PrReviewMetrics, AgentMetrics)
-    assert PrReviewMetrics().kind == "pr-review"
+    assert issubclass(PRReviewMetrics, AgentMetrics)
+    assert PRReviewMetrics().kind == "pr-review"
     assert "api_calls" not in AgentMetrics.model_fields
 
 


### PR DESCRIPTION
## Summary

- add a discriminated `AnyAgentMetrics` union as the registry for typed metrics schemas
- keep stable execution fields on `AgentMetrics` and PR Review-only telemetry on `PRReviewMetrics`
- replace the standalone `expected_metrics` mapping with an `AgentMetricsContract` that pairs each harness with its concrete metrics type and required-field subset
- reject newly created results whose metrics type does not match the configured harness, and warn only for missing required fields
- persist the selected detailed usage diagnostics needed from `_run-metrics.json`
- round-trip the concrete metrics type through result JSON without custom restoration logic

## Design

`AgentMetricsContract` is the single harness-specific contract:

- `metrics_type` defines which fields may be reported and which discriminated payload the harness must return
- `required_fields` defines the subset the harness promises to populate and therefore which missing values should warn

Typed variants can be added to `AnyAgentMetrics` when another harness or harness/category setup gains specialized telemetry. Optional subtype diagnostics remain nullable and do not warn unless that harness explicitly makes them required.

## Why

This establishes the typed extension point needed by #851 without adding PR Review-only fields to the shared metrics class or replacing validation with an untyped property bag. The persisted `kind` discriminator lets Pydantic select the concrete model directly and keeps result artifacts self-describing.

## Validation

- `uv run ruff check`
- pre-commit, including `ty check`
- `uv run pytest -q` (969 passed, 1 skipped, 1 deselected)