### PR TITLE
Avoid unpinned cache action in pre-commit CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,7 +31,7 @@ jobs:
           all-groups: true
 
       - name: Run pre-commit
-        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+        run: uv run pre-commit run --all-files --show-diff-on-failure --color=always
         env:
           # Render ruff lint findings as inline PR annotations (CI-only; local runs stay human-readable)
           RUFF_OUTPUT_FORMAT: github


### PR DESCRIPTION
## Why

The repository now requires every external GitHub Action to be pinned to a full commit SHA. Although `pre-commit/action` itself was pinned, its composite action invokes `actions/cache@v4` by a mutable tag, causing both CI lint jobs to fail during workflow preparation.

Run the already-installed repository dependency directly instead of using the wrapper. This preserves the same pre-commit arguments and GitHub annotation behavior without introducing a transitive unpinned action.

## Summary

- **Replaced** the `pre-commit/action` wrapper with `uv run pre-commit run` using the wrapper's existing arguments.
- **Preserved** Ruff GitHub annotations through the existing `RUFF_OUTPUT_FORMAT` environment setting.
- **Removed** the transitive `actions/cache@v4` reference blocked by repository policy.